### PR TITLE
fix: og title 수정

### DIFF
--- a/src/app/(with-header)/page.tsx
+++ b/src/app/(with-header)/page.tsx
@@ -12,12 +12,16 @@ import {
   parseSessionListSearchParams,
   toURLSearchParams,
 } from "@/features/session/utils/parseSessionListSearchParams";
+import { SITE_TITLE } from "@/lib/constants/seo";
 import { createPageMetadata } from "@/lib/seo/metadata";
 
 export const metadata = createPageMetadata({
   title: "홈",
   description: "모집 중인 모각작 세션을 찾아보고 참여하세요.",
   pathname: "/",
+  openGraph: {
+    title: SITE_TITLE,
+  },
 });
 
 /**


### PR DESCRIPTION
## 작업 내용

- 홈 페이지의 `og:title`이 "홈"으로 표시되던 문제 수정
- `createPageMetadata`에서 `openGraph.title`을 `SITE_TITLE`("GAK - 모여서 각자 작업")로 명시하여 SNS 공유 시 서비스명이 정상 노출되도록 변경

## 참고 사항

- 브라우저 탭 title은 기존대로 "홈 | GAK" 유지 (Next.js `title.template` 적용)
- 카카오톡은 OG 캐시가 있어 [카카오 디버거](https://developers.kakao.com/tool/debugger/sharing)에서 캐시 초기화 필요

## 연관 이슈
close #212 
