### PR TITLE
fix: 강퇴 감지 조건 추가 및 분기 처리

### DIFF
--- a/src/features/lobby/components/LobbyHeader.tsx
+++ b/src/features/lobby/components/LobbyHeader.tsx
@@ -13,7 +13,7 @@ interface LobbyHeaderProps {
   onShowDialog: () => void;
   onCloseDialog: () => void;
   isLeavingRef: React.MutableRefObject<boolean>;
-  onLeaveStart?: () => void;
+  onLeavingChange?: (isLeaving: boolean) => void;
 }
 
 export function LobbyHeader({
@@ -22,13 +22,14 @@ export function LobbyHeader({
   onShowDialog,
   onCloseDialog,
   isLeavingRef,
-  onLeaveStart,
+  onLeavingChange,
 }: LobbyHeaderProps) {
   const leaveButtonRef = useRef<HTMLButtonElement>(null);
   const { handleLeave, isPending, serverError } = useLeaveSessionHandler({
     sessionId,
     isLeavingRef,
     onCloseDialog,
+    onLeaveFail: () => onLeavingChange?.(false),
   });
 
   return (
@@ -71,7 +72,7 @@ export function LobbyHeader({
             leaveButtonRef.current?.focus();
           }}
           onConfirm={() => {
-            onLeaveStart?.();
+            onLeavingChange?.(true);
             handleLeave();
           }}
           isPending={isPending}

--- a/src/features/lobby/components/WaitingRoomContent.tsx
+++ b/src/features/lobby/components/WaitingRoomContent.tsx
@@ -148,7 +148,7 @@ export function WaitingRoomContent({ sessionId }: WaitingRoomContentProps) {
           onShowDialog={() => setShowLeaveDialog(true)}
           onCloseDialog={() => setShowLeaveDialog(false)}
           isLeavingRef={isLeavingRef}
-          onLeaveStart={() => setIsLeaving(true)}
+          onLeavingChange={setIsLeaving}
         />
         <SessionInfoCard session={session} />
         <div className="gap-lg flex">

--- a/src/features/session/hooks/useLeaveSessionHandler.ts
+++ b/src/features/session/hooks/useLeaveSessionHandler.ts
@@ -14,6 +14,7 @@ interface UseLeaveSessionHandlerOptions {
   isLeavingRef: React.MutableRefObject<boolean>;
   onCloseDialog: () => void;
   onBeforeNavigate?: () => void;
+  onLeaveFail?: () => void;
 }
 
 export function useLeaveSessionHandler({
@@ -21,6 +22,7 @@ export function useLeaveSessionHandler({
   isLeavingRef,
   onCloseDialog,
   onBeforeNavigate,
+  onLeaveFail,
 }: UseLeaveSessionHandlerOptions) {
   const [serverError, setServerError] = useState<string | null>(null);
   const leaveSessionMutation = useLeaveSession();
@@ -36,6 +38,7 @@ export function useLeaveSessionHandler({
       navigateWithHardReload("/");
     } catch (error: unknown) {
       isLeavingRef.current = false;
+      onLeaveFail?.();
       const message = error instanceof ApiError ? error.message : DEFAULT_API_ERROR_MESSAGE;
       setServerError(message);
       toast.error(message);


### PR DESCRIPTION
## 작업 내용

> 나가기 동작 시 강퇴하기 dialog 출력 문제 수정.

> onLeaveStart → **onLeavingChange**로 변경하여 true/false 양방향 전달
> LobbyHeader에서 나가기 확인 시 onLeavingChange(true), 실패 시 onLeavingChange(false) 호출
> useLeaveSessionHandler에 onLeaveFail 콜백 추가 — catch 블록에서 isLeavingRef.current = false 직후 호출

## 참고 사항


## 연관 이슈

> close #225 
