### PR TITLE
feat: Footer 컴포넌트 Figma 동기화

### DIFF
--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -81,11 +81,10 @@ export function Footer() {
         <div className="flex w-full flex-col items-start px-[8px]">
           {/* Description Container */}
           <div className="flex w-full items-center justify-center">
-            <div className="text-text-disabled min-w-px flex-1 text-[11px] leading-none whitespace-pre-wrap md:text-xs">
-              <p className="mb-0 leading-[1.4]">GAK 문의 / 제휴: dnd9team@gmail.com</p>
-              <p className="mb-0 leading-[1.4]">​</p>
-              <p className="leading-[1.4]">
-                모든 제작물의 저작건은 GAK의 소유이므로 사전 허가 없이 무단복제, 도용을 금합니다.
+            <div className="text-text-disabled flex min-w-px flex-1 flex-col gap-[1.4em] text-[11px] leading-[1.4] md:text-xs">
+              <p>GAK 문의 / 제휴: dnd9team@gmail.com</p>
+              <p>
+                모든 제작물의 저작권은 GAK의 소유이므로 사전 허가 없이 무단복제, 도용을 금합니다.
               </p>
             </div>
           </div>

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -11,7 +11,7 @@ import { getCurrentYear } from "@/lib/utils/date";
 
 /**
  * Footer - 공통 푸터
- * Figma Node ID: 1466-22771
+ * Figma Node ID: 169:34263 (Desktop), 169:34314 (Tablet), 169:34336 (Mobile)
  */
 export function Footer() {
   const currentYear = getCurrentYear();
@@ -19,28 +19,28 @@ export function Footer() {
   return (
     <footer className="bg-surface-strong w-full">
       {/* Top Divider */}
-      <div className="border-border-gray-default mx-auto h-[2px] w-full max-w-[1280px]" />
+      <div className="bg-border-gray-default mx-auto h-[2px] w-full max-w-[1280px]" />
 
       <div className="px-lg md:px-xl pb-xl mx-auto flex w-full max-w-[1280px] flex-col justify-center gap-[20px] pt-[32px] xl:px-[120px]">
         {/* Top Section */}
         <div className="gap-2xs md:gap-xs flex w-full flex-col items-start">
-          {/* Logo */}
+          {/* Logo Container */}
           <div className="p-sm flex flex-col items-start rounded-sm">
             <Link href={ROOT_ROUTE} aria-label="GAK 홈으로 이동">
               <Image
                 src="/footer-logo.svg"
                 alt="GAK"
-                width={105}
-                height={40}
-                className="h-9 w-[90px] md:h-10 md:w-[105px]"
+                width={90}
+                height={24}
+                className="h-[20px] w-[75px] md:h-[24px] md:w-[90px]"
                 priority
               />
             </Link>
           </div>
 
-          {/* Links */}
+          {/* Button Container */}
           <nav aria-label="푸터 링크" className="w-full">
-            <ul className="md:gap-md flex flex-wrap items-center gap-[16px]">
+            <ul className="flex flex-wrap items-center gap-[8px] md:gap-[16px]">
               <li>
                 <Link
                   href={TERMS_ROUTE}
@@ -52,9 +52,9 @@ export function Footer() {
               <li>
                 <Link
                   href={PRIVACY_ROUTE}
-                  className="text-text-disabled hover:text-text-primary focus-visible:ring-primary rounded-sm p-[8px] text-xs leading-[1.4] font-semibold transition-colors focus-visible:ring-2 focus-visible:outline-none"
+                  className="text-text-tertiary hover:text-text-primary focus-visible:ring-primary rounded-sm p-[8px] text-xs leading-[1.4] font-semibold transition-colors focus-visible:ring-2 focus-visible:outline-none"
                 >
-                  개인정보 처리방침
+                  개인정보처리방침
                 </Link>
               </li>
               <li>
@@ -79,20 +79,23 @@ export function Footer() {
 
         {/* Info Area */}
         <div className="flex w-full flex-col items-start px-[8px]">
-          <p className="text-text-disabled text-xs leading-[1.4] whitespace-pre-wrap">
-            GAK 문의 / 제휴: dnd9team@gmail.com
-          </p>
-          <br />
-          <p className="text-text-disabled text-xs leading-[1.4] whitespace-pre-wrap">
-            모든 제작물의 저작건은 GAK의 소유이므로 사전 허가 없이 무단복제, 도용을 금합니다.
-          </p>
+          {/* Description Container */}
+          <div className="flex w-full items-center justify-center">
+            <div className="text-text-disabled min-w-px flex-1 text-[11px] leading-none whitespace-pre-wrap md:text-xs">
+              <p className="mb-0 leading-[1.4]">GAK 문의 / 제휴: dnd9team@gmail.com</p>
+              <p className="mb-0 leading-[1.4]">​</p>
+              <p className="leading-[1.4]">
+                모든 제작물의 저작건은 GAK의 소유이므로 사전 허가 없이 무단복제, 도용을 금합니다.
+              </p>
+            </div>
+          </div>
         </div>
 
         {/* Rights */}
         <div className="flex w-full flex-col items-start justify-center px-[8px]">
           <div className="bg-border-subtle h-px w-full shrink-0" />
           <div className="py-sm flex w-full items-center">
-            <p className="font-regular text-[10px] leading-[1.4] text-gray-700 md:text-[11px]">
+            <p className="min-w-px flex-1 text-[10px] leading-[1.4] text-gray-700 md:text-[11px]">
               © {currentYear} GAK by DND 9team. All Rights Reserved.
             </p>
           </div>


### PR DESCRIPTION
## 작업 내용

Footer 컴포넌트를 Figma 디자인(노드 169:34263)과 동기화합니다.

- Top Divider 렌더링 버그 수정 (`border-border-gray-default` → `bg-border-gray-default`)
- 로고 크기 수정 (Desktop: 90×24px, Mobile: 75×20px)
- 개인정보처리방침 색상 수정 (`text-text-disabled` → `text-text-tertiary`)
- 개인정보처리방침 텍스트 수정 (띄어쓰기 제거: `개인정보 처리방침` → `개인정보처리방침`)
- 모바일 링크 Button Container gap 8px 적용
- 모바일 info 텍스트 11px 적용
- Info area 구조 Figma 일치화 (`<br>` → `<p>` + Description Container wrapper)
- Figma Node ID 주석 업데이트 (1466-22771 → 169:34263)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 변경 사항

* **스타일**
  * 푸터 상단 구분선 및 배경 스타일 변경
  * 로고 크기 및 반응형 클래스 간소화
  * 링크 목록 간격 및 브레이크포인트별 레이아웃 개선
  * 설명 텍스트 영역을 중앙 정렬된 플렉스 구조로 재구성

* **버그 수정**
  * 개인정보처리방침 레이블 텍스트 정정 (공백 제거)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dnd-side-project/dnd-14th-9-frontend/pull/265)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 참고 사항

- `/footer-logo.svg`는 gray 버전으로 확인됨 (별도 파일 추가 없음)
- Copyright 기호는 `©` 유지 (Figma의 `Ⓒ`는 비표준 유니코드)
- `<nav>`/`<Link>` 구조는 접근성을 위해 Figma 디자인과 다르게 유지

## 연관 이슈

close #264

## CodeRabbit 운영 메모

- 증분 리뷰 재실행: `@coderabbitai review`
- 전체 PR 재검토: `@coderabbitai full review`