### PR TITLE
chore: Oracle Cloud Object Storage 버킷 도메인 next.config.ts remotePatterns 추가 (#260)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,11 @@ const nextConfig: NextConfig = {
     remotePatterns: [
       {
         protocol: "https",
+        hostname: "axdf2halbi8o.compat.objectstorage.ap-chuncheon-1.oraclecloud.com",
+        pathname: "/**",
+      },
+      {
+        protocol: "https",
         hostname: "gak-aws-s3-bucket.s3.ap-northeast-2.amazonaws.com",
         pathname: "/**",
       },

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,7 +8,7 @@ const nextConfig: NextConfig = {
       {
         protocol: "https",
         hostname: "axdf2halbi8o.compat.objectstorage.ap-chuncheon-1.oraclecloud.com",
-        pathname: "/**",
+        pathname: "/gak-bucket/**",
       },
       {
         protocol: "https",


### PR DESCRIPTION
## 작업 내용

> 백엔드 서버가 Oracle Cloud로 이전되면서 변경된 이미지 버킷 도메인을 `next.config.ts`의 `images.remotePatterns`에 추가합니다.

@coderabbitai summary

- 추가 도메인: `axdf2halbi8o.compat.objectstorage.ap-chuncheon-1.oraclecloud.com`
- 기존 AWS S3 도메인은 레거시 이미지 대응을 위해 유지

## 참고 사항

> - `next.config.ts` 수정이므로 배포 환경에서도 서버 재시작이 필요합니다.
> - 기존 AWS 버킷에 저장된 이미지도 계속 렌더링 가능하도록 기존 항목을 제거하지 않았습니다.

## 연관 이슈

> close #260

## CodeRabbit 운영 메모

- 증분 리뷰 재실행: `@coderabbitai review`
- 전체 PR 재검토: `@coderabbitai full review`