### PR TITLE
feat: ChipBadge cyan/positive state 추가 (Figma 동기화)

### DIFF
--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -29,6 +29,11 @@ const BADGE_VARIANTS = cva(
         closing: ["bg-[#FF174429]", "text-text-status-negative-default", "border-red-800"],
         inProgress: ["bg-[#27EA6729]", "text-text-brand-default", "border-[#178A42]"],
         closed: ["bg-alpha-white-16", "text-text-disabled", "border-border-subtle"],
+        positive: [
+          "bg-[rgba(0,184,219,0.16)]",
+          "text-text-status-positive-default",
+          "border-[#00b8db]",
+        ],
       },
       radius: {
         max: "rounded-max",

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -32,7 +32,7 @@ const BADGE_VARIANTS = cva(
         positive: [
           "bg-[rgba(0,184,219,0.16)]",
           "text-text-status-positive-default",
-          "border-[#00b8db]",
+          "border-border-success-default",
         ],
       },
       radius: {

--- a/src/features/session/components/Card/Card.tsx
+++ b/src/features/session/components/Card/Card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Badge } from "@/components/Badge/Badge";
+import { Badge, type BadgeProps } from "@/components/Badge/Badge";
 import { RelativeTimeBadge } from "@/components/RelativeTime/RelativeTimeBadge";
 import { Thumbnail } from "@/components/Thumbnail/Thumbnail";
 import { isPastTime } from "@/lib/utils/date";
@@ -16,7 +16,7 @@ export interface CardProps {
   /** 직접 상태 뱃지 텍스트를 지정 (createdAt 기반 상대시간 대신 사용) */
   statusText?: string;
   /** 상태 뱃지 스타일 (statusText 사용 시 함께 지정) */
-  statusBadgeStatus?: "recruiting" | "closing" | "inProgress" | "closed";
+  statusBadgeStatus?: NonNullable<BadgeProps["status"]>;
   title: string;
   nickname?: string;
   /** 제목 아래 설명 텍스트 (nickname 대신 표시) */

--- a/src/stories/components/Badge/Badge.stories.tsx
+++ b/src/stories/components/Badge/Badge.stories.tsx
@@ -20,7 +20,7 @@ const meta = {
   argTypes: {
     status: {
       control: "select",
-      options: ["recruiting", "closing", "inProgress", "closed"],
+      options: ["recruiting", "closing", "inProgress", "closed", "positive"],
       description: "Badge의 상태",
     },
     radius: {
@@ -73,6 +73,20 @@ export const Closed: Story = {
   },
 };
 
+export const Positive: Story = {
+  args: {
+    status: "positive",
+    children: "긍정 상태",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Figma cyan state — 긍정적 상태를 나타내는 배지 (예: 모집 시작 임박 등)",
+      },
+    },
+  },
+};
+
 export const RadiusMax: Story = {
   args: {
     status: "recruiting",
@@ -113,6 +127,7 @@ export const AllStatuses: Story = {
       <Badge status="closing">마감 임박</Badge>
       <Badge status="inProgress">진행중</Badge>
       <Badge status="closed">마감</Badge>
+      <Badge status="positive">긍정 상태</Badge>
     </div>
   ),
   parameters: {

--- a/src/test/components/Badge.test.tsx
+++ b/src/test/components/Badge.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+
+import { Badge } from "@/components/Badge/Badge";
+
+describe("Badge", () => {
+  it("기본 렌더링", () => {
+    render(<Badge>기본</Badge>);
+    expect(screen.getByText("기본")).toBeInTheDocument();
+  });
+
+  it("positive status 렌더링", () => {
+    render(<Badge status="positive">긍정 상태</Badge>);
+    const badge = screen.getByText("긍정 상태");
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveClass("text-text-status-positive-default");
+    expect(badge).toHaveClass("bg-[rgba(0,184,219,0.16)]");
+  });
+
+  it.each([
+    ["recruiting", "모집중"],
+    ["closing", "마감 임박"],
+    ["inProgress", "진행중"],
+    ["closed", "마감"],
+    ["positive", "긍정 상태"],
+  ] as const)("status=%s 렌더링", (status, label) => {
+    render(<Badge status={status}>{label}</Badge>);
+    expect(screen.getByText(label)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Figma 디자인 시스템에 정의된 5번째 color state(cyan)를 ChipBadge 컴포넌트에 추가합니다.

- **Figma spec**: bg `rgba(0,184,219,0.16)`, text `#00b8db`, border `#00b8db`
- **Usage**: 향후 "모집 시작 임박" 같은 positive 상태 표현용 (현재 미사용)
- **Status name**: `positive` (도메인 언어 일관성)

## Changes
- ✅ ChipBadge CVA variant에 `positive` status 추가
- ✅ 렌더링 테스트 + 모든 status 테스트 커버 확인
- ✅ Storybook에 Positive story 추가 및 AllStatuses에 반영

## Test Coverage
- All existing tests pass ✅
- New positive status rendering verified ✅
- CSS class application confirmed ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * Badge 컴포넌트에 새로운 긍정 상태 변형이 추가되어 상태 표시 옵션이 확대되었습니다.

* **테스트**
  * 새로운 긍정 상태 변형에 대한 테스트 케이스가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->