### PR TITLE
feat: 홈 화면 스켈레톤 UI 반응형 수정 (#268)

### DIFF
--- a/src/features/session/components/RecommendedSection/RecommendedGrid.tsx
+++ b/src/features/session/components/RecommendedSection/RecommendedGrid.tsx
@@ -74,6 +74,7 @@ export function RecommendedGrid({
             <div key={session.sessionId} className="w-[226px] shrink-0">
               <Link href={`/session/${session.sessionId}`} scroll={false} className="block">
                 <Card
+                  size="sm"
                   thumbnailSrc={session.imageUrl}
                   category={session.category}
                   createdAt={session.startTime}
@@ -101,6 +102,7 @@ export function RecommendedGrid({
           <div key={session.sessionId} className="mx-auto w-full xl:max-w-69">
             <Link href={`/session/${session.sessionId}`} scroll={false} className="block">
               <Card
+                size="responsive"
                 thumbnailSrc={session.imageUrl}
                 category={session.category}
                 createdAt={session.startTime}

--- a/src/features/session/components/RecommendedSection/RecommendedGridSkeleton.tsx
+++ b/src/features/session/components/RecommendedSection/RecommendedGridSkeleton.tsx
@@ -1,10 +1,5 @@
 import { CardSkeleton } from "../Card/CardSkeleton";
 
-interface RecommendedGridSkeletonProps {
-  /** 스토리북 검증 등을 위해 특정 breakpoint 레이아웃을 강제합니다. */
-  forceBreakpoint?: "mobile" | "tablet" | "desktop";
-}
-
 /**
  * RecommendedGridSkeleton - 추천 세션 카드 4장 그리드 로딩 스켈레톤
  *
@@ -12,25 +7,11 @@ interface RecommendedGridSkeletonProps {
  * - mobile(md 미만): 가로 스크롤 + 우측 fade overlay
  * - tablet/desktop(md 이상): grid (2열 → xl 4열)
  */
-export function RecommendedGridSkeleton({ forceBreakpoint }: RecommendedGridSkeletonProps) {
-  const mobileContainerClass = forceBreakpoint
-    ? forceBreakpoint === "mobile"
-      ? "relative block"
-      : "hidden"
-    : "relative md:hidden";
-
-  const gridContainerClass = forceBreakpoint
-    ? forceBreakpoint === "tablet"
-      ? "grid grid-cols-2 gap-6"
-      : forceBreakpoint === "desktop"
-        ? "grid grid-cols-4 gap-6 gap-y-[48px]"
-        : "hidden"
-    : "hidden grid-cols-2 gap-6 md:grid xl:grid-cols-4 xl:gap-y-[48px]";
-
+export function RecommendedGridSkeleton() {
   return (
     <>
       {/* Mobile: 가로 스크롤 */}
-      <div className={mobileContainerClass}>
+      <div className="relative md:hidden">
         <div className="flex gap-6 overflow-x-auto pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           {Array.from({ length: 4 }).map((_, i) => (
             <div key={i} className="w-[226px] shrink-0">
@@ -46,7 +27,7 @@ export function RecommendedGridSkeleton({ forceBreakpoint }: RecommendedGridSkel
       </div>
 
       {/* Tablet / Desktop: grid */}
-      <div className={gridContainerClass}>
+      <div className="hidden grid-cols-2 gap-6 md:grid xl:grid-cols-4 xl:gap-y-[48px]">
         {Array.from({ length: 4 }).map((_, i) => (
           <div key={i} className="mx-auto w-full xl:max-w-69">
             <CardSkeleton size="responsive" />

--- a/src/features/session/components/RecommendedSection/RecommendedGridSkeleton.tsx
+++ b/src/features/session/components/RecommendedSection/RecommendedGridSkeleton.tsx
@@ -1,5 +1,10 @@
 import { CardSkeleton } from "../Card/CardSkeleton";
 
+interface RecommendedGridSkeletonProps {
+  /** 스토리북 검증 등을 위해 특정 breakpoint 레이아웃을 강제합니다. */
+  forceBreakpoint?: "mobile" | "tablet" | "desktop";
+}
+
 /**
  * RecommendedGridSkeleton - 추천 세션 카드 4장 그리드 로딩 스켈레톤
  *
@@ -7,11 +12,25 @@ import { CardSkeleton } from "../Card/CardSkeleton";
  * - mobile(md 미만): 가로 스크롤 + 우측 fade overlay
  * - tablet/desktop(md 이상): grid (2열 → xl 4열)
  */
-export function RecommendedGridSkeleton() {
+export function RecommendedGridSkeleton({ forceBreakpoint }: RecommendedGridSkeletonProps) {
+  const mobileContainerClass = forceBreakpoint
+    ? forceBreakpoint === "mobile"
+      ? "relative block"
+      : "hidden"
+    : "relative md:hidden";
+
+  const gridContainerClass = forceBreakpoint
+    ? forceBreakpoint === "tablet"
+      ? "grid grid-cols-2 gap-6"
+      : forceBreakpoint === "desktop"
+        ? "grid grid-cols-4 gap-6 gap-y-[48px]"
+        : "hidden"
+    : "hidden grid-cols-2 gap-6 md:grid xl:grid-cols-4 xl:gap-y-[48px]";
+
   return (
     <>
       {/* Mobile: 가로 스크롤 */}
-      <div className="relative md:hidden">
+      <div className={mobileContainerClass}>
         <div className="flex gap-6 overflow-x-auto pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
           {Array.from({ length: 4 }).map((_, i) => (
             <div key={i} className="w-[226px] shrink-0">
@@ -27,7 +46,7 @@ export function RecommendedGridSkeleton() {
       </div>
 
       {/* Tablet / Desktop: grid */}
-      <div className="hidden grid-cols-2 gap-6 md:grid xl:grid-cols-4 xl:gap-y-[48px]">
+      <div className={gridContainerClass}>
         {Array.from({ length: 4 }).map((_, i) => (
           <div key={i} className="mx-auto w-full xl:max-w-69">
             <CardSkeleton size="responsive" />

--- a/src/features/session/components/RecommendedSection/RecommendedGridSkeleton.tsx
+++ b/src/features/session/components/RecommendedSection/RecommendedGridSkeleton.tsx
@@ -12,7 +12,7 @@ export function RecommendedGridSkeleton() {
     <>
       {/* Mobile: 가로 스크롤 */}
       <div className="relative md:hidden">
-        <div className="flex gap-6 overflow-x-auto pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        <div className="scrollbar-hide flex gap-6 overflow-x-auto pb-1">
           {Array.from({ length: 4 }).map((_, i) => (
             <div key={i} className="w-[226px] shrink-0">
               <CardSkeleton size="sm" />
@@ -27,7 +27,7 @@ export function RecommendedGridSkeleton() {
       </div>
 
       {/* Tablet / Desktop: grid */}
-      <div className="hidden grid-cols-2 gap-6 md:grid xl:grid-cols-4 xl:gap-y-[48px]">
+      <div className="hidden min-h-[300px] grid-cols-2 gap-6 md:grid xl:grid-cols-4 xl:gap-y-[48px]">
         {Array.from({ length: 4 }).map((_, i) => (
           <div key={i} className="mx-auto w-full xl:max-w-69">
             <CardSkeleton size="responsive" />

--- a/src/features/session/components/RecommendedSection/RecommendedGridSkeleton.tsx
+++ b/src/features/session/components/RecommendedSection/RecommendedGridSkeleton.tsx
@@ -2,15 +2,38 @@ import { CardSkeleton } from "../Card/CardSkeleton";
 
 /**
  * RecommendedGridSkeleton - 추천 세션 카드 4장 그리드 로딩 스켈레톤
+ *
+ * RecommendedGrid와 동일한 반응형 구조:
+ * - mobile(md 미만): 가로 스크롤 + 우측 fade overlay
+ * - tablet/desktop(md 이상): grid (2열 → xl 4열)
  */
 export function RecommendedGridSkeleton() {
   return (
-    <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 xl:gap-y-[48px]">
-      {Array.from({ length: 4 }).map((_, i) => (
-        <div key={i} className="mx-auto w-full md:max-w-69">
-          <CardSkeleton size="responsive" />
+    <>
+      {/* Mobile: 가로 스크롤 */}
+      <div className="relative md:hidden">
+        <div className="flex gap-6 overflow-x-auto pb-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="w-[226px] shrink-0">
+              <CardSkeleton size="sm" />
+            </div>
+          ))}
         </div>
-      ))}
-    </div>
+        {/* 우측 fade overlay */}
+        <div
+          aria-hidden="true"
+          className="from-surface-default pointer-events-none absolute inset-y-0 right-0 w-20 bg-gradient-to-l to-transparent"
+        />
+      </div>
+
+      {/* Tablet / Desktop: grid */}
+      <div className="hidden grid-cols-2 gap-6 md:grid xl:grid-cols-4 xl:gap-y-[48px]">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="mx-auto w-full xl:max-w-69">
+            <CardSkeleton size="responsive" />
+          </div>
+        ))}
+      </div>
+    </>
   );
 }

--- a/src/features/session/components/SessionList/SessionListSkeleton.tsx
+++ b/src/features/session/components/SessionList/SessionListSkeleton.tsx
@@ -1,10 +1,5 @@
 import { CardSkeleton } from "../Card/CardSkeleton";
 
-interface SessionListSkeletonProps {
-  /** 스토리북 검증 등을 위해 특정 breakpoint 레이아웃을 강제합니다. */
-  forceBreakpoint?: "mobile" | "tablet" | "lg" | "desktop";
-}
-
 /**
  * SessionListSkeleton - 모집 중 세션 로딩 스켈레톤
  *
@@ -12,27 +7,13 @@ interface SessionListSkeletonProps {
  * - 헤더: 제목 + 설명 + 필터바 영역
  * - 카드 그리드: grid-cols-1 → md:grid-cols-2 → xl:grid-cols-4
  */
-export function SessionListSkeleton({ forceBreakpoint }: SessionListSkeletonProps) {
-  const headerRowClass = forceBreakpoint
-    ? forceBreakpoint === "mobile"
-      ? "flex flex-col gap-3"
-      : "flex flex-row items-start justify-between gap-5"
-    : "flex flex-col gap-3 md:flex-row md:items-start md:justify-between md:gap-5";
-
-  const gridClass = forceBreakpoint
-    ? forceBreakpoint === "mobile"
-      ? "grid grid-cols-1 gap-6"
-      : forceBreakpoint === "tablet" || forceBreakpoint === "lg"
-        ? "grid grid-cols-2 gap-6"
-        : "grid grid-cols-4 gap-6 gap-y-[48px]"
-    : "grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4 xl:gap-y-[48px]";
-
+export function SessionListSkeleton() {
   return (
     <section className="gap-xl flex flex-col">
       {/* 헤더 스켈레톤 */}
       <div className="flex flex-col gap-[10px]">
         <div className="bg-surface-strong h-7 w-40 animate-pulse rounded-sm" />
-        <div className={headerRowClass}>
+        <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between md:gap-5">
           <div className="bg-surface-strong h-5 w-64 animate-pulse rounded-sm" />
           {/* 필터바 스켈레톤 */}
           <div className="flex shrink-0 gap-2">
@@ -44,7 +25,7 @@ export function SessionListSkeleton({ forceBreakpoint }: SessionListSkeletonProp
       </div>
 
       {/* 카드 그리드 스켈레톤 (4×3 = 12장) */}
-      <div className={gridClass}>
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4 xl:gap-y-[48px]">
         {Array.from({ length: 12 }).map((_, i) => (
           <div key={i} className="mx-auto w-full xl:max-w-69">
             <CardSkeleton size="responsive" />

--- a/src/features/session/components/SessionList/SessionListSkeleton.tsx
+++ b/src/features/session/components/SessionList/SessionListSkeleton.tsx
@@ -1,5 +1,10 @@
 import { CardSkeleton } from "../Card/CardSkeleton";
 
+interface SessionListSkeletonProps {
+  /** 스토리북 검증 등을 위해 특정 breakpoint 레이아웃을 강제합니다. */
+  forceBreakpoint?: "mobile" | "tablet" | "lg" | "desktop";
+}
+
 /**
  * SessionListSkeleton - 모집 중 세션 로딩 스켈레톤
  *
@@ -7,13 +12,27 @@ import { CardSkeleton } from "../Card/CardSkeleton";
  * - 헤더: 제목 + 설명 + 필터바 영역
  * - 카드 그리드: grid-cols-1 → md:grid-cols-2 → xl:grid-cols-4
  */
-export function SessionListSkeleton() {
+export function SessionListSkeleton({ forceBreakpoint }: SessionListSkeletonProps) {
+  const headerRowClass = forceBreakpoint
+    ? forceBreakpoint === "mobile"
+      ? "flex flex-col gap-3"
+      : "flex flex-row items-start justify-between gap-5"
+    : "flex flex-col gap-3 md:flex-row md:items-start md:justify-between md:gap-5";
+
+  const gridClass = forceBreakpoint
+    ? forceBreakpoint === "mobile"
+      ? "grid grid-cols-1 gap-6"
+      : forceBreakpoint === "tablet" || forceBreakpoint === "lg"
+        ? "grid grid-cols-2 gap-6"
+        : "grid grid-cols-4 gap-6 gap-y-[48px]"
+    : "grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4 xl:gap-y-[48px]";
+
   return (
     <section className="gap-xl flex flex-col">
       {/* 헤더 스켈레톤 */}
       <div className="flex flex-col gap-[10px]">
         <div className="bg-surface-strong h-7 w-40 animate-pulse rounded-sm" />
-        <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between md:gap-5">
+        <div className={headerRowClass}>
           <div className="bg-surface-strong h-5 w-64 animate-pulse rounded-sm" />
           {/* 필터바 스켈레톤 */}
           <div className="flex shrink-0 gap-2">
@@ -25,7 +44,7 @@ export function SessionListSkeleton() {
       </div>
 
       {/* 카드 그리드 스켈레톤 (4×3 = 12장) */}
-      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4 xl:gap-y-[48px]">
+      <div className={gridClass}>
         {Array.from({ length: 12 }).map((_, i) => (
           <div key={i} className="mx-auto w-full xl:max-w-69">
             <CardSkeleton size="responsive" />

--- a/src/features/session/components/SessionList/SessionListSkeleton.tsx
+++ b/src/features/session/components/SessionList/SessionListSkeleton.tsx
@@ -2,20 +2,32 @@ import { CardSkeleton } from "../Card/CardSkeleton";
 
 /**
  * SessionListSkeleton - 모집 중 세션 로딩 스켈레톤
+ *
+ * SessionList와 동일한 반응형 구조:
+ * - 헤더: 제목 + 설명 + 필터바 영역
+ * - 카드 그리드: grid-cols-1 → md:grid-cols-2 → xl:grid-cols-4
  */
 export function SessionListSkeleton() {
   return (
     <section className="gap-xl flex flex-col">
-      {/* 헤더 + 필터 스켈레톤 */}
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      {/* 헤더 스켈레톤 */}
+      <div className="flex flex-col gap-[10px]">
         <div className="bg-surface-strong h-7 w-40 animate-pulse rounded-sm" />
-        <div className="bg-surface-strong h-10 w-20 animate-pulse rounded-sm" />
+        <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between md:gap-5">
+          <div className="bg-surface-strong h-5 w-64 animate-pulse rounded-sm" />
+          {/* 필터바 스켈레톤 */}
+          <div className="flex shrink-0 gap-2">
+            <div className="bg-surface-strong h-9 w-20 animate-pulse rounded-md" />
+            <div className="bg-surface-strong h-9 w-20 animate-pulse rounded-md" />
+            <div className="bg-surface-strong h-9 w-20 animate-pulse rounded-md" />
+          </div>
+        </div>
       </div>
 
       {/* 카드 그리드 스켈레톤 (4×3 = 12장) */}
-      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 xl:gap-y-[48px]">
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-4 xl:gap-y-[48px]">
         {Array.from({ length: 12 }).map((_, i) => (
-          <div key={i} className="mx-auto w-full md:max-w-69">
+          <div key={i} className="mx-auto w-full xl:max-w-69">
             <CardSkeleton size="responsive" />
           </div>
         ))}

--- a/src/stories/features/session/RecommendedSection/RecommendedSection.stories.tsx
+++ b/src/stories/features/session/RecommendedSection/RecommendedSection.stories.tsx
@@ -1,5 +1,6 @@
 import { Card } from "@/features/session/components/Card/Card";
 import { RecommendedGridSkeleton } from "@/features/session/components/RecommendedSection/RecommendedGridSkeleton";
+import type { SessionListItem } from "@/features/session/types";
 
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 
@@ -25,8 +26,8 @@ const customViewports = {
  * 실제 카드 컴포넌트(Card)에 가짜 데이터를 직접 주입한 추천 세션 목록의 실제 반응형 레이아웃과,
  * 이에 대응하는 로딩 스켈레톤(RecommendedGridSkeleton)의 반응형 레이아웃 정합성을 1:1 비교 검증합니다.
  *
- * 💡 프로덕션 컴포넌트를 단 한 줄도 수정하지 않기 위해,
- * 스토리북 파일 내에서 CSS style override 기법을 사용하여 미디어 쿼리(md:, xl:)를 우회 강제합니다.
+ * 💡 각 breakpoint를 한 화면에서 안정적으로 비교하기 위해,
+ * 스토리북 파일 내 CSS style override 기법으로 미디어 쿼리(md:, xl:)를 우회 강제합니다.
  */
 const meta = {
   title: "Features/Session/RecommendedSection",
@@ -140,12 +141,12 @@ function FixedWidthFrame({
 // ---------------------------------------------------------------------------
 // Mock Data (가짜 데이터 직접 주입 방식)
 // ---------------------------------------------------------------------------
-const mockRecommendedSessions = Array.from({ length: 4 }, (_, i) => ({
+const MOCK_RECOMMENDED_SESSIONS: SessionListItem[] = Array.from({ length: 4 }, (_, i) => ({
   sessionId: i + 1,
-  category: "DEVELOPMENT",
+  category: "DEVELOPMENT" as const,
   title: `추천 세션 타이틀 ${i + 1}`,
   hostNickname: `호스트 닉네임 ${i + 1}`,
-  status: "WAITING",
+  status: "WAITING" as const,
   currentParticipants: i + 1,
   maxParticipants: 10,
   sessionDurationMinutes: 60,
@@ -166,9 +167,10 @@ export const CompareMobile: Story = {
       >
         <div className="relative">
           <div className="scrollbar-hide flex gap-6 overflow-x-auto pb-1">
-            {mockRecommendedSessions.map((session) => (
+            {MOCK_RECOMMENDED_SESSIONS.map((session) => (
               <div key={session.sessionId} className="w-[226px] shrink-0">
                 <Card
+                  size="sm"
                   thumbnailSrc={session.imageUrl}
                   category={session.category}
                   createdAt={session.startTime}
@@ -212,9 +214,10 @@ export const CompareTablet: Story = {
         title="[실제 컴포넌트 가짜 데이터 주입] RecommendedGrid - Tablet (2열 그리드)"
       >
         <div className="grid grid-cols-2 gap-6">
-          {mockRecommendedSessions.map((session) => (
+          {MOCK_RECOMMENDED_SESSIONS.map((session) => (
             <div key={session.sessionId} className="mx-auto w-full xl:max-w-69">
               <Card
+                size="responsive"
                 thumbnailSrc={session.imageUrl}
                 category={session.category}
                 createdAt={session.startTime}
@@ -256,9 +259,10 @@ export const CompareDesktop: Story = {
         title="[실제 컴포넌트 가짜 데이터 주입] RecommendedGrid - Desktop (4열 그리드)"
       >
         <div className="grid grid-cols-4 gap-6 gap-y-[48px]">
-          {mockRecommendedSessions.map((session) => (
+          {MOCK_RECOMMENDED_SESSIONS.map((session) => (
             <div key={session.sessionId} className="mx-auto w-full xl:max-w-69">
               <Card
+                size="responsive"
                 thumbnailSrc={session.imageUrl}
                 category={session.category}
                 createdAt={session.startTime}

--- a/src/stories/features/session/RecommendedSection/RecommendedSection.stories.tsx
+++ b/src/stories/features/session/RecommendedSection/RecommendedSection.stories.tsx
@@ -2,29 +2,43 @@ import { RecommendedGridSkeleton } from "@/features/session/components/Recommend
 
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 
+const customViewports = {
+  mobile: {
+    name: "Mobile (375px)",
+    styles: { width: "375px", height: "600px" },
+  },
+  tablet: {
+    name: "Tablet (768px)",
+    styles: { width: "768px", height: "600px" },
+  },
+  desktop: {
+    name: "Desktop (1280px)",
+    styles: { width: "1280px", height: "800px" },
+  },
+};
+
 /**
  * RecommendedSection 스켈레톤 스토리
  *
  * 목적: 스켈레톤 UI가 실제 RecommendedGrid의 반응형 레이아웃과
  * 일치하는지 breakpoint별로 고정된 너비에서 시각적으로 검증합니다.
  *
- * ⚠️ defaultViewport가 아닌 고정 너비 컨테이너를 사용합니다.
- * → Storybook 창 크기에 관계없이 항상 동일한 레이아웃 상태를 보여줍니다.
- *
- * 검증 포인트:
- * - mobile(767px 이하): 가로 스크롤 구조 + 우측 fade overlay
- * - tablet(768px): 2열 그리드
- * - desktop(1280px): 4열 그리드
+ * ⚠️ CSS 미디어 쿼리는 뷰포트(iframe) 크기를 따르기 때문에,
+ * customViewports를 등록하고 각 스토리별로 defaultViewport를 결합하여
+ * 실제 뷰포트 크기와 FixedWidthFrame 너비를 일치시킵니다.
  */
 const meta = {
   title: "Features/Session/RecommendedSection",
   component: RecommendedGridSkeleton,
   parameters: {
     layout: "centered",
+    viewport: {
+      viewports: customViewports,
+    },
     docs: {
       description: {
         component:
-          "추천 세션 그리드 스켈레톤입니다. 고정 너비 컨테이너 기준으로 실제 RecommendedGrid와 동일한 반응형 구조를 검증합니다.",
+          "추천 세션 그리드 스켈레톤입니다. 커스텀 뷰포트 설정과 고정 너비 컨테이너의 결합을 통해 실제 RecommendedGrid와 동일한 반응형 구조를 안전하게 검증합니다.",
       },
     },
   },
@@ -57,6 +71,7 @@ export const GridSkeletonMobile: Story = {
     </FixedWidthFrame>
   ),
   parameters: {
+    viewport: { defaultViewport: "mobile" },
     docs: {
       description: {
         story:
@@ -77,6 +92,7 @@ export const GridSkeletonTablet: Story = {
     </FixedWidthFrame>
   ),
   parameters: {
+    viewport: { defaultViewport: "tablet" },
     docs: {
       description: {
         story: "너비 768px 고정 (md): grid-cols-2로 2열 렌더링되어야 합니다.",
@@ -96,6 +112,7 @@ export const GridSkeletonDesktop: Story = {
     </FixedWidthFrame>
   ),
   parameters: {
+    viewport: { defaultViewport: "desktop" },
     docs: {
       description: {
         story: "너비 1280px 고정 (xl): xl:grid-cols-4로 4열 렌더링되어야 합니다.",

--- a/src/stories/features/session/RecommendedSection/RecommendedSection.stories.tsx
+++ b/src/stories/features/session/RecommendedSection/RecommendedSection.stories.tsx
@@ -1,5 +1,4 @@
 import { RecommendedGridSkeleton } from "@/features/session/components/RecommendedSection/RecommendedGridSkeleton";
-import { RecommendedSectionSkeleton } from "@/features/session/components/RecommendedSection/RecommendedSectionSkeleton";
 
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 
@@ -86,44 +85,6 @@ export const GridSkeletonDesktop: Story = {
     docs: {
       description: {
         story: "desktop(1280px~): xl:grid-cols-4로 4열 렌더링되어야 합니다.",
-      },
-    },
-  },
-};
-
-// ---------------------------------------------------------------------------
-// RecommendedSectionSkeleton (헤더 포함 전체) — 뷰포트별
-// ---------------------------------------------------------------------------
-
-/** mobile: 섹션 헤더 + 가로 스크롤 그리드 전체 스켈레톤 */
-export const SectionSkeletonMobile: Story = {
-  render: () => (
-    <StoryWrapper>
-      <RecommendedSectionSkeleton />
-    </StoryWrapper>
-  ),
-  parameters: {
-    viewport: { defaultViewport: "mobile1" },
-    docs: {
-      description: {
-        story: "mobile: 섹션 헤더(제목+부제+페이지네이션 영역) + 가로 스크롤 그리드 전체 확인",
-      },
-    },
-  },
-};
-
-/** desktop: 섹션 헤더 + 4열 그리드 전체 스켈레톤 */
-export const SectionSkeletonDesktop: Story = {
-  render: () => (
-    <StoryWrapper>
-      <RecommendedSectionSkeleton />
-    </StoryWrapper>
-  ),
-  parameters: {
-    viewport: { defaultViewport: "desktop" },
-    docs: {
-      description: {
-        story: "desktop: 섹션 헤더(우측 페이지네이션 영역) + 4열 그리드 전체 확인",
       },
     },
   },

--- a/src/stories/features/session/RecommendedSection/RecommendedSection.stories.tsx
+++ b/src/stories/features/session/RecommendedSection/RecommendedSection.stories.tsx
@@ -1,0 +1,130 @@
+import { RecommendedGridSkeleton } from "@/features/session/components/RecommendedSection/RecommendedGridSkeleton";
+import { RecommendedSectionSkeleton } from "@/features/session/components/RecommendedSection/RecommendedSectionSkeleton";
+
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+/**
+ * RecommendedSection 스켈레톤 스토리
+ *
+ * 목적: 스켈레톤 UI가 실제 RecommendedGrid/RecommendedSection의
+ * 반응형 레이아웃과 일치하는지 뷰포트별로 시각적으로 검증합니다.
+ *
+ * 검증 포인트:
+ * - mobile(375px): 가로 스크롤 구조 + 우측 fade overlay
+ * - tablet(768px): 2열 그리드
+ * - desktop(1280px): 4열 그리드
+ */
+const meta = {
+  title: "Features/Session/RecommendedSection",
+  component: RecommendedGridSkeleton,
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          "추천 세션 그리드 스켈레톤입니다. 뷰포트별로 실제 RecommendedGrid와 동일한 반응형 구조를 가져야 합니다.",
+      },
+    },
+  },
+} satisfies Meta<typeof RecommendedGridSkeleton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function StoryWrapper({ children }: { children: React.ReactNode }) {
+  return <div className="dark min-h-screen bg-[#0b0f0e] p-5 md:px-10 xl:px-[54px]">{children}</div>;
+}
+
+// ---------------------------------------------------------------------------
+// RecommendedGridSkeleton — 뷰포트별
+// ---------------------------------------------------------------------------
+
+/** mobile(375px): 가로 스크롤 구조로 렌더링되어야 합니다. */
+export const GridSkeletonMobile: Story = {
+  render: () => (
+    <StoryWrapper>
+      <RecommendedGridSkeleton />
+    </StoryWrapper>
+  ),
+  parameters: {
+    viewport: { defaultViewport: "mobile1" },
+    docs: {
+      description: {
+        story:
+          "mobile(375px): 카드가 `w-[226px] shrink-0`으로 가로 스크롤되어야 합니다. 우측 fade overlay도 확인하세요.",
+      },
+    },
+  },
+};
+
+/** tablet(768px): 2열 그리드로 렌더링되어야 합니다. */
+export const GridSkeletonTablet: Story = {
+  render: () => (
+    <StoryWrapper>
+      <RecommendedGridSkeleton />
+    </StoryWrapper>
+  ),
+  parameters: {
+    viewport: { defaultViewport: "tablet" },
+    docs: {
+      description: {
+        story: "tablet(768px): grid-cols-2로 2열 렌더링되어야 합니다.",
+      },
+    },
+  },
+};
+
+/** desktop(1280px): 4열 그리드로 렌더링되어야 합니다. */
+export const GridSkeletonDesktop: Story = {
+  render: () => (
+    <StoryWrapper>
+      <RecommendedGridSkeleton />
+    </StoryWrapper>
+  ),
+  parameters: {
+    viewport: { defaultViewport: "desktop" },
+    docs: {
+      description: {
+        story: "desktop(1280px~): xl:grid-cols-4로 4열 렌더링되어야 합니다.",
+      },
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// RecommendedSectionSkeleton (헤더 포함 전체) — 뷰포트별
+// ---------------------------------------------------------------------------
+
+/** mobile: 섹션 헤더 + 가로 스크롤 그리드 전체 스켈레톤 */
+export const SectionSkeletonMobile: Story = {
+  render: () => (
+    <StoryWrapper>
+      <RecommendedSectionSkeleton />
+    </StoryWrapper>
+  ),
+  parameters: {
+    viewport: { defaultViewport: "mobile1" },
+    docs: {
+      description: {
+        story: "mobile: 섹션 헤더(제목+부제+페이지네이션 영역) + 가로 스크롤 그리드 전체 확인",
+      },
+    },
+  },
+};
+
+/** desktop: 섹션 헤더 + 4열 그리드 전체 스켈레톤 */
+export const SectionSkeletonDesktop: Story = {
+  render: () => (
+    <StoryWrapper>
+      <RecommendedSectionSkeleton />
+    </StoryWrapper>
+  ),
+  parameters: {
+    viewport: { defaultViewport: "desktop" },
+    docs: {
+      description: {
+        story: "desktop: 섹션 헤더(우측 페이지네이션 영역) + 4열 그리드 전체 확인",
+      },
+    },
+  },
+};

--- a/src/stories/features/session/RecommendedSection/RecommendedSection.stories.tsx
+++ b/src/stories/features/session/RecommendedSection/RecommendedSection.stories.tsx
@@ -25,8 +25,8 @@ const customViewports = {
  * 실제 카드 컴포넌트(Card)에 가짜 데이터를 직접 주입한 추천 세션 목록의 실제 반응형 레이아웃과,
  * 이에 대응하는 로딩 스켈레톤(RecommendedGridSkeleton)의 반응형 레이아웃 정합성을 1:1 비교 검증합니다.
  *
- * 💡 실제 API 호출이나 React Query 의존성을 완전히 제거하기 위해,
- * 스토리북 상에서 가짜 데이터를 직접 주입(Presenter UI)하여 렌더링합니다.
+ * 💡 프로덕션 컴포넌트를 단 한 줄도 수정하지 않기 위해,
+ * 스토리북 파일 내에서 CSS style override 기법을 사용하여 미디어 쿼리(md:, xl:)를 우회 강제합니다.
  */
 const meta = {
   title: "Features/Session/RecommendedSection",
@@ -48,17 +48,84 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+// ---------------------------------------------------------------------------
+// CSS Breakpoint Style Override (프로덕션 컴포넌트 오염 방지용 트릭)
+// ---------------------------------------------------------------------------
+function BreakpointOverrideStyle({ mode }: { mode: "mobile" | "tablet" | "desktop" }) {
+  if (mode === "mobile") {
+    return (
+      <style
+        dangerouslySetInnerHTML={{
+          __html: `
+        /* 모바일 강제: 가로 스크롤 영역 보임, 그리드 영역 숨김 */
+        .breakpoint-mobile .md\\:hidden {
+          display: block !important;
+        }
+        .breakpoint-mobile .md\\:grid {
+          display: none !important;
+        }
+      `,
+        }}
+      />
+    );
+  }
+
+  if (mode === "tablet") {
+    return (
+      <style
+        dangerouslySetInnerHTML={{
+          __html: `
+        /* 태블릿 강제: 가로 스크롤 숨김, 2열 그리드 강제 */
+        .breakpoint-tablet .md\\:hidden {
+          display: none !important;
+        }
+        .breakpoint-tablet .md\\:grid {
+          display: grid !important;
+        }
+        .breakpoint-tablet .xl\\:grid-cols-4 {
+          grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+        }
+      `,
+        }}
+      />
+    );
+  }
+
+  // desktop
+  return (
+    <style
+      dangerouslySetInnerHTML={{
+        __html: `
+      /* 데스크탑 강제: 가로 스크롤 숨김, 4열 그리드 강제 */
+      .breakpoint-desktop .md\\:hidden {
+        display: none !important;
+      }
+      .breakpoint-desktop .md\\:grid {
+        display: grid !important;
+      }
+      .breakpoint-desktop .xl\\:grid-cols-4 {
+        grid-template-columns: repeat(4, minmax(0, 1fr)) !important;
+      }
+    `,
+      }}
+    />
+  );
+}
+
 function FixedWidthFrame({
   width,
   title,
+  mode,
   children,
 }: {
   width: number;
   title: string;
+  mode: "mobile" | "tablet" | "desktop";
   children: React.ReactNode;
 }) {
   return (
-    <div className="flex flex-col gap-2">
+    <div className={`flex flex-col gap-2 breakpoint-${mode}`}>
+      <BreakpointOverrideStyle mode={mode} />
       <div className="text-text-muted px-2 text-xs font-bold">{title}</div>
       <div
         className="dark border-border-subtle rounded-md border bg-[#0b0f0e] p-5"
@@ -94,6 +161,7 @@ export const CompareMobile: Story = {
     <div className="flex flex-col gap-8">
       <FixedWidthFrame
         width={375}
+        mode="mobile"
         title="[실제 컴포넌트 가짜 데이터 주입] RecommendedGrid - Mobile (가로 스크롤)"
       >
         <div className="relative">
@@ -120,9 +188,10 @@ export const CompareMobile: Story = {
 
       <FixedWidthFrame
         width={375}
+        mode="mobile"
         title="[스켈레톤] RecommendedGridSkeleton - Mobile (가로 스크롤)"
       >
-        <RecommendedGridSkeleton forceBreakpoint="mobile" />
+        <RecommendedGridSkeleton />
       </FixedWidthFrame>
     </div>
   ),
@@ -139,6 +208,7 @@ export const CompareTablet: Story = {
     <div className="flex flex-col gap-8">
       <FixedWidthFrame
         width={768}
+        mode="tablet"
         title="[실제 컴포넌트 가짜 데이터 주입] RecommendedGrid - Tablet (2열 그리드)"
       >
         <div className="grid grid-cols-2 gap-6">
@@ -160,8 +230,12 @@ export const CompareTablet: Story = {
         </div>
       </FixedWidthFrame>
 
-      <FixedWidthFrame width={768} title="[스켈레톤] RecommendedGridSkeleton - Tablet (2열 그리드)">
-        <RecommendedGridSkeleton forceBreakpoint="tablet" />
+      <FixedWidthFrame
+        width={768}
+        mode="tablet"
+        title="[스켈레톤] RecommendedGridSkeleton - Tablet (2열 그리드)"
+      >
+        <RecommendedGridSkeleton />
       </FixedWidthFrame>
     </div>
   ),
@@ -178,6 +252,7 @@ export const CompareDesktop: Story = {
     <div className="flex flex-col gap-8">
       <FixedWidthFrame
         width={1440}
+        mode="desktop"
         title="[실제 컴포넌트 가짜 데이터 주입] RecommendedGrid - Desktop (4열 그리드)"
       >
         <div className="grid grid-cols-4 gap-6 gap-y-[48px]">
@@ -201,9 +276,10 @@ export const CompareDesktop: Story = {
 
       <FixedWidthFrame
         width={1440}
+        mode="desktop"
         title="[스켈레톤] RecommendedGridSkeleton - Desktop (4열 그리드)"
       >
-        <RecommendedGridSkeleton forceBreakpoint="desktop" />
+        <RecommendedGridSkeleton />
       </FixedWidthFrame>
     </div>
   ),

--- a/src/stories/features/session/RecommendedSection/RecommendedSection.stories.tsx
+++ b/src/stories/features/session/RecommendedSection/RecommendedSection.stories.tsx
@@ -5,11 +5,14 @@ import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 /**
  * RecommendedSection 스켈레톤 스토리
  *
- * 목적: 스켈레톤 UI가 실제 RecommendedGrid/RecommendedSection의
- * 반응형 레이아웃과 일치하는지 뷰포트별로 시각적으로 검증합니다.
+ * 목적: 스켈레톤 UI가 실제 RecommendedGrid의 반응형 레이아웃과
+ * 일치하는지 breakpoint별로 고정된 너비에서 시각적으로 검증합니다.
+ *
+ * ⚠️ defaultViewport가 아닌 고정 너비 컨테이너를 사용합니다.
+ * → Storybook 창 크기에 관계없이 항상 동일한 레이아웃 상태를 보여줍니다.
  *
  * 검증 포인트:
- * - mobile(375px): 가로 스크롤 구조 + 우측 fade overlay
+ * - mobile(767px 이하): 가로 스크롤 구조 + 우측 fade overlay
  * - tablet(768px): 2열 그리드
  * - desktop(1280px): 4열 그리드
  */
@@ -17,11 +20,11 @@ const meta = {
   title: "Features/Session/RecommendedSection",
   component: RecommendedGridSkeleton,
   parameters: {
-    layout: "fullscreen",
+    layout: "centered",
     docs: {
       description: {
         component:
-          "추천 세션 그리드 스켈레톤입니다. 뷰포트별로 실제 RecommendedGrid와 동일한 반응형 구조를 가져야 합니다.",
+          "추천 세션 그리드 스켈레톤입니다. 고정 너비 컨테이너 기준으로 실제 RecommendedGrid와 동일한 반응형 구조를 검증합니다.",
       },
     },
   },
@@ -30,61 +33,72 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-function StoryWrapper({ children }: { children: React.ReactNode }) {
-  return <div className="dark min-h-screen bg-[#0b0f0e] p-5 md:px-10 xl:px-[54px]">{children}</div>;
+function FixedWidthFrame({ width, children }: { width: number; children: React.ReactNode }) {
+  return (
+    <div className="dark bg-[#0b0f0e] p-5" style={{ width, overflow: "hidden" }}>
+      {children}
+    </div>
+  );
 }
 
 // ---------------------------------------------------------------------------
-// RecommendedGridSkeleton — 뷰포트별
+// RecommendedGridSkeleton — breakpoint별 고정 너비
 // ---------------------------------------------------------------------------
 
-/** mobile(375px): 가로 스크롤 구조로 렌더링되어야 합니다. */
+/**
+ * mobile: 너비 375px 고정
+ * → md(768px) 미만이므로 가로 스크롤 구조가 보여야 합니다.
+ * → `w-[226px] shrink-0` 카드 + 우측 fade overlay 확인
+ */
 export const GridSkeletonMobile: Story = {
   render: () => (
-    <StoryWrapper>
+    <FixedWidthFrame width={375}>
       <RecommendedGridSkeleton />
-    </StoryWrapper>
+    </FixedWidthFrame>
   ),
   parameters: {
-    viewport: { defaultViewport: "mobile1" },
     docs: {
       description: {
         story:
-          "mobile(375px): 카드가 `w-[226px] shrink-0`으로 가로 스크롤되어야 합니다. 우측 fade overlay도 확인하세요.",
+          "너비 375px 고정 (md 미만): 카드가 `w-[226px] shrink-0`으로 가로 스크롤되어야 합니다. 우측 fade overlay도 확인하세요.",
       },
     },
   },
 };
 
-/** tablet(768px): 2열 그리드로 렌더링되어야 합니다. */
+/**
+ * tablet: 너비 768px 고정
+ * → md(768px) 이상이므로 2열 그리드가 보여야 합니다.
+ */
 export const GridSkeletonTablet: Story = {
   render: () => (
-    <StoryWrapper>
+    <FixedWidthFrame width={768}>
       <RecommendedGridSkeleton />
-    </StoryWrapper>
+    </FixedWidthFrame>
   ),
   parameters: {
-    viewport: { defaultViewport: "tablet" },
     docs: {
       description: {
-        story: "tablet(768px): grid-cols-2로 2열 렌더링되어야 합니다.",
+        story: "너비 768px 고정 (md): grid-cols-2로 2열 렌더링되어야 합니다.",
       },
     },
   },
 };
 
-/** desktop(1280px): 4열 그리드로 렌더링되어야 합니다. */
+/**
+ * desktop: 너비 1280px 고정
+ * → xl(1280px) 이상이므로 4열 그리드가 보여야 합니다.
+ */
 export const GridSkeletonDesktop: Story = {
   render: () => (
-    <StoryWrapper>
+    <FixedWidthFrame width={1280}>
       <RecommendedGridSkeleton />
-    </StoryWrapper>
+    </FixedWidthFrame>
   ),
   parameters: {
-    viewport: { defaultViewport: "desktop" },
     docs: {
       description: {
-        story: "desktop(1280px~): xl:grid-cols-4로 4열 렌더링되어야 합니다.",
+        story: "너비 1280px 고정 (xl): xl:grid-cols-4로 4열 렌더링되어야 합니다.",
       },
     },
   },

--- a/src/stories/features/session/RecommendedSection/RecommendedSection.stories.tsx
+++ b/src/stories/features/session/RecommendedSection/RecommendedSection.stories.tsx
@@ -1,3 +1,4 @@
+import { Card } from "@/features/session/components/Card/Card";
 import { RecommendedGridSkeleton } from "@/features/session/components/RecommendedSection/RecommendedGridSkeleton";
 
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
@@ -12,20 +13,20 @@ const customViewports = {
     styles: { width: "768px", height: "600px" },
   },
   desktop: {
-    name: "Desktop (1280px)",
-    styles: { width: "1280px", height: "800px" },
+    name: "Desktop (1440px)",
+    styles: { width: "1440px", height: "800px" },
   },
 };
 
 /**
- * RecommendedSection 스켈레톤 스토리
+ * RecommendedSection 스켈레톤 & 실제 컴포넌트 비교 스토리
  *
- * 목적: 스켈레톤 UI가 실제 RecommendedGrid의 반응형 레이아웃과
- * 일치하는지 breakpoint별로 고정된 너비에서 시각적으로 검증합니다.
+ * 목적:
+ * 실제 카드 컴포넌트(Card)에 가짜 데이터를 직접 주입한 추천 세션 목록의 실제 반응형 레이아웃과,
+ * 이에 대응하는 로딩 스켈레톤(RecommendedGridSkeleton)의 반응형 레이아웃 정합성을 1:1 비교 검증합니다.
  *
- * ⚠️ CSS 미디어 쿼리는 뷰포트(iframe) 크기를 따르기 때문에,
- * customViewports를 등록하고 각 스토리별로 defaultViewport를 결합하여
- * 실제 뷰포트 크기와 FixedWidthFrame 너비를 일치시킵니다.
+ * 💡 실제 API 호출이나 React Query 의존성을 완전히 제거하기 위해,
+ * 스토리북 상에서 가짜 데이터를 직접 주입(Presenter UI)하여 렌더링합니다.
  */
 const meta = {
   title: "Features/Session/RecommendedSection",
@@ -38,7 +39,7 @@ const meta = {
     docs: {
       description: {
         component:
-          "추천 세션 그리드 스켈레톤입니다. 커스텀 뷰포트 설정과 고정 너비 컨테이너의 결합을 통해 실제 RecommendedGrid와 동일한 반응형 구조를 안전하게 검증합니다.",
+          "추천 세션 영역의 실제 컴포넌트와 스켈레톤 컴포넌트 비교 스토리입니다. 반응형 레이아웃의 구조적 정합성을 확인합니다.",
       },
     },
   },
@@ -47,76 +48,166 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-function FixedWidthFrame({ width, children }: { width: number; children: React.ReactNode }) {
+function FixedWidthFrame({
+  width,
+  title,
+  children,
+}: {
+  width: number;
+  title: string;
+  children: React.ReactNode;
+}) {
   return (
-    <div className="dark bg-[#0b0f0e] p-5" style={{ width, overflow: "hidden" }}>
-      {children}
+    <div className="flex flex-col gap-2">
+      <div className="text-text-muted px-2 text-xs font-bold">{title}</div>
+      <div
+        className="dark border-border-subtle rounded-md border bg-[#0b0f0e] p-5"
+        style={{ width, overflow: "hidden" }}
+      >
+        {children}
+      </div>
     </div>
   );
 }
 
 // ---------------------------------------------------------------------------
-// RecommendedGridSkeleton — breakpoint별 고정 너비
+// Mock Data (가짜 데이터 직접 주입 방식)
 // ---------------------------------------------------------------------------
+const mockRecommendedSessions = Array.from({ length: 4 }, (_, i) => ({
+  sessionId: i + 1,
+  category: "DEVELOPMENT",
+  title: `추천 세션 타이틀 ${i + 1}`,
+  hostNickname: `호스트 닉네임 ${i + 1}`,
+  status: "WAITING",
+  currentParticipants: i + 1,
+  maxParticipants: 10,
+  sessionDurationMinutes: 60,
+  startTime: "2026-02-21T10:00:00",
+  imageUrl: "",
+}));
 
-/**
- * mobile: 너비 375px 고정
- * → md(768px) 미만이므로 가로 스크롤 구조가 보여야 합니다.
- * → `w-[226px] shrink-0` 카드 + 우측 fade overlay 확인
- */
-export const GridSkeletonMobile: Story = {
+// ---------------------------------------------------------------------------
+// 1. Mobile (375px) — 가로 스크롤 구조 비교
+// ---------------------------------------------------------------------------
+export const CompareMobile: Story = {
   render: () => (
-    <FixedWidthFrame width={375}>
-      <RecommendedGridSkeleton />
-    </FixedWidthFrame>
+    <div className="flex flex-col gap-8">
+      <FixedWidthFrame
+        width={375}
+        title="[실제 컴포넌트 가짜 데이터 주입] RecommendedGrid - Mobile (가로 스크롤)"
+      >
+        <div className="relative">
+          <div className="scrollbar-hide flex gap-6 overflow-x-auto pb-1">
+            {mockRecommendedSessions.map((session) => (
+              <div key={session.sessionId} className="w-[226px] shrink-0">
+                <Card
+                  thumbnailSrc={session.imageUrl}
+                  category={session.category}
+                  createdAt={session.startTime}
+                  title={session.title}
+                  nickname={session.hostNickname}
+                  currentParticipants={session.currentParticipants}
+                  maxParticipants={session.maxParticipants}
+                  durationMinutes={session.sessionDurationMinutes}
+                  sessionDate={session.startTime}
+                />
+              </div>
+            ))}
+          </div>
+          <div className="from-surface-default pointer-events-none absolute inset-y-0 right-0 w-20 bg-gradient-to-l to-transparent" />
+        </div>
+      </FixedWidthFrame>
+
+      <FixedWidthFrame
+        width={375}
+        title="[스켈레톤] RecommendedGridSkeleton - Mobile (가로 스크롤)"
+      >
+        <RecommendedGridSkeleton forceBreakpoint="mobile" />
+      </FixedWidthFrame>
+    </div>
   ),
   parameters: {
     viewport: { defaultViewport: "mobile" },
-    docs: {
-      description: {
-        story:
-          "너비 375px 고정 (md 미만): 카드가 `w-[226px] shrink-0`으로 가로 스크롤되어야 합니다. 우측 fade overlay도 확인하세요.",
-      },
-    },
   },
 };
 
-/**
- * tablet: 너비 768px 고정
- * → md(768px) 이상이므로 2열 그리드가 보여야 합니다.
- */
-export const GridSkeletonTablet: Story = {
+// ---------------------------------------------------------------------------
+// 2. Tablet (768px) — 2열 그리드 구조 비교
+// ---------------------------------------------------------------------------
+export const CompareTablet: Story = {
   render: () => (
-    <FixedWidthFrame width={768}>
-      <RecommendedGridSkeleton />
-    </FixedWidthFrame>
+    <div className="flex flex-col gap-8">
+      <FixedWidthFrame
+        width={768}
+        title="[실제 컴포넌트 가짜 데이터 주입] RecommendedGrid - Tablet (2열 그리드)"
+      >
+        <div className="grid grid-cols-2 gap-6">
+          {mockRecommendedSessions.map((session) => (
+            <div key={session.sessionId} className="mx-auto w-full xl:max-w-69">
+              <Card
+                thumbnailSrc={session.imageUrl}
+                category={session.category}
+                createdAt={session.startTime}
+                title={session.title}
+                nickname={session.hostNickname}
+                currentParticipants={session.currentParticipants}
+                maxParticipants={session.maxParticipants}
+                durationMinutes={session.sessionDurationMinutes}
+                sessionDate={session.startTime}
+              />
+            </div>
+          ))}
+        </div>
+      </FixedWidthFrame>
+
+      <FixedWidthFrame width={768} title="[스켈레톤] RecommendedGridSkeleton - Tablet (2열 그리드)">
+        <RecommendedGridSkeleton forceBreakpoint="tablet" />
+      </FixedWidthFrame>
+    </div>
   ),
   parameters: {
     viewport: { defaultViewport: "tablet" },
-    docs: {
-      description: {
-        story: "너비 768px 고정 (md): grid-cols-2로 2열 렌더링되어야 합니다.",
-      },
-    },
   },
 };
 
-/**
- * desktop: 너비 1280px 고정
- * → xl(1280px) 이상이므로 4열 그리드가 보여야 합니다.
- */
-export const GridSkeletonDesktop: Story = {
+// ---------------------------------------------------------------------------
+// 3. Desktop (1440px) — xl: 4열 그리드 구조 비교
+// ---------------------------------------------------------------------------
+export const CompareDesktop: Story = {
   render: () => (
-    <FixedWidthFrame width={1280}>
-      <RecommendedGridSkeleton />
-    </FixedWidthFrame>
+    <div className="flex flex-col gap-8">
+      <FixedWidthFrame
+        width={1440}
+        title="[실제 컴포넌트 가짜 데이터 주입] RecommendedGrid - Desktop (4열 그리드)"
+      >
+        <div className="grid grid-cols-4 gap-6 gap-y-[48px]">
+          {mockRecommendedSessions.map((session) => (
+            <div key={session.sessionId} className="mx-auto w-full xl:max-w-69">
+              <Card
+                thumbnailSrc={session.imageUrl}
+                category={session.category}
+                createdAt={session.startTime}
+                title={session.title}
+                nickname={session.hostNickname}
+                currentParticipants={session.currentParticipants}
+                maxParticipants={session.maxParticipants}
+                durationMinutes={session.sessionDurationMinutes}
+                sessionDate={session.startTime}
+              />
+            </div>
+          ))}
+        </div>
+      </FixedWidthFrame>
+
+      <FixedWidthFrame
+        width={1440}
+        title="[스켈레톤] RecommendedGridSkeleton - Desktop (4열 그리드)"
+      >
+        <RecommendedGridSkeleton forceBreakpoint="desktop" />
+      </FixedWidthFrame>
+    </div>
   ),
   parameters: {
     viewport: { defaultViewport: "desktop" },
-    docs: {
-      description: {
-        story: "너비 1280px 고정 (xl): xl:grid-cols-4로 4열 렌더링되어야 합니다.",
-      },
-    },
   },
 };

--- a/src/stories/features/session/SessionList/SessionList.stories.tsx
+++ b/src/stories/features/session/SessionList/SessionList.stories.tsx
@@ -1,0 +1,132 @@
+import { SessionListSkeleton } from "@/features/session/components/SessionList/SessionListSkeleton";
+
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+/**
+ * SessionList 스켈레톤 스토리
+ *
+ * 목적: SessionListSkeleton이 실제 SessionList의
+ * 반응형 레이아웃과 일치하는지 뷰포트별로 시각적으로 검증합니다.
+ *
+ * 검증 포인트:
+ * - 헤더: 제목 + 설명 텍스트 + 필터바 (mobile은 세로, md+ 가로 배치)
+ * - mobile(375px): 1열 그리드
+ * - tablet(768px): 2열 그리드 (md:grid-cols-2)
+ * - desktop xl(1280px+): 4열 그리드 (xl:grid-cols-4)
+ * - lg breakpoint(1024px)에서 3열이 되어서는 안 됩니다.
+ */
+const meta = {
+  title: "Features/Session/SessionList",
+  component: SessionListSkeleton,
+  parameters: {
+    layout: "fullscreen",
+    docs: {
+      description: {
+        component:
+          "모집 중 세션 목록 스켈레톤입니다. 뷰포트별로 실제 SessionList와 동일한 반응형 구조를 가져야 합니다.",
+      },
+    },
+  },
+} satisfies Meta<typeof SessionListSkeleton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function StoryWrapper({ children }: { children: React.ReactNode }) {
+  return <div className="dark min-h-screen bg-[#0b0f0e] p-5 md:px-10 xl:px-[54px]">{children}</div>;
+}
+
+// ---------------------------------------------------------------------------
+// SessionListSkeleton — 뷰포트별
+// ---------------------------------------------------------------------------
+
+/**
+ * mobile(375px): 헤더가 세로 스택, 카드는 1열
+ *
+ * 실제 SessionList 확인 포인트:
+ * - 헤더: flex-col (제목 → 설명 → 필터바 순 세로 배치)
+ * - 카드 그리드: grid-cols-1
+ */
+export const SkeletonMobile: Story = {
+  render: () => (
+    <StoryWrapper>
+      <SessionListSkeleton />
+    </StoryWrapper>
+  ),
+  parameters: {
+    viewport: { defaultViewport: "mobile1" },
+    docs: {
+      description: {
+        story: "mobile(375px): 헤더 세로 스택 + 1열 그리드. 필터바가 헤더 아래 세로로 배치됩니다.",
+      },
+    },
+  },
+};
+
+/**
+ * tablet(768px): 헤더가 가로 배치, 카드는 2열
+ *
+ * 실제 SessionList 확인 포인트:
+ * - 헤더: md:flex-row (좌측 제목+설명, 우측 필터바)
+ * - 카드 그리드: md:grid-cols-2
+ */
+export const SkeletonTablet: Story = {
+  render: () => (
+    <StoryWrapper>
+      <SessionListSkeleton />
+    </StoryWrapper>
+  ),
+  parameters: {
+    viewport: { defaultViewport: "tablet" },
+    docs: {
+      description: {
+        story:
+          "tablet(768px): 헤더 가로 배치(제목+설명 / 필터바) + 2열 그리드. lg(1024px)에서도 2열이어야 합니다.",
+      },
+    },
+  },
+};
+
+/**
+ * lg(1024px): 2열 유지 확인 — 3열이 되어서는 안 됩니다.
+ *
+ * 이 뷰포트에서 3열이 된다면 실제 SessionList와 불일치입니다.
+ */
+export const SkeletonLg: Story = {
+  render: () => (
+    <StoryWrapper>
+      <SessionListSkeleton />
+    </StoryWrapper>
+  ),
+  parameters: {
+    viewport: { defaultViewport: "desktop" },
+    docs: {
+      description: {
+        story:
+          "lg(1024px): ⚠️ 2열 유지 확인 포인트. 3열이 되면 실제 SessionList(lg:grid-cols-3 없음)와 불일치입니다.",
+      },
+    },
+  },
+};
+
+/**
+ * desktop xl(1280px+): 헤더 가로 배치, 카드는 4열
+ *
+ * 실제 SessionList 확인 포인트:
+ * - 카드 그리드: xl:grid-cols-4, xl:gap-y-[48px]
+ */
+export const SkeletonDesktop: Story = {
+  render: () => (
+    <StoryWrapper>
+      <SessionListSkeleton />
+    </StoryWrapper>
+  ),
+  parameters: {
+    viewport: { defaultViewport: "desktop" },
+    docs: {
+      description: {
+        story: "desktop xl(1280px+): 4열 그리드 + xl:gap-y-[48px] 확인.",
+      },
+    },
+  },
+};

--- a/src/stories/features/session/SessionList/SessionList.stories.tsx
+++ b/src/stories/features/session/SessionList/SessionList.stories.tsx
@@ -1,3 +1,4 @@
+import { SessionCardItem } from "@/features/session/components/SessionList/SessionCardItem";
 import { SessionListSkeleton } from "@/features/session/components/SessionList/SessionListSkeleton";
 
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
@@ -16,20 +17,20 @@ const customViewports = {
     styles: { width: "1024px", height: "800px" },
   },
   desktop: {
-    name: "Desktop (1280px)",
-    styles: { width: "1280px", height: "800px" },
+    name: "Desktop (1440px)",
+    styles: { width: "1440px", height: "800px" },
   },
 };
 
 /**
- * SessionList 스켈레톤 스토리
+ * SessionList 스켈레톤 & 실제 컴포넌트 비교 스토리
  *
- * 목적: 스켈레톤 UI가 실제 SessionList의 반응형 레이아웃과
- * 일치하는지 breakpoint별로 고정된 너비에서 시각적으로 검증합니다.
+ * 목적:
+ * 실제 카드 컴포넌트(SessionCardItem)에 가짜 데이터를 직접 주입한 모집 중 세션 목록의 실제 반응형 레이아웃과,
+ * 이에 대응하는 로딩 스켈레톤(SessionListSkeleton)의 반응형 레이아웃 정합성을 1:1 비교 검증합니다.
  *
- * ⚠️ CSS 미디어 쿼리는 뷰포트(iframe) 크기를 따르기 때문에,
- * customViewports를 등록하고 각 스토리별로 defaultViewport를 결합하여
- * 실제 뷰포트 크기와 FixedWidthFrame 너비를 일치시킵니다.
+ * 💡 실제 API 호출, React Query, useSearchParams 등의 비즈니스 의존성을 완전히 제거하기 위해,
+ * 스토리북 상에서 가짜 데이터를 직접 props로 주입(Presenter UI)하여 렌더링합니다.
  */
 const meta = {
   title: "Features/Session/SessionList",
@@ -42,7 +43,7 @@ const meta = {
     docs: {
       description: {
         component:
-          "모집 중 세션 목록 스켈레톤입니다. 커스텀 뷰포트 설정과 고정 너비 컨테이너의 결합을 통해 실제 SessionList와 동일한 반응형 구조를 검증합니다.",
+          "모집 중 세션 목록 실제 컴포넌트와 스켈레톤 컴포넌트 비교 스토리입니다. 반응형 레이아웃의 구조적 정합성을 확인합니다.",
       },
     },
   },
@@ -51,101 +52,237 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-function FixedWidthFrame({ width, children }: { width: number; children: React.ReactNode }) {
+function FixedWidthFrame({
+  width,
+  title,
+  children,
+}: {
+  width: number;
+  title: string;
+  children: React.ReactNode;
+}) {
   return (
-    <div
-      className="dark bg-[#0b0f0e] p-5 md:px-10 xl:px-[54px]"
-      style={{ width, overflow: "hidden" }}
-    >
-      {children}
+    <div className="flex flex-col gap-2">
+      <div className="text-text-muted px-2 text-xs font-bold">{title}</div>
+      <div
+        className="dark border-border-subtle rounded-md border bg-[#0b0f0e] p-5 md:px-10 xl:px-[54px]"
+        style={{ width, overflow: "hidden" }}
+      >
+        {children}
+      </div>
     </div>
   );
 }
 
 // ---------------------------------------------------------------------------
-// SessionListSkeleton — breakpoint별 고정 너비
+// Mock Data (가짜 데이터 직접 주입 방식)
 // ---------------------------------------------------------------------------
+const mockSessions = Array.from({ length: 8 }, (_, i) => ({
+  sessionId: i + 1,
+  category: "DEVELOPMENT" as const,
+  title: `모집 중인 세션 타이틀 ${i + 1}`,
+  hostNickname: `호스트 ${i + 1}`,
+  status: "WAITING" as const,
+  currentParticipants: i + 1,
+  maxParticipants: 10,
+  sessionDurationMinutes: 60,
+  startTime: "2026-02-21T10:00:00",
+  imageUrl: "",
+}));
 
-/**
- * mobile: 너비 375px 고정
- * → md(768px) 미만이므로 1열 그리드 및 헤더 세로 스택이 보여야 합니다.
- */
-export const SkeletonMobile: Story = {
+const mockOnShare = (id: number) => {
+  alert(`Share Session Link: ${id}`);
+};
+
+// ---------------------------------------------------------------------------
+// 1. Mobile (375px) — 1열 그리드 및 세로 헤더 비교
+// ---------------------------------------------------------------------------
+export const CompareMobile: Story = {
   render: () => (
-    <FixedWidthFrame width={375}>
-      <SessionListSkeleton />
-    </FixedWidthFrame>
+    <div className="flex flex-col gap-8">
+      <FixedWidthFrame
+        width={375}
+        title="[실제 컴포넌트 가짜 데이터 주입] SessionList - Mobile (1열 + 세로 헤더)"
+      >
+        <section className="gap-lg flex flex-col">
+          <div className="flex flex-col gap-[10px]">
+            <h2 className="text-text-primary text-lg font-bold">지금 모집 중인 세션</h2>
+            <div className="flex flex-col gap-3">
+              <p className="text-text-muted text-[13px]">
+                현재 모집 중인 세션에 바로 참여해 보세요
+              </p>
+              {/* 모바일 가짜 필터바 버튼 예시 */}
+              <div className="flex gap-2 overflow-x-auto pb-1">
+                <button className="bg-surface-subtle text-text-secondary rounded-md px-3 py-1.5 text-xs whitespace-nowrap">
+                  정렬
+                </button>
+                <button className="bg-surface-subtle text-text-secondary rounded-md px-3 py-1.5 text-xs whitespace-nowrap">
+                  날짜
+                </button>
+                <button className="bg-surface-subtle text-text-secondary rounded-md px-3 py-1.5 text-xs whitespace-nowrap">
+                  시간
+                </button>
+              </div>
+            </div>
+          </div>
+          <div className="grid grid-cols-1 gap-6">
+            {mockSessions.map((session) => (
+              <SessionCardItem key={session.sessionId} session={session} onShare={mockOnShare} />
+            ))}
+          </div>
+        </section>
+      </FixedWidthFrame>
+
+      <FixedWidthFrame
+        width={375}
+        title="[스켈레톤] SessionListSkeleton - Mobile (1열 + 세로 헤더)"
+      >
+        <SessionListSkeleton forceBreakpoint="mobile" />
+      </FixedWidthFrame>
+    </div>
   ),
   parameters: {
     viewport: { defaultViewport: "mobile" },
-    docs: {
-      description: {
-        story:
-          "너비 375px 고정 (md 미만): 헤더 세로 스택 + 1열 그리드. 필터바가 헤더 아래 세로로 배치됩니다.",
-      },
-    },
   },
 };
 
-/**
- * tablet: 너비 768px 고정
- * → md(768px) 이상이므로 2열 그리드 및 헤더 가로 배치가 보여야 합니다.
- */
-export const SkeletonTablet: Story = {
+// ---------------------------------------------------------------------------
+// 2. Tablet (768px) — 2열 그리드 및 가로 헤더 비교
+// ---------------------------------------------------------------------------
+export const CompareTablet: Story = {
   render: () => (
-    <FixedWidthFrame width={768}>
-      <SessionListSkeleton />
-    </FixedWidthFrame>
+    <div className="flex flex-col gap-8">
+      <FixedWidthFrame
+        width={768}
+        title="[실제 컴포넌트 가짜 데이터 주입] SessionList - Tablet (2열 + 가로 헤더)"
+      >
+        <section className="gap-lg flex flex-col">
+          <div className="flex flex-col gap-[10px]">
+            <h2 className="text-text-primary text-lg font-bold md:text-2xl">지금 모집 중인 세션</h2>
+            <div className="flex flex-row items-start justify-between gap-5">
+              <p className="text-text-muted text-base">현재 모집 중인 세션에 바로 참여해 보세요</p>
+              <div className="flex gap-2">
+                <button className="bg-surface-subtle text-text-secondary rounded-md px-3 py-1.5 text-xs">
+                  정렬
+                </button>
+                <button className="bg-surface-subtle text-text-secondary rounded-md px-3 py-1.5 text-xs">
+                  날짜
+                </button>
+                <button className="bg-surface-subtle text-text-secondary rounded-md px-3 py-1.5 text-xs">
+                  시간
+                </button>
+              </div>
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-6">
+            {mockSessions.map((session) => (
+              <SessionCardItem key={session.sessionId} session={session} onShare={mockOnShare} />
+            ))}
+          </div>
+        </section>
+      </FixedWidthFrame>
+
+      <FixedWidthFrame
+        width={768}
+        title="[스켈레톤] SessionListSkeleton - Tablet (2열 + 가로 헤더)"
+      >
+        <SessionListSkeleton forceBreakpoint="tablet" />
+      </FixedWidthFrame>
+    </div>
   ),
   parameters: {
     viewport: { defaultViewport: "tablet" },
-    docs: {
-      description: {
-        story: "너비 768px 고정 (md): 헤더 가로 배치(제목+설명 / 필터바) + 2열 그리드.",
-      },
-    },
   },
 };
 
-/**
- * lg: 너비 1024px 고정
- * → md 이상, xl 미만이므로 2열 그리드가 유지되어야 합니다.
- * ⚠️ 3열이 되면 실제 SessionList와 불일치입니다.
- */
-export const SkeletonLg: Story = {
+// ---------------------------------------------------------------------------
+// 3. Lg (1024px) — ⚠️ 2열 유지 확인 비교
+// ---------------------------------------------------------------------------
+export const CompareLg: Story = {
   render: () => (
-    <FixedWidthFrame width={1024}>
-      <SessionListSkeleton />
-    </FixedWidthFrame>
+    <div className="flex flex-col gap-8">
+      <FixedWidthFrame
+        width={1024}
+        title="[실제 컴포넌트 가짜 데이터 주입] SessionList - Lg (⚠️ 2열 유지 확인)"
+      >
+        <section className="gap-lg flex flex-col">
+          <div className="flex flex-col gap-[10px]">
+            <h2 className="text-text-primary text-lg font-bold md:text-2xl">지금 모집 중인 세션</h2>
+            <div className="flex flex-row items-start justify-between gap-5">
+              <p className="text-text-muted text-base">현재 모집 중인 세션에 바로 참여해 보세요</p>
+              <div className="flex gap-2">
+                <button className="bg-surface-subtle text-text-secondary rounded-md px-3 py-1.5 text-xs">
+                  정렬
+                </button>
+                <button className="bg-surface-subtle text-text-secondary rounded-md px-3 py-1.5 text-xs">
+                  날짜
+                </button>
+                <button className="bg-surface-subtle text-text-secondary rounded-md px-3 py-1.5 text-xs">
+                  시간
+                </button>
+              </div>
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-6">
+            {mockSessions.map((session) => (
+              <SessionCardItem key={session.sessionId} session={session} onShare={mockOnShare} />
+            ))}
+          </div>
+        </section>
+      </FixedWidthFrame>
+
+      <FixedWidthFrame width={1024} title="[스켈레톤] SessionListSkeleton - Lg (⚠️ 2열 유지 확인)">
+        <SessionListSkeleton forceBreakpoint="lg" />
+      </FixedWidthFrame>
+    </div>
   ),
   parameters: {
     viewport: { defaultViewport: "lg" },
-    docs: {
-      description: {
-        story:
-          "너비 1024px 고정 (lg): ⚠️ 2열 유지 확인 포인트. 3열이 되면 실제 SessionList와 불일치입니다.",
-      },
-    },
   },
 };
 
-/**
- * desktop: 너비 1280px 고정
- * → xl(1280px) 이상이므로 4열 그리드가 보여야 합니다.
- */
-export const SkeletonDesktop: Story = {
+// ---------------------------------------------------------------------------
+// 4. Desktop (1440px) — 4열 그리드 비교
+// ---------------------------------------------------------------------------
+export const CompareDesktop: Story = {
   render: () => (
-    <FixedWidthFrame width={1280}>
-      <SessionListSkeleton />
-    </FixedWidthFrame>
+    <div className="flex flex-col gap-8">
+      <FixedWidthFrame
+        width={1440}
+        title="[실제 컴포넌트 가짜 데이터 주입] SessionList - Desktop (4열 그리드)"
+      >
+        <section className="gap-lg flex flex-col">
+          <div className="flex flex-col gap-[10px]">
+            <h2 className="text-text-primary text-lg font-bold md:text-2xl">지금 모집 중인 세션</h2>
+            <div className="flex flex-row items-start justify-between gap-5">
+              <p className="text-text-muted text-base">현재 모집 중인 세션에 바로 참여해 보세요</p>
+              <div className="flex gap-2">
+                <button className="bg-surface-subtle text-text-secondary rounded-md px-3 py-1.5 text-xs">
+                  정렬
+                </button>
+                <button className="bg-surface-subtle text-text-secondary rounded-md px-3 py-1.5 text-xs">
+                  날짜
+                </button>
+                <button className="bg-surface-subtle text-text-secondary rounded-md px-3 py-1.5 text-xs">
+                  시간
+                </button>
+              </div>
+            </div>
+          </div>
+          <div className="grid grid-cols-4 gap-6 gap-y-[48px]">
+            {mockSessions.map((session) => (
+              <SessionCardItem key={session.sessionId} session={session} onShare={mockOnShare} />
+            ))}
+          </div>
+        </section>
+      </FixedWidthFrame>
+
+      <FixedWidthFrame width={1440} title="[스켈레톤] SessionListSkeleton - Desktop (4열 그리드)">
+        <SessionListSkeleton forceBreakpoint="desktop" />
+      </FixedWidthFrame>
+    </div>
   ),
   parameters: {
     viewport: { defaultViewport: "desktop" },
-    docs: {
-      description: {
-        story:
-          "너비 1280px 고정 (xl): xl:grid-cols-4로 4열 렌더링되며 xl:gap-y-[48px]가 적용됩니다.",
-      },
-    },
   },
 };

--- a/src/stories/features/session/SessionList/SessionList.stories.tsx
+++ b/src/stories/features/session/SessionList/SessionList.stories.tsx
@@ -2,31 +2,47 @@ import { SessionListSkeleton } from "@/features/session/components/SessionList/S
 
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 
+const customViewports = {
+  mobile: {
+    name: "Mobile (375px)",
+    styles: { width: "375px", height: "600px" },
+  },
+  tablet: {
+    name: "Tablet (768px)",
+    styles: { width: "768px", height: "600px" },
+  },
+  lg: {
+    name: "Lg (1024px)",
+    styles: { width: "1024px", height: "800px" },
+  },
+  desktop: {
+    name: "Desktop (1280px)",
+    styles: { width: "1280px", height: "800px" },
+  },
+};
+
 /**
  * SessionList 스켈레톤 스토리
  *
  * 목적: 스켈레톤 UI가 실제 SessionList의 반응형 레이아웃과
  * 일치하는지 breakpoint별로 고정된 너비에서 시각적으로 검증합니다.
  *
- * ⚠️ defaultViewport가 아닌 고정 너비 컨테이너를 사용합니다.
- * → Storybook 창 크기에 관계없이 항상 동일한 레이아웃 상태를 보여줍니다.
- *
- * 검증 포인트:
- * - 헤더: 제목 + 설명 텍스트 + 필터바 (mobile은 세로, md+ 가로 배치)
- * - mobile(375px): 1열 그리드
- * - tablet(768px): 2열 그리드 (md:grid-cols-2)
- * - lg(1024px): ⚠️ 2열 유지 (3열이 되어서는 안 됩니다.)
- * - desktop xl(1280px+): 4열 그리드 (xl:grid-cols-4)
+ * ⚠️ CSS 미디어 쿼리는 뷰포트(iframe) 크기를 따르기 때문에,
+ * customViewports를 등록하고 각 스토리별로 defaultViewport를 결합하여
+ * 실제 뷰포트 크기와 FixedWidthFrame 너비를 일치시킵니다.
  */
 const meta = {
   title: "Features/Session/SessionList",
   component: SessionListSkeleton,
   parameters: {
     layout: "centered",
+    viewport: {
+      viewports: customViewports,
+    },
     docs: {
       description: {
         component:
-          "모집 중 세션 목록 스켈레톤입니다. 고정 너비 컨테이너 기준으로 실제 SessionList와 동일한 반응형 구조를 검증합니다.",
+          "모집 중 세션 목록 스켈레톤입니다. 커스텀 뷰포트 설정과 고정 너비 컨테이너의 결합을 통해 실제 SessionList와 동일한 반응형 구조를 검증합니다.",
       },
     },
   },
@@ -61,6 +77,7 @@ export const SkeletonMobile: Story = {
     </FixedWidthFrame>
   ),
   parameters: {
+    viewport: { defaultViewport: "mobile" },
     docs: {
       description: {
         story:
@@ -81,6 +98,7 @@ export const SkeletonTablet: Story = {
     </FixedWidthFrame>
   ),
   parameters: {
+    viewport: { defaultViewport: "tablet" },
     docs: {
       description: {
         story: "너비 768px 고정 (md): 헤더 가로 배치(제목+설명 / 필터바) + 2열 그리드.",
@@ -101,6 +119,7 @@ export const SkeletonLg: Story = {
     </FixedWidthFrame>
   ),
   parameters: {
+    viewport: { defaultViewport: "lg" },
     docs: {
       description: {
         story:
@@ -121,6 +140,7 @@ export const SkeletonDesktop: Story = {
     </FixedWidthFrame>
   ),
   parameters: {
+    viewport: { defaultViewport: "desktop" },
     docs: {
       description: {
         story:

--- a/src/stories/features/session/SessionList/SessionList.stories.tsx
+++ b/src/stories/features/session/SessionList/SessionList.stories.tsx
@@ -5,25 +5,28 @@ import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 /**
  * SessionList 스켈레톤 스토리
  *
- * 목적: SessionListSkeleton이 실제 SessionList의
- * 반응형 레이아웃과 일치하는지 뷰포트별로 시각적으로 검증합니다.
+ * 목적: 스켈레톤 UI가 실제 SessionList의 반응형 레이아웃과
+ * 일치하는지 breakpoint별로 고정된 너비에서 시각적으로 검증합니다.
+ *
+ * ⚠️ defaultViewport가 아닌 고정 너비 컨테이너를 사용합니다.
+ * → Storybook 창 크기에 관계없이 항상 동일한 레이아웃 상태를 보여줍니다.
  *
  * 검증 포인트:
  * - 헤더: 제목 + 설명 텍스트 + 필터바 (mobile은 세로, md+ 가로 배치)
  * - mobile(375px): 1열 그리드
  * - tablet(768px): 2열 그리드 (md:grid-cols-2)
+ * - lg(1024px): ⚠️ 2열 유지 (3열이 되어서는 안 됩니다.)
  * - desktop xl(1280px+): 4열 그리드 (xl:grid-cols-4)
- * - lg breakpoint(1024px)에서 3열이 되어서는 안 됩니다.
  */
 const meta = {
   title: "Features/Session/SessionList",
   component: SessionListSkeleton,
   parameters: {
-    layout: "fullscreen",
+    layout: "centered",
     docs: {
       description: {
         component:
-          "모집 중 세션 목록 스켈레톤입니다. 뷰포트별로 실제 SessionList와 동일한 반응형 구조를 가져야 합니다.",
+          "모집 중 세션 목록 스켈레톤입니다. 고정 너비 컨테이너 기준으로 실제 SessionList와 동일한 반응형 구조를 검증합니다.",
       },
     },
   },
@@ -32,100 +35,96 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-function StoryWrapper({ children }: { children: React.ReactNode }) {
-  return <div className="dark min-h-screen bg-[#0b0f0e] p-5 md:px-10 xl:px-[54px]">{children}</div>;
+function FixedWidthFrame({ width, children }: { width: number; children: React.ReactNode }) {
+  return (
+    <div
+      className="dark bg-[#0b0f0e] p-5 md:px-10 xl:px-[54px]"
+      style={{ width, overflow: "hidden" }}
+    >
+      {children}
+    </div>
+  );
 }
 
 // ---------------------------------------------------------------------------
-// SessionListSkeleton — 뷰포트별
+// SessionListSkeleton — breakpoint별 고정 너비
 // ---------------------------------------------------------------------------
 
 /**
- * mobile(375px): 헤더가 세로 스택, 카드는 1열
- *
- * 실제 SessionList 확인 포인트:
- * - 헤더: flex-col (제목 → 설명 → 필터바 순 세로 배치)
- * - 카드 그리드: grid-cols-1
+ * mobile: 너비 375px 고정
+ * → md(768px) 미만이므로 1열 그리드 및 헤더 세로 스택이 보여야 합니다.
  */
 export const SkeletonMobile: Story = {
   render: () => (
-    <StoryWrapper>
+    <FixedWidthFrame width={375}>
       <SessionListSkeleton />
-    </StoryWrapper>
+    </FixedWidthFrame>
   ),
   parameters: {
-    viewport: { defaultViewport: "mobile1" },
     docs: {
       description: {
-        story: "mobile(375px): 헤더 세로 스택 + 1열 그리드. 필터바가 헤더 아래 세로로 배치됩니다.",
+        story:
+          "너비 375px 고정 (md 미만): 헤더 세로 스택 + 1열 그리드. 필터바가 헤더 아래 세로로 배치됩니다.",
       },
     },
   },
 };
 
 /**
- * tablet(768px): 헤더가 가로 배치, 카드는 2열
- *
- * 실제 SessionList 확인 포인트:
- * - 헤더: md:flex-row (좌측 제목+설명, 우측 필터바)
- * - 카드 그리드: md:grid-cols-2
+ * tablet: 너비 768px 고정
+ * → md(768px) 이상이므로 2열 그리드 및 헤더 가로 배치가 보여야 합니다.
  */
 export const SkeletonTablet: Story = {
   render: () => (
-    <StoryWrapper>
+    <FixedWidthFrame width={768}>
       <SessionListSkeleton />
-    </StoryWrapper>
+    </FixedWidthFrame>
   ),
   parameters: {
-    viewport: { defaultViewport: "tablet" },
     docs: {
       description: {
-        story:
-          "tablet(768px): 헤더 가로 배치(제목+설명 / 필터바) + 2열 그리드. lg(1024px)에서도 2열이어야 합니다.",
+        story: "너비 768px 고정 (md): 헤더 가로 배치(제목+설명 / 필터바) + 2열 그리드.",
       },
     },
   },
 };
 
 /**
- * lg(1024px): 2열 유지 확인 — 3열이 되어서는 안 됩니다.
- *
- * 이 뷰포트에서 3열이 된다면 실제 SessionList와 불일치입니다.
+ * lg: 너비 1024px 고정
+ * → md 이상, xl 미만이므로 2열 그리드가 유지되어야 합니다.
+ * ⚠️ 3열이 되면 실제 SessionList와 불일치입니다.
  */
 export const SkeletonLg: Story = {
   render: () => (
-    <StoryWrapper>
+    <FixedWidthFrame width={1024}>
       <SessionListSkeleton />
-    </StoryWrapper>
+    </FixedWidthFrame>
   ),
   parameters: {
-    viewport: { defaultViewport: "desktop" },
     docs: {
       description: {
         story:
-          "lg(1024px): ⚠️ 2열 유지 확인 포인트. 3열이 되면 실제 SessionList(lg:grid-cols-3 없음)와 불일치입니다.",
+          "너비 1024px 고정 (lg): ⚠️ 2열 유지 확인 포인트. 3열이 되면 실제 SessionList와 불일치입니다.",
       },
     },
   },
 };
 
 /**
- * desktop xl(1280px+): 헤더 가로 배치, 카드는 4열
- *
- * 실제 SessionList 확인 포인트:
- * - 카드 그리드: xl:grid-cols-4, xl:gap-y-[48px]
+ * desktop: 너비 1280px 고정
+ * → xl(1280px) 이상이므로 4열 그리드가 보여야 합니다.
  */
 export const SkeletonDesktop: Story = {
   render: () => (
-    <StoryWrapper>
+    <FixedWidthFrame width={1280}>
       <SessionListSkeleton />
-    </StoryWrapper>
+    </FixedWidthFrame>
   ),
   parameters: {
-    viewport: { defaultViewport: "desktop" },
     docs: {
       description: {
-        story: "desktop xl(1280px+): 4열 그리드 + xl:gap-y-[48px] 확인.",
+        story:
+          "너비 1280px 고정 (xl): xl:grid-cols-4로 4열 렌더링되며 xl:gap-y-[48px]가 적용됩니다.",
       },
     },
   },

--- a/src/stories/features/session/SessionList/SessionList.stories.tsx
+++ b/src/stories/features/session/SessionList/SessionList.stories.tsx
@@ -29,8 +29,8 @@ const customViewports = {
  * 실제 카드 컴포넌트(SessionCardItem)에 가짜 데이터를 직접 주입한 모집 중 세션 목록의 실제 반응형 레이아웃과,
  * 이에 대응하는 로딩 스켈레톤(SessionListSkeleton)의 반응형 레이아웃 정합성을 1:1 비교 검증합니다.
  *
- * 💡 실제 API 호출, React Query, useSearchParams 등의 비즈니스 의존성을 완전히 제거하기 위해,
- * 스토리북 상에서 가짜 데이터를 직접 props로 주입(Presenter UI)하여 렌더링합니다.
+ * 💡 프로덕션 컴포넌트를 단 한 줄도 수정하지 않기 위해,
+ * 스토리북 파일 내에서 CSS style override 기법을 사용하여 미디어 쿼리(md:, xl:)를 우회 강제합니다.
  */
 const meta = {
   title: "Features/Session/SessionList",
@@ -52,17 +52,90 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+// ---------------------------------------------------------------------------
+// CSS Breakpoint Style Override (프로덕션 컴포넌트 오염 방지용 트릭)
+// ---------------------------------------------------------------------------
+function BreakpointOverrideStyle({ mode }: { mode: "mobile" | "tablet" | "lg" | "desktop" }) {
+  if (mode === "mobile") {
+    return (
+      <style
+        dangerouslySetInnerHTML={{
+          __html: `
+        /* 모바일 강제: 헤더 세로 스택, 1열 그리드 */
+        .breakpoint-mobile .md\\:flex-row {
+          flex-direction: column !important;
+          align-items: flex-start !important;
+          justify-content: flex-start !important;
+        }
+        .breakpoint-mobile .md\\:grid-cols-2 {
+          grid-template-columns: repeat(1, minmax(0, 1fr)) !important;
+        }
+      `,
+        }}
+      />
+    );
+  }
+
+  if (mode === "tablet" || mode === "lg") {
+    return (
+      <style
+        dangerouslySetInnerHTML={{
+          __html: `
+        /* 태블릿 강제: 헤더 가로 배치, 2열 그리드 */
+        .breakpoint-tablet .md\\:flex-row,
+        .breakpoint-lg .md\\:flex-row {
+          flex-direction: row !important;
+          align-items: flex-start !important;
+          justify-content: space-between !important;
+        }
+        .breakpoint-tablet .md\\:grid-cols-2,
+        .breakpoint-lg .md\\:grid-cols-2 {
+          grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+        }
+        .breakpoint-tablet .xl\\:grid-cols-4,
+        .breakpoint-lg .xl\\:grid-cols-4 {
+          grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+        }
+      `,
+        }}
+      />
+    );
+  }
+
+  // desktop
+  return (
+    <style
+      dangerouslySetInnerHTML={{
+        __html: `
+      /* 데스크탑 강제: 헤더 가로 배치, 4열 그리드 */
+      .breakpoint-desktop .md\\:flex-row {
+        flex-direction: row !important;
+        align-items: flex-start !important;
+        justify-content: space-between !important;
+      }
+      .breakpoint-desktop .xl\\:grid-cols-4 {
+        grid-template-columns: repeat(4, minmax(0, 1fr)) !important;
+      }
+    `,
+      }}
+    />
+  );
+}
+
 function FixedWidthFrame({
   width,
   title,
+  mode,
   children,
 }: {
   width: number;
   title: string;
+  mode: "mobile" | "tablet" | "lg" | "desktop";
   children: React.ReactNode;
 }) {
   return (
-    <div className="flex flex-col gap-2">
+    <div className={`flex flex-col gap-2 breakpoint-${mode}`}>
+      <BreakpointOverrideStyle mode={mode} />
       <div className="text-text-muted px-2 text-xs font-bold">{title}</div>
       <div
         className="dark border-border-subtle rounded-md border bg-[#0b0f0e] p-5 md:px-10 xl:px-[54px]"
@@ -102,6 +175,7 @@ export const CompareMobile: Story = {
     <div className="flex flex-col gap-8">
       <FixedWidthFrame
         width={375}
+        mode="mobile"
         title="[실제 컴포넌트 가짜 데이터 주입] SessionList - Mobile (1열 + 세로 헤더)"
       >
         <section className="gap-lg flex flex-col">
@@ -111,7 +185,6 @@ export const CompareMobile: Story = {
               <p className="text-text-muted text-[13px]">
                 현재 모집 중인 세션에 바로 참여해 보세요
               </p>
-              {/* 모바일 가짜 필터바 버튼 예시 */}
               <div className="flex gap-2 overflow-x-auto pb-1">
                 <button className="bg-surface-subtle text-text-secondary rounded-md px-3 py-1.5 text-xs whitespace-nowrap">
                   정렬
@@ -135,9 +208,10 @@ export const CompareMobile: Story = {
 
       <FixedWidthFrame
         width={375}
+        mode="mobile"
         title="[스켈레톤] SessionListSkeleton - Mobile (1열 + 세로 헤더)"
       >
-        <SessionListSkeleton forceBreakpoint="mobile" />
+        <SessionListSkeleton />
       </FixedWidthFrame>
     </div>
   ),
@@ -154,6 +228,7 @@ export const CompareTablet: Story = {
     <div className="flex flex-col gap-8">
       <FixedWidthFrame
         width={768}
+        mode="tablet"
         title="[실제 컴포넌트 가짜 데이터 주입] SessionList - Tablet (2열 + 가로 헤더)"
       >
         <section className="gap-lg flex flex-col">
@@ -184,9 +259,10 @@ export const CompareTablet: Story = {
 
       <FixedWidthFrame
         width={768}
+        mode="tablet"
         title="[스켈레톤] SessionListSkeleton - Tablet (2열 + 가로 헤더)"
       >
-        <SessionListSkeleton forceBreakpoint="tablet" />
+        <SessionListSkeleton />
       </FixedWidthFrame>
     </div>
   ),
@@ -203,6 +279,7 @@ export const CompareLg: Story = {
     <div className="flex flex-col gap-8">
       <FixedWidthFrame
         width={1024}
+        mode="lg"
         title="[실제 컴포넌트 가짜 데이터 주입] SessionList - Lg (⚠️ 2열 유지 확인)"
       >
         <section className="gap-lg flex flex-col">
@@ -231,8 +308,12 @@ export const CompareLg: Story = {
         </section>
       </FixedWidthFrame>
 
-      <FixedWidthFrame width={1024} title="[스켈레톤] SessionListSkeleton - Lg (⚠️ 2열 유지 확인)">
-        <SessionListSkeleton forceBreakpoint="lg" />
+      <FixedWidthFrame
+        width={1024}
+        mode="lg"
+        title="[스켈레톤] SessionListSkeleton - Lg (⚠️ 2열 유지 확인)"
+      >
+        <SessionListSkeleton />
       </FixedWidthFrame>
     </div>
   ),
@@ -249,6 +330,7 @@ export const CompareDesktop: Story = {
     <div className="flex flex-col gap-8">
       <FixedWidthFrame
         width={1440}
+        mode="desktop"
         title="[실제 컴포넌트 가짜 데이터 주입] SessionList - Desktop (4열 그리드)"
       >
         <section className="gap-lg flex flex-col">
@@ -277,8 +359,12 @@ export const CompareDesktop: Story = {
         </section>
       </FixedWidthFrame>
 
-      <FixedWidthFrame width={1440} title="[스켈레톤] SessionListSkeleton - Desktop (4열 그리드)">
-        <SessionListSkeleton forceBreakpoint="desktop" />
+      <FixedWidthFrame
+        width={1440}
+        mode="desktop"
+        title="[스켈레톤] SessionListSkeleton - Desktop (4열 그리드)"
+      >
+        <SessionListSkeleton />
       </FixedWidthFrame>
     </div>
   ),

--- a/src/stories/features/session/SessionList/SessionList.stories.tsx
+++ b/src/stories/features/session/SessionList/SessionList.stories.tsx
@@ -138,7 +138,7 @@ function FixedWidthFrame({
       <BreakpointOverrideStyle mode={mode} />
       <div className="text-text-muted px-2 text-xs font-bold">{title}</div>
       <div
-        className="dark border-border-subtle rounded-md border bg-[#0b0f0e] p-5 md:px-10 xl:px-[54px]"
+        className="dark border-border-subtle bg-surface-default rounded-md border p-5 md:px-10 xl:px-[54px]"
         style={{ width, overflow: "hidden" }}
       >
         {children}
@@ -167,6 +167,38 @@ const mockOnShare = (id: number) => {
   alert(`Share Session Link: ${id}`);
 };
 
+function FilterButton({ children }: { children: React.ReactNode }) {
+  return (
+    <button className="bg-surface-subtle text-text-secondary rounded-md px-3 py-1.5 text-xs whitespace-nowrap">
+      {children}
+    </button>
+  );
+}
+
+function SessionListHeader({ mode }: { mode: "mobile" | "tablet" | "lg" | "desktop" }) {
+  const isMobile = mode === "mobile";
+
+  return (
+    <div className="flex flex-col gap-[10px]">
+      <h2 className="text-text-primary text-lg font-bold md:text-2xl">지금 모집 중인 세션</h2>
+      <div
+        className={
+          isMobile ? "flex flex-col gap-3" : "flex flex-row items-start justify-between gap-5"
+        }
+      >
+        <p className={isMobile ? "text-text-muted text-[13px]" : "text-text-muted text-base"}>
+          현재 모집 중인 세션에 바로 참여해 보세요
+        </p>
+        <div className={isMobile ? "flex gap-2 overflow-x-auto pb-1" : "flex gap-2"}>
+          <FilterButton>정렬</FilterButton>
+          <FilterButton>날짜</FilterButton>
+          <FilterButton>시간</FilterButton>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // 1. Mobile (375px) — 1열 그리드 및 세로 헤더 비교
 // ---------------------------------------------------------------------------
@@ -179,25 +211,7 @@ export const CompareMobile: Story = {
         title="[실제 컴포넌트 가짜 데이터 주입] SessionList - Mobile (1열 + 세로 헤더)"
       >
         <section className="gap-lg flex flex-col">
-          <div className="flex flex-col gap-[10px]">
-            <h2 className="text-text-primary text-lg font-bold">지금 모집 중인 세션</h2>
-            <div className="flex flex-col gap-3">
-              <p className="text-text-muted text-[13px]">
-                현재 모집 중인 세션에 바로 참여해 보세요
-              </p>
-              <div className="flex gap-2 overflow-x-auto pb-1">
-                <button className="bg-surface-subtle text-text-secondary rounded-md px-3 py-1.5 text-xs whitespace-nowrap">
-                  정렬
-                </button>
-                <button className="bg-surface-subtle text-text-secondary rounded-md px-3 py-1.5 text-xs whitespace-nowrap">
-                  날짜
-                </button>
-                <button className="bg-surface-subtle text-text-secondary rounded-md px-3 py-1.5 text-xs whitespace-nowrap">
-                  시간
-                </button>
-              </div>
-            </div>
-          </div>
+          <SessionListHeader mode="mobile" />
           <div className="grid grid-cols-1 gap-6">
             {mockSessions.map((session) => (
               <SessionCardItem key={session.sessionId} session={session} onShare={mockOnShare} />
@@ -232,23 +246,7 @@ export const CompareTablet: Story = {
         title="[실제 컴포넌트 가짜 데이터 주입] SessionList - Tablet (2열 + 가로 헤더)"
       >
         <section className="gap-lg flex flex-col">
-          <div className="flex flex-col gap-[10px]">
-            <h2 className="text-text-primary text-lg font-bold md:text-2xl">지금 모집 중인 세션</h2>
-            <div className="flex flex-row items-start justify-between gap-5">
-              <p className="text-text-muted text-base">현재 모집 중인 세션에 바로 참여해 보세요</p>
-              <div className="flex gap-2">
-                <button className="bg-surface-subtle text-text-secondary rounded-md px-3 py-1.5 text-xs">
-                  정렬
-                </button>
-                <button className="bg-surface-subtle text-text-secondary rounded-md px-3 py-1.5 text-xs">
-                  날짜
-                </button>
-                <button className="bg-surface-subtle text-text-secondary rounded-md px-3 py-1.5 text-xs">
-                  시간
-                </button>
-              </div>
-            </div>
-          </div>
+          <SessionListHeader mode="tablet" />
           <div className="grid grid-cols-2 gap-6">
             {mockSessions.map((session) => (
               <SessionCardItem key={session.sessionId} session={session} onShare={mockOnShare} />
@@ -283,23 +281,7 @@ export const CompareLg: Story = {
         title="[실제 컴포넌트 가짜 데이터 주입] SessionList - Lg (⚠️ 2열 유지 확인)"
       >
         <section className="gap-lg flex flex-col">
-          <div className="flex flex-col gap-[10px]">
-            <h2 className="text-text-primary text-lg font-bold md:text-2xl">지금 모집 중인 세션</h2>
-            <div className="flex flex-row items-start justify-between gap-5">
-              <p className="text-text-muted text-base">현재 모집 중인 세션에 바로 참여해 보세요</p>
-              <div className="flex gap-2">
-                <button className="bg-surface-subtle text-text-secondary rounded-md px-3 py-1.5 text-xs">
-                  정렬
-                </button>
-                <button className="bg-surface-subtle text-text-secondary rounded-md px-3 py-1.5 text-xs">
-                  날짜
-                </button>
-                <button className="bg-surface-subtle text-text-secondary rounded-md px-3 py-1.5 text-xs">
-                  시간
-                </button>
-              </div>
-            </div>
-          </div>
+          <SessionListHeader mode="lg" />
           <div className="grid grid-cols-2 gap-6">
             {mockSessions.map((session) => (
               <SessionCardItem key={session.sessionId} session={session} onShare={mockOnShare} />
@@ -334,23 +316,7 @@ export const CompareDesktop: Story = {
         title="[실제 컴포넌트 가짜 데이터 주입] SessionList - Desktop (4열 그리드)"
       >
         <section className="gap-lg flex flex-col">
-          <div className="flex flex-col gap-[10px]">
-            <h2 className="text-text-primary text-lg font-bold md:text-2xl">지금 모집 중인 세션</h2>
-            <div className="flex flex-row items-start justify-between gap-5">
-              <p className="text-text-muted text-base">현재 모집 중인 세션에 바로 참여해 보세요</p>
-              <div className="flex gap-2">
-                <button className="bg-surface-subtle text-text-secondary rounded-md px-3 py-1.5 text-xs">
-                  정렬
-                </button>
-                <button className="bg-surface-subtle text-text-secondary rounded-md px-3 py-1.5 text-xs">
-                  날짜
-                </button>
-                <button className="bg-surface-subtle text-text-secondary rounded-md px-3 py-1.5 text-xs">
-                  시간
-                </button>
-              </div>
-            </div>
-          </div>
+          <SessionListHeader mode="desktop" />
           <div className="grid grid-cols-4 gap-6 gap-y-[48px]">
             {mockSessions.map((session) => (
               <SessionCardItem key={session.sessionId} session={session} onShare={mockOnShare} />


### PR DESCRIPTION
## 작업 내용

홈 화면(Session) 로딩 스켈레톤의 레이아웃을 실제 컴포넌트의 반응형 구조와 일치하도록 수정하고, 1:1 비교 검증을 위한 스토리북 스토리를 추가했습니다.

### 1. 스켈레톤 컴포넌트 반응형 수정 (실제 UI 구조와 일치)
* **RecommendedGridSkeleton**
  * mobile: 1열 -> 가로 스크롤 구조(`flex + overflow-x-auto` + 우측 fade overlay)로 개정
  * tablet/desktop: `md:grid-cols-2`, `xl:grid-cols-4` 적용 및 미사용 `lg:grid-cols-3` 제거
* **SessionListSkeleton**
  * 헤더: 단순 버튼 1개 -> 실제 헤더 구조(`제목 + 설명 + 필터바`) 모사
  * 그리드: `sm:grid-cols-2`, `lg:grid-cols-3` -> `md:grid-cols-2`, `xl:grid-cols-4` 적용

### 2. 가짜 데이터 기반 1:1 비교 스토리북 추가
* **대상 파일**: `RecommendedSection.stories.tsx`, `SessionList.stories.tsx`
* **구조**: 실제 카드 컴포넌트(`Card`, `SessionCardItem`)에 Mock 데이터를 직접 주입한 실데이터 뷰와 스켈레톤 뷰를 뷰포트별로 병렬 배치하여 1:1 비교 대조 검증을 수행합니다.
* **CSS Style Override 기법 적용**: 프로덕션 컴포넌트를 오염시키지 않기 위해, 스토리북 파일 내부에서만 부모 선택자 스타일(`<style>`)을 덮어써서 물리 해상도와 무관하게 뷰포트 레이아웃(mobile, tablet, lg, desktop)을 안정적으로 강제 시뮬레이션하도록 구현했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **스타일**
  * 추천 섹션 로딩 스켈레톤을 모바일(가로 스크롤 + 우측 페이드)과 태블릿/데스크톱(그리드: md 2열 → xl 4열)로 분기하여 레이아웃 개선
  * 세션 목록 로딩 스켈레톤 주석·레이아웃과 그리드 반응점을 md/xl 기준으로 조정

* **테스트**
  * 추천 섹션 및 세션 목록의 모바일/태블릿/데스크톱 뷰 비교를 위한 Storybook 스토리 추가

* **기타**
  * 추천 그리드의 카드 크기 전달 로직을 뷰포트별로 조정

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dnd-side-project/dnd-14th-9-frontend/pull/269?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 연관 이슈

close #268
