### PR TITLE
Feature/#10 react query factory

### DIFF
--- a/src/hooks/createCrudHooks.ts
+++ b/src/hooks/createCrudHooks.ts
@@ -26,16 +26,16 @@
  *
  * @example
  * // 목록/상세 조회 + 생성만 (수정/삭제 없음)
- * const studentCrud = createCrudHooks({
- *   queryKey: "students",
- *   getList: getStudents,
- *   getDetail: getStudent,
- *   create: postStudent,
+ * const sessionCrud = createCrudHooks({
+ *   queryKey: "sessions",
+ *   getList: getSessions,
+ *   getDetail: getSession,
+ *   create: postSession,
  * });
  *
- * export const useStudents = studentCrud.useList;
- * export const useStudent = studentCrud.useDetail;
- * export const useCreateStudent = studentCrud.useCreate;
+ * export const useSessions = sessionCrud.useList;
+ * export const useSession = sessionCrud.useDetail;
+ * export const useCreateSession = sessionCrud.useCreate;
  *
  * @example
  * // 조회 전용 (생성/수정/삭제 없음)
@@ -47,6 +47,28 @@
  *
  * export const useNotices = noticeCrud.useList;
  * export const useNotice = noticeCrud.useDetail;
+ */
+
+/**
+ * Query Key Factory 구조
+ *
+ * React Query는 키 배열의 앞부분이 일치하면 함께 무효화됩니다.
+ * 이 계층 구조를 활용해 세밀한 캐시 제어가 가능합니다.
+ *
+ * @example queryKey: "sessions"인 경우
+ * ```
+ * keys.all           → ["sessions"]                        // 전체 무효화
+ * keys.lists()       → ["sessions", "list"]                // 모든 목록 무효화
+ * keys.list(params)  → ["sessions", "list", { page: 1 }]   // 특정 조건의 목록
+ * keys.detail(id)    → ["sessions", "detail", "abc123"]    // 특정 상세
+ * ```
+ *
+ * @example 무효화 범위
+ * ```
+ * invalidateQueries({ queryKey: keys.all })     // sessions 관련 전체
+ * invalidateQueries({ queryKey: keys.lists() }) // 목록만 (detail 유지)
+ * invalidateQueries({ queryKey: keys.detail(id) }) // 특정 상세만
+ * ```
  */
 
 import {
@@ -80,9 +102,13 @@ interface CrudHooksConfig<
 
 type BaseReturn<TListParams, TListResponse> = {
   keys: {
+    /** ["queryKey"] - 해당 리소스의 모든 쿼리 무효화 시 사용 */
     all: readonly [string];
+    /** ["queryKey", "list"] - 모든 목록 쿼리 무효화 시 사용 */
     lists: () => readonly [string, "list"];
+    /** ["queryKey", "list", params] - 특정 파라미터의 목록 쿼리 */
     list: (params: TListParams) => readonly [string, "list", TListParams];
+    /** ["queryKey", "detail", id] - 특정 ID의 상세 쿼리 */
     detail: (id: string) => readonly [string, "detail", string];
   };
   useList: (params: TListParams) => UseQueryResult<TListResponse>;


### PR DESCRIPTION
## 작업 내용

### Summary
- CRUD Hook Factory의 버그 수정 및 기능 개선
- update/remove/getDetail 독립적 설정 지원
- 타입 시스템 단순화

### Changes
#### Bug Fixes
- useUpdate, useDelete에서 new QueryClient() → useQueryClient()로 수정
> 기존: 매번 새 QueryClient 생성으로 invalidateQueries 동작 안함
> 수정: 앱의 QueryClient 사용으로 캐시 무효화 정상 동작

#### Features
- 독립적 옵션 설정: getDetail, update, remove를 각각 독립적으로 설정 가능
> 기존: update && remove 둘 다 있어야만 훅 생성
> 변경: 각 옵션 유무에 따라 개별 훅 생성
- 상세 조회 지원: getDetail 옵션 및 useDetail 훅 추가
- keys.detail(id) 쿼리 키 추가
- useDetail(id) 훅으로 단일 항목 조회

#### Refactor
- 오버로드 시그니처 8개 → Partial 조합으로 단순화
- JSDoc 예제 업데이트 및 오타 수정

## 참고 사항

> 안에 예시를 잘 살펴봐주세요.

## 연관 이슈

> close #10 
