### PR TITLE
Feature/#244 fix sse

### DIFF
--- a/src/features/lobby/components/WaitingRoomContent.tsx
+++ b/src/features/lobby/components/WaitingRoomContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useState } from "react";
 
 import dynamic from "next/dynamic";
 
@@ -53,11 +53,24 @@ export function WaitingRoomContent({ sessionId }: WaitingRoomContentProps) {
   const { data: initialWaitingData, isLoading: isWaitingRoomLoading } = useWaitingRoom(sessionId, {
     enabled: isAuthenticated,
   });
-  // 실시간 업데이트: SSE로 수신
-  const { data: sseWaitingData } = useWaitingMembersSSE({ sessionId, enabled: true });
-
   const isAuthDataLoading = isAuthenticated && (isWaitingRoomLoading || isMeLoading);
   const myMemberId = isAuthDataLoading ? undefined : meData?.result?.id;
+
+  // SSE KICKED 이벤트 콜백
+  const handleKicked = useCallback(
+    (memberIds: number[]) => {
+      if (myMemberId && memberIds.includes(myMemberId)) {
+        setIsKicked(true);
+      }
+    },
+    [myMemberId]
+  );
+  // 실시간 업데이트: SSE로 수신
+  const { data: sseWaitingData } = useWaitingMembersSSE({
+    sessionId,
+    enabled: true,
+    onKicked: handleKicked,
+  });
 
   const { isSessionTransitionRef } = useLeaveOnUnmount({
     sessionId,

--- a/src/features/lobby/components/WaitingRoomContent.tsx
+++ b/src/features/lobby/components/WaitingRoomContent.tsx
@@ -66,9 +66,11 @@ export function WaitingRoomContent({ sessionId }: WaitingRoomContentProps) {
     [myMemberId]
   );
   // 실시간 업데이트: SSE로 수신
+  // myMemberId가 확정된 후에만 구독 시작 (인증/로딩 완료를 함의).
+  // 미확정 상태에서 KICKED 이벤트가 도착하면 handleKicked 가드에 걸려 영구 손실됨.
   const { data: sseWaitingData } = useWaitingMembersSSE({
     sessionId,
-    enabled: true,
+    enabled: !!myMemberId,
     onKicked: handleKicked,
   });
 

--- a/src/features/lobby/components/WaitingRoomContent.tsx
+++ b/src/features/lobby/components/WaitingRoomContent.tsx
@@ -113,7 +113,15 @@ export function WaitingRoomContent({ sessionId }: WaitingRoomContentProps) {
   }
 
   // SSE를 통한 강퇴 감지 (참여자였는데 멤버 목록에서 사라진 경우)
-  if (wasParticipant && sseWaitingData && myMemberId && !isKicked && !isLeaving) {
+  // members가 누락된 비정상 payload는 강퇴 추론에서 제외
+  if (
+    wasParticipant &&
+    sseWaitingData &&
+    Array.isArray(sseWaitingData.members) &&
+    myMemberId &&
+    !isKicked &&
+    !isLeaving
+  ) {
     const isStillMember = sseWaitingData.members.some((m) => m.memberId === myMemberId);
     if (!isStillMember) {
       setIsKicked(true);

--- a/src/features/lobby/hooks/useLeaveOnUnmount.ts
+++ b/src/features/lobby/hooks/useLeaveOnUnmount.ts
@@ -49,7 +49,10 @@ export function useLeaveOnUnmount({
 
     return () => {
       if (shouldSkipLeave()) return;
-      fetch(leaveUrl, { method: "DELETE", keepalive: true, credentials: "include" });
+      // 이탈 경로 실패는 의도적으로 무시 (좀비 멤버는 서버 SSE disconnect/타임아웃으로 정리)
+      fetch(leaveUrl, { method: "DELETE", keepalive: true, credentials: "include" }).catch(
+        () => {}
+      );
     };
   }, [enabled, sessionId, isLeavingRef]);
 

--- a/src/features/lobby/hooks/useLeaveOnUnmount.ts
+++ b/src/features/lobby/hooks/useLeaveOnUnmount.ts
@@ -13,7 +13,11 @@ interface UseLeaveOnUnmountOptions {
  * 대기방 페이지 이탈 시 leave API를 호출하는 훅
  *
  * - soft navigation(GNB 로고 클릭 등): useEffect cleanup에서 호출
- * - hard navigation(탭 닫기, 새로고침 등): beforeunload 이벤트에서 호출
+ * - hard navigation(탭 닫기/새로고침): leave를 호출하지 않음
+ *   브라우저는 새로고침과 탭 닫기를 사전에 구분할 수 없어 beforeunload로 leave를
+ *   보내면 새로고침에도 발사되어 본인이 서버에서 제거되는 문제가 있음.
+ *   탭 닫기/네트워크 단절로 인한 좀비 멤버는 백엔드의 SSE disconnect 또는
+ *   타임아웃 기반 정리로 처리하는 것이 정합성 측면에서 권장됨.
  * - 정상 나가기/강퇴/세션 전환 시에는 중복 호출을 방지
  */
 export function useLeaveOnUnmount({
@@ -32,9 +36,9 @@ export function useLeaveOnUnmount({
     }
   }, [isKicked]);
 
-  // 페이지 이탈 시 대기방 leave API 호출
-  // 순수 fetch를 사용하는 이유: api.delete()는 AbortController/timeout/retry 등
-  // 정상 페이지 컨텍스트용이므로, 페이지 이탈 시 fire-and-forget에는 keepalive fetch가 적합
+  // soft navigation 이탈 시 대기방 leave API 호출
+  // keepalive fetch를 사용하는 이유: 라우팅 전환 직전 호출이 페이지 컨텍스트
+  // 종료와 겹쳐도 요청이 끊기지 않도록 보장
   useEffect(() => {
     if (!enabled) return;
 
@@ -43,16 +47,9 @@ export function useLeaveOnUnmount({
     const shouldSkipLeave = () =>
       isLeavingRef.current || isKickedRef.current || isSessionTransitionRef.current;
 
-    const leaveOnExit = () => {
+    return () => {
       if (shouldSkipLeave()) return;
       fetch(leaveUrl, { method: "DELETE", keepalive: true, credentials: "include" });
-    };
-
-    window.addEventListener("beforeunload", leaveOnExit);
-
-    return () => {
-      window.removeEventListener("beforeunload", leaveOnExit);
-      leaveOnExit();
     };
   }, [enabled, sessionId, isLeavingRef]);
 

--- a/src/features/lobby/hooks/useWaitingMembersSSE.ts
+++ b/src/features/lobby/hooks/useWaitingMembersSSE.ts
@@ -1,19 +1,22 @@
 "use client";
 
-import type { SSEError } from "@/lib/sse/types";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import type { SSEConnectionStatus, SSEError } from "@/lib/sse/types";
 import { useSSE } from "@/lib/sse/useSSE";
 
-import type { WaitingMembersEventData } from "../types";
+import type { WaitingMembersEventData, WaitingMembersSSEPayload } from "../types";
 
 interface UseWaitingMembersSSEOptions {
   sessionId: string;
   enabled?: boolean;
   onError?: (error: SSEError) => void;
+  onKicked?: (memberIds: number[]) => void;
 }
 
 interface UseWaitingMembersSSEReturn {
   data: WaitingMembersEventData | null;
-  status: import("@/lib/sse/types").SSEConnectionStatus;
+  status: SSEConnectionStatus;
   error: SSEError | null;
   reconnect: () => void;
   disconnect: () => void;
@@ -23,11 +26,35 @@ export function useWaitingMembersSSE({
   sessionId,
   enabled = true,
   onError,
+  onKicked,
 }: UseWaitingMembersSSEOptions): UseWaitingMembersSSEReturn {
-  return useSSE<WaitingMembersEventData>({
+  const [roomData, setRoomData] = useState<WaitingMembersEventData | null>(null);
+  const onKickedRef = useRef(onKicked);
+  useEffect(() => {
+    onKickedRef.current = onKicked;
+  }, [onKicked]);
+
+  const handleData = useCallback((payload: WaitingMembersSSEPayload) => {
+    if (payload.eventType === "ROOM_UPDATE") {
+      setRoomData(payload.data);
+    } else if (payload.eventType === "KICKED") {
+      onKickedRef.current?.(payload.data.memberIds);
+    }
+  }, []);
+
+  const { status, error, reconnect, disconnect } = useSSE<WaitingMembersSSEPayload>({
     url: `/api/sse/waiting/${sessionId}`,
     eventName: "waiting-members-updated",
     enabled: enabled && !!sessionId,
+    onData: handleData,
     onError,
   });
+
+  return {
+    data: roomData,
+    status,
+    error,
+    reconnect,
+    disconnect,
+  };
 }

--- a/src/features/lobby/hooks/useWaitingMembersSSE.ts
+++ b/src/features/lobby/hooks/useWaitingMembersSSE.ts
@@ -36,8 +36,11 @@ export function useWaitingMembersSSE({
 
   const handleData = useCallback((payload: WaitingMembersSSEPayload) => {
     if (payload.eventType === "ROOM_UPDATE") {
+      // members 필드가 누락된 비정상 payload는 무시 (런타임 가드)
+      if (!payload.data || !Array.isArray(payload.data.members)) return;
       setRoomData(payload.data);
     } else if (payload.eventType === "KICKED") {
+      if (!Array.isArray(payload.data?.memberIds)) return;
       onKickedRef.current?.(payload.data.memberIds);
     }
   }, []);

--- a/src/features/lobby/hooks/useWaitingMembersSSE.ts
+++ b/src/features/lobby/hooks/useWaitingMembersSSE.ts
@@ -42,19 +42,28 @@ export function useWaitingMembersSSE({
     onKickedRef.current = onKicked;
   }, [onKicked]);
 
-  const handleData = useCallback((payload: WaitingMembersSSEPayload) => {
-    if (payload.eventType === "ROOM_UPDATE") {
-      // members 필드가 누락된 비정상 payload는 무시 (런타임 가드)
-      if (!payload.data || !Array.isArray(payload.data.members)) return;
-      setRoomData(payload.data);
-    } else if (payload.eventType === "KICKED") {
-      if (!Array.isArray(payload.data?.memberIds)) return;
-      onKickedRef.current?.(payload.data.memberIds);
-    }
-  }, []);
+  const sseUrl = `/api/sse/waiting/${sessionId}`;
+
+  // 이전 sessionId의 in-flight SSE 이벤트가 새 sessionId 컨텍스트에서 setRoomData를
+  // 호출해 stale 데이터로 덮어씌우는 race를 차단. useSSE가 이벤트 리스너 등록 시점의
+  // url을 meta로 전달해주므로, 현재 sseUrl과 일치하지 않는 콜백은 모두 drop.
+  const handleData = useCallback(
+    (payload: WaitingMembersSSEPayload, meta: { url: string }) => {
+      if (meta.url !== sseUrl) return;
+      if (payload.eventType === "ROOM_UPDATE") {
+        // members 필드가 누락된 비정상 payload는 무시 (런타임 가드)
+        if (!payload.data || !Array.isArray(payload.data.members)) return;
+        setRoomData(payload.data);
+      } else if (payload.eventType === "KICKED") {
+        if (!Array.isArray(payload.data?.memberIds)) return;
+        onKickedRef.current?.(payload.data.memberIds);
+      }
+    },
+    [sseUrl]
+  );
 
   const { status, error, reconnect, disconnect } = useSSE<WaitingMembersSSEPayload>({
-    url: `/api/sse/waiting/${sessionId}`,
+    url: sseUrl,
     eventName: "waiting-members-updated",
     enabled: enabled && !!sessionId,
     onData: handleData,

--- a/src/features/lobby/hooks/useWaitingMembersSSE.ts
+++ b/src/features/lobby/hooks/useWaitingMembersSSE.ts
@@ -29,6 +29,14 @@ export function useWaitingMembersSSE({
   onKicked,
 }: UseWaitingMembersSSEOptions): UseWaitingMembersSSEReturn {
   const [roomData, setRoomData] = useState<WaitingMembersEventData | null>(null);
+  // sessionId 변경 시 이전 방 데이터가 stale 상태로 노출되지 않도록 렌더 중 초기화
+  // (effect 안에서 setState 시 cascading render 유발하므로 prev prop 비교 패턴 사용)
+  const [prevSessionId, setPrevSessionId] = useState(sessionId);
+  if (prevSessionId !== sessionId) {
+    setPrevSessionId(sessionId);
+    setRoomData(null);
+  }
+
   const onKickedRef = useRef(onKicked);
   useEffect(() => {
     onKickedRef.current = onKicked;

--- a/src/features/lobby/types.ts
+++ b/src/features/lobby/types.ts
@@ -26,9 +26,19 @@ export interface WaitingMembersEventData {
   members: WaitingMember[];
 }
 
+// 강퇴 이벤트 데이터
+export interface KickedEventData {
+  memberIds: number[];
+}
+
+// waiting-members-updated SSE 이벤트 payload (discriminated union)
+export type WaitingMembersSSEPayload =
+  | { eventType: "ROOM_UPDATE"; data: WaitingMembersEventData }
+  | { eventType: "KICKED"; data: KickedEventData };
+
 // SSE 이벤트 타입 (discriminated union)
 export type WaitingRoomSSEEvent =
-  | { type: "waiting-members-updated"; data: WaitingMembersEventData }
+  | { type: "waiting-members-updated"; data: WaitingMembersSSEPayload }
   | { type: "error"; data: { code: string; message: string } };
 
 export type WaitingRoomSSEEventType = WaitingRoomSSEEvent["type"];

--- a/src/lib/sse/useSSE.ts
+++ b/src/lib/sse/useSSE.ts
@@ -6,11 +6,16 @@ import { SSEClient } from "./client";
 
 import type { SSEConnectionStatus, SSEError } from "./types";
 
+export interface SSEEventMeta {
+  /** 이벤트 리스너가 등록된 시점의 url (in-flight 이벤트 race 검증용) */
+  url: string;
+}
+
 interface UseSSEOptions<T> {
   url: string;
   eventName: string;
   enabled?: boolean;
-  onData?: (data: T) => void;
+  onData?: (data: T, meta: SSEEventMeta) => void;
   onError?: (error: SSEError) => void;
 }
 
@@ -81,10 +86,14 @@ export function useSSE<T>({
     });
 
     // 이벤트 리스너 등록
+    // registeredUrl: 이 effect 인스턴스가 구독을 시작한 시점의 url을 클로저로 캡쳐.
+    // EventSource.close() 이후에도 이미 dispatch queue에 들어간 message 이벤트는
+    // 처리될 수 있어, 콜백 측에서 등록 시점 url을 알아야 stale 이벤트를 식별할 수 있음.
+    const registeredUrl = url;
     const unsubscribeEvent = client.on<T>(eventName, (eventData) => {
       setData(eventData);
       setError(null);
-      onDataRef.current?.(eventData);
+      onDataRef.current?.(eventData, { url: registeredUrl });
     });
 
     // 에러 리스너

--- a/src/test/sse/useWaitingMembersSSE.test.ts
+++ b/src/test/sse/useWaitingMembersSSE.test.ts
@@ -162,7 +162,7 @@ describe("useWaitingMembersSSE", () => {
   });
 
   describe("이벤트 수신", () => {
-    it("waiting-members-updated 이벤트 수신 시 data가 업데이트되어야 합니다", async () => {
+    it("waiting-members-updated 이벤트(ROOM_UPDATE) 수신 시 data가 업데이트되어야 합니다", async () => {
       const { result } = renderHook(() =>
         useWaitingMembersSSE({
           sessionId: "test-session",
@@ -186,10 +186,70 @@ describe("useWaitingMembersSSE", () => {
       };
 
       act(() => {
-        simulateSSEEvent("waiting-members-updated", mockData);
+        simulateSSEEvent("waiting-members-updated", { eventType: "ROOM_UPDATE", data: mockData });
       });
 
       expect(result.current.data).toEqual(mockData);
+    });
+
+    it("members 필드가 누락된 비정상 ROOM_UPDATE는 무시되어야 합니다", () => {
+      const { result } = renderHook(() =>
+        useWaitingMembersSSE({
+          sessionId: "test-session",
+          enabled: true,
+        })
+      );
+
+      act(() => {
+        simulateSSEEvent("waiting-members-updated", {
+          eventType: "ROOM_UPDATE",
+          data: { participantCount: 0 },
+        });
+      });
+
+      expect(result.current.data).toBeNull();
+    });
+
+    it("KICKED 이벤트 수신 시 onKicked 콜백이 memberIds로 호출되어야 합니다", () => {
+      const onKicked = jest.fn();
+
+      renderHook(() =>
+        useWaitingMembersSSE({
+          sessionId: "test-session",
+          enabled: true,
+          onKicked,
+        })
+      );
+
+      act(() => {
+        simulateSSEEvent("waiting-members-updated", {
+          eventType: "KICKED",
+          data: { memberIds: [1, 2, 3] },
+        });
+      });
+
+      expect(onKicked).toHaveBeenCalledWith([1, 2, 3]);
+    });
+
+    it("memberIds가 누락된 비정상 KICKED 이벤트는 onKicked가 호출되지 않아야 합니다", () => {
+      const onKicked = jest.fn();
+
+      renderHook(() =>
+        useWaitingMembersSSE({
+          sessionId: "test-session",
+          enabled: true,
+          onKicked,
+        })
+      );
+
+      act(() => {
+        simulateSSEEvent("waiting-members-updated", {
+          eventType: "KICKED",
+          data: {},
+        });
+      });
+
+      expect(onKicked).not.toHaveBeenCalled();
     });
 
     it("error 이벤트 수신 시 error가 업데이트되어야 합니다", () => {


### PR DESCRIPTION
## 작업 내용

> SSE 수정
> 대기방에서  새로고침 시, leave api 호출 확인 부분 수정
> 배포 단계 에러 임시 처리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 대기실에서 명시적 강제 퇴장(KICKED) 이벤트를 처리해 즉시 강제 퇴장 상태 반영
  * 사용자 식별이 확인된 이후에만 실시간 구독을 시작

* **버그 수정**
  * 서버에서 잘못된/비정상 SSE 페이로드가 올 경우 상태 갱신을 무시하도록 견고성 강화
  * 탭 닫기/새로고침 시 자동 퇴장 호출 제거 — 이동 시에만 안전하게 퇴장 처리

* **테스트**
  * ROOM_UPDATE 및 KICKED 이벤트의 유효성 검사 및 동작 검증 테스트 추가/확대
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 참고 사항

> 코드 리뷰 시 참고할 만한 사항이나 주의할 점을 작성해주세요.

## 연관 이슈

> 이 PR과 연관된 이슈 번호를 작성하세요. 예) close #10

## CodeRabbit 운영 메모

- 증분 리뷰 재실행: `@coderabbitai review`
- 전체 PR 재검토: `@coderabbitai full review`
