### PR TITLE
[fix] 공개 페이지 이동 시 로그인 유지가 조기 해제되는 문제

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ AGENTS.md
 docs
 
 .playwright-mcp
+.omx/

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -43,6 +43,7 @@ interface AuthFailureResponseOptions {
 }
 
 type RefreshFailureReason = "http_error" | "invalid_response" | "timeout" | "network_error";
+type RouteType = "public" | "protected" | "api";
 
 export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
@@ -171,16 +172,17 @@ function shouldPersistRedirectAfterLogin(pathname: string): boolean {
   return !isApiRoute(pathname);
 }
 
-function getRouteType(pathname: string): "public" | "protected" | "api" {
-  if (isApiRoute(pathname)) {
-    return "api";
-  }
+const ROUTE_TYPE_CONFIG: Array<{
+  type: Exclude<RouteType, "public">;
+  check: (pathname: string) => boolean;
+}> = [
+  { type: "api", check: isApiRoute },
+  { type: "protected", check: isProtectedPageRoute },
+];
 
-  if (isProtectedPageRoute(pathname)) {
-    return "protected";
-  }
-
-  return "public";
+function getRouteType(pathname: string): RouteType {
+  const matched = ROUTE_TYPE_CONFIG.find((route) => route.check(pathname));
+  return matched?.type ?? "public";
 }
 
 function logRefreshFailure(
@@ -320,7 +322,7 @@ async function tryRefreshToken(
     if (!tokens) {
       logRefreshFailure(request, {
         reason: "invalid_response",
-        status: 500,
+        status: reissueResponse.status,
         cookieClear: !allowPassThroughOnFailure,
       });
       if (allowPassThroughOnFailure) {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -42,6 +42,8 @@ interface AuthFailureResponseOptions {
   status?: number;
 }
 
+type RefreshFailureReason = "http_error" | "invalid_response" | "timeout" | "network_error";
+
 export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const isPublicPageRoute = isKnownPublicPageRoute(pathname);
@@ -169,6 +171,43 @@ function shouldPersistRedirectAfterLogin(pathname: string): boolean {
   return !isApiRoute(pathname);
 }
 
+function getRouteType(pathname: string): "public" | "protected" | "api" {
+  if (isApiRoute(pathname)) {
+    return "api";
+  }
+
+  if (isProtectedPageRoute(pathname)) {
+    return "protected";
+  }
+
+  return "public";
+}
+
+function logRefreshFailure(
+  request: NextRequest,
+  details: {
+    reason: RefreshFailureReason;
+    status: number;
+    cookieClear: boolean;
+    error?: unknown;
+  }
+) {
+  const context = {
+    reason: details.reason,
+    status: details.status,
+    path: request.nextUrl.pathname,
+    routeType: getRouteType(request.nextUrl.pathname),
+    cookieClear: details.cookieClear,
+  };
+
+  if (details.error) {
+    console.error("Proxy: Token refresh failed", context, details.error);
+    return;
+  }
+
+  console.error("Proxy: Token refresh failed", context);
+}
+
 /**
  * JWT payload는 base64url 인코딩(-, _)과 padding 생략을 사용한다.
  * atob 디코딩 전 표준 base64(+ , /) 및 padding으로 정규화한다.
@@ -251,13 +290,13 @@ async function tryRefreshToken(
     }
 
     if (!reissueResponse.ok) {
-      console.error("Proxy: Token refresh failed:", reissueResponse.status);
+      logRefreshFailure(request, {
+        reason: "http_error",
+        status: reissueResponse.status,
+        cookieClear: !allowPassThroughOnFailure,
+      });
       if (allowPassThroughOnFailure) {
-        const response = NextResponse.next();
-        if (reissueResponse.status === 401 || reissueResponse.status === 403) {
-          clearAuthCookies(response.cookies);
-        }
-        return response;
+        return NextResponse.next();
       }
 
       const errorCode = await getErrorCodeFromResponse(reissueResponse);
@@ -279,7 +318,11 @@ async function tryRefreshToken(
 
     // API 응답 검증 (필수 버그 픽스)
     if (!tokens) {
-      console.error("Proxy: Invalid refresh response format");
+      logRefreshFailure(request, {
+        reason: "invalid_response",
+        status: 500,
+        cookieClear: !allowPassThroughOnFailure,
+      });
       if (allowPassThroughOnFailure) {
         return NextResponse.next();
       }
@@ -318,7 +361,12 @@ async function tryRefreshToken(
     return response;
   } catch (error) {
     const isTimeout = error instanceof Error && error.name === "AbortError";
-    console.error(`Proxy: Token refresh ${isTimeout ? "timeout" : "network error"}`, error);
+    logRefreshFailure(request, {
+      reason: isTimeout ? "timeout" : "network_error",
+      status: isTimeout ? 504 : 500,
+      cookieClear: !allowPassThroughOnFailure,
+      error,
+    });
 
     if (allowPassThroughOnFailure) {
       return NextResponse.next();

--- a/src/test/proxy.test.ts
+++ b/src/test/proxy.test.ts
@@ -140,6 +140,19 @@ describe("Proxy Middleware", () => {
     });
   }
 
+  function expectRefreshFailureLog(
+    details: Partial<{
+      reason: string;
+      routeType: "public" | "protected" | "api";
+      status: number;
+      cookieClear: boolean;
+    }>
+  ) {
+    expect(consoleErrorSpy.mock.calls).toEqual(
+      expect.arrayContaining([["Proxy: Token refresh failed", expect.objectContaining(details)]])
+    );
+  }
+
   describe("공개 라우트", () => {
     it("홈(/) 경로는 인증 없이 통과해야 함", async () => {
       // Given
@@ -204,7 +217,7 @@ describe("Proxy Middleware", () => {
       expect(hasSetCookie(response, (cookie) => cookie.includes("refreshToken="))).toBe(true);
     });
 
-    it("공개 라우트에서 재발급이 401/403이면 리다이렉트 없이 인증 쿠키를 정리해야 함", async () => {
+    it("공개 라우트에서 재발급이 401/403이면 리다이렉트와 쿠키 정리 없이 통과해야 함", async () => {
       const refreshToken = createMockToken(30 * 24 * 60 * 60);
       const request = new NextRequest("http://localhost:3000/login", {
         headers: {
@@ -221,8 +234,14 @@ describe("Proxy Middleware", () => {
 
       expect(response.status).toBe(200);
       expect(response.headers.get("location")).toBeNull();
-      expect(hasSetCookie(response, (cookie) => cookie.startsWith("accessToken=;"))).toBe(true);
-      expect(hasSetCookie(response, (cookie) => cookie.startsWith("refreshToken=;"))).toBe(true);
+      expect(hasSetCookie(response, (cookie) => cookie.startsWith("accessToken=;"))).toBe(false);
+      expect(hasSetCookie(response, (cookie) => cookie.startsWith("refreshToken=;"))).toBe(false);
+      expectRefreshFailureLog({
+        reason: "http_error",
+        routeType: "public",
+        status: 401,
+        cookieClear: false,
+      });
     });
 
     it("공개 라우트에서 재발급이 5xx로 실패하면 리다이렉트 없이 통과해야 함", async () => {
@@ -657,6 +676,12 @@ describe("Proxy Middleware", () => {
       expectRedirectAfterLoginCookie(response, PRIMARY_PROTECTED_PAGE_PATH);
       expect(hasSetCookie(response, (cookie) => cookie.startsWith("accessToken=;"))).toBe(true);
       expect(hasSetCookie(response, (cookie) => cookie.startsWith("refreshToken=;"))).toBe(true);
+      expectRefreshFailureLog({
+        reason: "http_error",
+        routeType: "protected",
+        status: 401,
+        cookieClear: true,
+      });
     });
 
     it("재발급 API 호출 중 네트워크 에러가 발생하면 로그인 라우트로 리다이렉트해야 함", async () => {
@@ -992,6 +1017,12 @@ describe("Proxy Middleware", () => {
 
       // Then: 인증 에러 JSON
       await expectApiAuthError(response, { code: "AUTH401_4" });
+      expectRefreshFailureLog({
+        reason: "http_error",
+        routeType: "api",
+        status: 401,
+        cookieClear: true,
+      });
     });
 
     it("/api/* 에서 재발급 네트워크 에러가 나면 500 JSON 에러를 반환해야 함", async () => {

--- a/src/test/proxy.test.ts
+++ b/src/test/proxy.test.ts
@@ -31,6 +31,8 @@ const PROTECTED_PAGE_ACCESS_PATHS = [
 
 describe("Proxy Middleware", () => {
   let consoleErrorSpy: jest.SpyInstance;
+  type RefreshFailureReason = "http_error" | "invalid_response" | "timeout" | "network_error";
+  type RouteType = "public" | "protected" | "api";
 
   function createRefreshSuccessResponse(
     accessToken: string = "new_access",
@@ -38,6 +40,7 @@ describe("Proxy Middleware", () => {
   ) {
     return {
       ok: true,
+      status: 200,
       json: jest.fn().mockResolvedValue({
         result: {
           accessToken,
@@ -142,8 +145,8 @@ describe("Proxy Middleware", () => {
 
   function expectRefreshFailureLog(
     details: Partial<{
-      reason: string;
-      routeType: "public" | "protected" | "api";
+      reason: RefreshFailureReason;
+      routeType: RouteType;
       status: number;
       cookieClear: boolean;
     }>
@@ -217,32 +220,35 @@ describe("Proxy Middleware", () => {
       expect(hasSetCookie(response, (cookie) => cookie.includes("refreshToken="))).toBe(true);
     });
 
-    it("공개 라우트에서 재발급이 401/403이면 리다이렉트와 쿠키 정리 없이 통과해야 함", async () => {
-      const refreshToken = createMockToken(30 * 24 * 60 * 60);
-      const request = new NextRequest("http://localhost:3000/login", {
-        headers: {
-          cookie: `refreshToken=${refreshToken}`,
-        },
-      });
+    it.each([401, 403])(
+      "공개 라우트에서 재발급이 %i이면 리다이렉트와 쿠키 정리 없이 통과해야 함",
+      async (status) => {
+        const refreshToken = createMockToken(30 * 24 * 60 * 60);
+        const request = new NextRequest("http://localhost:3000/login", {
+          headers: {
+            cookie: `refreshToken=${refreshToken}`,
+          },
+        });
 
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 401,
-      });
+        mockFetch.mockResolvedValueOnce({
+          ok: false,
+          status,
+        });
 
-      const response = await proxy(request);
+        const response = await proxy(request);
 
-      expect(response.status).toBe(200);
-      expect(response.headers.get("location")).toBeNull();
-      expect(hasSetCookie(response, (cookie) => cookie.startsWith("accessToken=;"))).toBe(false);
-      expect(hasSetCookie(response, (cookie) => cookie.startsWith("refreshToken=;"))).toBe(false);
-      expectRefreshFailureLog({
-        reason: "http_error",
-        routeType: "public",
-        status: 401,
-        cookieClear: false,
-      });
-    });
+        expect(response.status).toBe(200);
+        expect(response.headers.get("location")).toBeNull();
+        expect(hasSetCookie(response, (cookie) => cookie.startsWith("accessToken=;"))).toBe(false);
+        expect(hasSetCookie(response, (cookie) => cookie.startsWith("refreshToken=;"))).toBe(false);
+        expectRefreshFailureLog({
+          reason: "http_error",
+          routeType: "public",
+          status,
+          cookieClear: false,
+        });
+      }
+    );
 
     it("공개 라우트에서 재발급이 5xx로 실패하면 리다이렉트 없이 통과해야 함", async () => {
       const refreshToken = createMockToken(30 * 24 * 60 * 60);
@@ -275,6 +281,7 @@ describe("Proxy Middleware", () => {
 
       mockFetch.mockResolvedValueOnce({
         ok: true,
+        status: 200,
         json: jest.fn().mockResolvedValue({
           result: {
             accessToken: "new_access",
@@ -289,6 +296,12 @@ describe("Proxy Middleware", () => {
       expect(response.headers.get("location")).toBeNull();
       expect(hasSetCookie(response, (cookie) => cookie.startsWith("accessToken=;"))).toBe(false);
       expect(hasSetCookie(response, (cookie) => cookie.startsWith("refreshToken=;"))).toBe(false);
+      expectRefreshFailureLog({
+        reason: "invalid_response",
+        routeType: "public",
+        status: 200,
+        cookieClear: false,
+      });
     });
 
     it("공개 라우트에서 재발급 네트워크 에러가 나도 리다이렉트 없이 통과해야 함", async () => {
@@ -629,6 +642,7 @@ describe("Proxy Middleware", () => {
       // Mock: accessToken 타입이 문자열이 아님
       mockFetch.mockResolvedValueOnce({
         ok: true,
+        status: 200,
         json: jest.fn().mockResolvedValue({
           result: {
             accessToken: 12345,
@@ -643,6 +657,12 @@ describe("Proxy Middleware", () => {
       // Then
       expectLoginRedirect(response, "COMMON500");
       expectRedirectAfterLoginCookie(response, PRIMARY_PROTECTED_PAGE_PATH);
+      expectRefreshFailureLog({
+        reason: "invalid_response",
+        routeType: "protected",
+        status: 200,
+        cookieClear: true,
+      });
       expect(hasSetCookie(response, (cookie) => cookie.startsWith("accessToken=;"))).toBe(true);
       expect(hasSetCookie(response, (cookie) => cookie.startsWith("refreshToken=;"))).toBe(true);
     });


### PR DESCRIPTION
## 개요
공개 페이지에서 access token 만료 후 soft refresh가 401/403으로 실패하면 프론트가 auth 쿠키를 즉시 삭제하던 동작을 수정해, refresh token 유효기간 기대보다 먼저 로그인 상태가 풀리지 않도록 정리했습니다.

## 변경 사항
- 공개 페이지 soft refresh 실패(401/403) 시 auth 쿠키를 즉시 삭제하지 않도록 `src/proxy.ts` 수정
- protected/API 경로는 기존처럼 hard failure 시 redirect/401 + cookie clear 계약 유지
- refresh 실패 로그에 `routeType`, `status`, `cookieClear` 정보를 추가
- `src/test/proxy.test.ts`에 public/protected/api 경계 회귀 테스트 및 로그 검증 추가
- `.omx/`를 저장소 추적 대상에서 제외하도록 `.gitignore` 반영 (`omx` runtime이 생성하는 로컬 상태/로그/작업 디렉터리)

## 테스트
- [x] `pnpm exec eslint src/proxy.ts src/test/proxy.test.ts`
- [x] `pnpm exec jest --runInBand --runTestsByPath src/test/proxy.test.ts src/test/auth/callback-route.test.ts`
- [x] `rm -rf .next && pnpm exec tsc --noEmit`
- [x] `pnpm build`

## 리뷰 포인트
- public soft failure는 비파괴, protected/API failure는 파괴라는 경계가 유지되는지
- structured refresh failure log가 운영 관찰에 충분한지
- stale-auth UX 리스크를 현재 범위에서 수용 가능한지

Closes #235


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 공개 경로에서 401/403 응답 시 인증 쿠키 자동 삭제 동작 개선
  * 토큰 새로고침 실패 시 구조화된 오류 로깅 추가로 디버깅 정보 개선

* **테스트**
  * 토큰 새로고침 실패 시나리오에 대한 테스트 커버리지 확대

* **기타**
  * 빌드 설정 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->