### PR TITLE
fix: 세션 여백 닫힘 동작, esc 키 버그 수정

### DIFF
--- a/src/features/lobby/components/SessionJoinModal.tsx
+++ b/src/features/lobby/components/SessionJoinModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 
 import { Button } from "@/components/Button/Button";
 import { ButtonGroup } from "@/components/ButtonGroup/ButtonGroup";
@@ -38,18 +38,13 @@ export function SessionJoinModal({ sessionId, onClose, onJoinSuccess }: SessionJ
 
   const joinSessionMutation = useJoinSession();
 
-  // callback ref: dialog 요소가 DOM에 마운트되면 showModal 호출
-  const setDialogRef = (node: HTMLDialogElement | null) => {
-    if (node && !node.open) {
+  const setDialogRef = useCallback((node: HTMLDialogElement | null) => {
+    if (node) {
+      if (node.open) node.close();
       node.showModal();
     }
     dialogRef.current = node;
-  };
-
-  const handleBackdropClick = (event: React.MouseEvent<HTMLDialogElement>) => {
-    if (event.target !== dialogRef.current) return;
-    onClose();
-  };
+  }, []);
 
   const handleTodoChange = (index: number, content: string) => {
     setTodos((prev) => prev.map((todo, i) => (i === index ? { ...todo, content } : todo)));
@@ -102,9 +97,13 @@ export function SessionJoinModal({ sessionId, onClose, onJoinSuccess }: SessionJ
     <Portal>
       <dialog
         ref={setDialogRef}
-        onCancel={onClose}
-        onClick={handleBackdropClick}
-        className="bg-surface-default gap-lg px-xl pt-xl pb-2xl fixed inset-0 m-auto flex w-full max-w-160 flex-col rounded-lg border border-gray-900 backdrop:bg-(--color-overlay-default)"
+        onKeyDown={(e) => {
+          if (e.key === "Escape") {
+            e.preventDefault();
+            e.stopPropagation();
+          }
+        }}
+        className="bg-surface-default gap-lg px-xl pt-xl pb-2xl fixed inset-0 m-auto flex w-full max-w-160 flex-col rounded-lg border border-gray-900 not-[&:modal]:hidden backdrop:bg-(--color-overlay-default)"
       >
         {/* 헤더 */}
         <div className="flex flex-col gap-1">

--- a/src/features/session/components/SessionDetailModal/SessionDetailModal.tsx
+++ b/src/features/session/components/SessionDetailModal/SessionDetailModal.tsx
@@ -26,7 +26,7 @@ interface SessionDetailModalProps {
 
 export function SessionDetailModal({ sessionId }: SessionDetailModalProps) {
   const { dialogRef, handleClose, handleBackdropClick } = useDialog("/");
-  const { data, isLoading, error: sessionError } = useSessionDetail(sessionId);
+  const { data, error: sessionError } = useSessionDetail(sessionId);
   const { shareSession } = useShareSession();
   const isAuthenticated = useIsAuthenticated();
   const [showJoinModal, setShowJoinModal] = useState(false);


### PR DESCRIPTION
## 작업 내용

1. dialog 여백 클릭 시 모달 닫힘

handleBackdropClick 함수 및 onClick={handleBackdropClick} 제거
<dialog> 태그의 padding 영역 클릭 시 event.target === dialogRef.current 조건이 충족되어 onClose()가 호출되던 문제 해결

2. ESC 키로 모달이 닫히는 문제

onCancel={onClose} 제거
onKeyDown에서 ESC 키 preventDefault() + stopPropagation() 처리
SessionJoinModal이 열려있을 때 ESC가 동작하지 않고, 부모 SessionDetailModal로 이벤트 전파도 차단

3. 새로고침 시 브라우저 상태 복원 방지

not-[:modal]:hidden CSS 추가: showModal() 없이 open 속성만 복원된 dialog를 숨김
callback ref에서 node.open 시 close() 후 showModal() 재호출로 top layer 정상 배치 보장

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 버그 수정
- 세션 참여 모달의 다이얼로그 상호작용 동작 최적화 및 키보드 처리 개선
- Escape 키 동작 및 다이얼로그 열기 시퀀스 개선
- 세션 상세 정보 모달의 로딩 상태 처리 간소화로 성능 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 참고 사항


## 연관 이슈

> close #233

## CodeRabbit 운영 메모

- 증분 리뷰 재실행: `@coderabbitai review`
- 전체 PR 재검토: `@coderabbitai full review`
