### PR TITLE
Feature/#73 session custom hook

### DIFF
--- a/src/features/session/hooks/useSessionHooks.ts
+++ b/src/features/session/hooks/useSessionHooks.ts
@@ -57,62 +57,36 @@ export function useSessionReport(sessionId: string) {
   });
 }
 
-export function useJoinSession() {
-  const queryClient = useQueryClient();
+const createSessionMutationHook = <TData, TVariables extends { sessionRoomId: string }>(
+  mutationFn: (vars: TVariables) => Promise<TData>
+) => {
+  return () => {
+    const queryClient = useQueryClient();
+    return useMutation<TData, unknown, TVariables>({
+      mutationFn,
+      onSuccess: (_, { sessionRoomId }) => {
+        queryClient.invalidateQueries({ queryKey: sessionKeys.detail(sessionRoomId) });
+      },
+    });
+  };
+};
 
-  return useMutation<
-    ApiSuccessResponse<JoinSessionResponse>,
-    unknown,
-    { sessionRoomId: string; body: JoinSessionRequest }
-  >({
-    mutationFn: ({ sessionRoomId, body }) => sessionApi.join(sessionRoomId, body),
-    onSuccess: (_, { sessionRoomId }) => {
-      queryClient.invalidateQueries({ queryKey: sessionKeys.detail(sessionRoomId) });
-    },
-  });
-}
+export const useJoinSession = createSessionMutationHook<
+  ApiSuccessResponse<JoinSessionResponse>,
+  { sessionRoomId: string; body: JoinSessionRequest }
+>(({ sessionRoomId, body }) => sessionApi.join(sessionRoomId, body));
 
-export function useSetGoal() {
-  const queryClient = useQueryClient();
+export const useSetGoal = createSessionMutationHook<
+  ApiSuccessResponse<SetGoalResponse>,
+  { sessionRoomId: string; body: SetGoalRequest }
+>(({ sessionRoomId, body }) => sessionApi.setGoal(sessionRoomId, body));
 
-  return useMutation<
-    ApiSuccessResponse<SetGoalResponse>,
-    unknown,
-    { sessionRoomId: string; body: SetGoalRequest }
-  >({
-    mutationFn: ({ sessionRoomId, body }) => sessionApi.setGoal(sessionRoomId, body),
-    onSuccess: (_, { sessionRoomId }) => {
-      queryClient.invalidateQueries({ queryKey: sessionKeys.detail(sessionRoomId) });
-    },
-  });
-}
+export const useAddTodos = createSessionMutationHook<
+  ApiSuccessResponse<AddTodosResponse>,
+  { sessionRoomId: string; body: AddTodosRequest }
+>(({ sessionRoomId, body }) => sessionApi.addTodos(sessionRoomId, body));
 
-export function useAddTodos() {
-  const queryClient = useQueryClient();
-
-  return useMutation<
-    ApiSuccessResponse<AddTodosResponse>,
-    unknown,
-    { sessionRoomId: string; body: AddTodosRequest }
-  >({
-    mutationFn: ({ sessionRoomId, body }) => sessionApi.addTodos(sessionRoomId, body),
-    onSuccess: (_, { sessionRoomId }) => {
-      queryClient.invalidateQueries({ queryKey: sessionKeys.detail(sessionRoomId) });
-    },
-  });
-}
-
-export function useToggleTodo() {
-  const queryClient = useQueryClient();
-
-  return useMutation<
-    ApiSuccessResponse<ToggleTodoResponse>,
-    unknown,
-    { sessionRoomId: string; todoId: string }
-  >({
-    mutationFn: ({ sessionRoomId, todoId }) => sessionApi.toggleTodo(sessionRoomId, todoId),
-    onSuccess: (_, { sessionRoomId }) => {
-      queryClient.invalidateQueries({ queryKey: sessionKeys.detail(sessionRoomId) });
-    },
-  });
-}
+export const useToggleTodo = createSessionMutationHook<
+  ApiSuccessResponse<ToggleTodoResponse>,
+  { sessionRoomId: string; todoId: string }
+>(({ sessionRoomId, todoId }) => sessionApi.toggleTodo(sessionRoomId, todoId));


### PR DESCRIPTION
## 작업 내용

### 생성된 훅
- useSessionList - 세션 목록 조회
- useSessionDetail - 세션 상세 조회
- useCreateSession - 세션 생성
- useSessionReport - 세션 리포트 조회
- useJoinSession - 세션 참가
- useSetGoal - 목표 설정
- useAddTodos - 할일 추가
- useToggleTodo - 할일 토글
- prefetchSessionList - 세션 목록 프리페치
- sessionKeys - Query key 객체
- 캐시 무효화
- 모든 mutation 성공 시 detail 캐시만 무효화
- report는 세션 종료 후에만 조회되므로 무효화 제외

## 참고 사항

> api 명세 변경에 따라 변경될 수 있습니다.

## 연관 이슈

> close #73 
