### PR TITLE
fix: 홈 세션 필터 모바일 패널 표시 오류 수정

### DIFF
--- a/src/features/session/components/SessionList/SessionListFilterBar.tsx
+++ b/src/features/session/components/SessionList/SessionListFilterBar.tsx
@@ -29,12 +29,12 @@ interface SessionListFilterBarProps {
 }
 
 type OpenFilterKey = "date" | "timeSlot" | "duration" | "participants" | "sort" | null;
-type SortFilterLayout = "compact" | "desktop";
+type SortFilterLayout = "nonDesktop" | "desktop";
 
 // 모바일/태블릿에서 overflow-x-auto로 인해 필터 팝업이 잘리는 현상을 방지하기 위한 여백 확보 클래스입니다.
 // 가장 높이가 높은 필터 패널(약 380px)을 기준으로 패딩을 주고, 음수 마진으로 레이아웃 흐름을 유지합니다.
 const FILTER_PANEL_SPACE_CLASS = "-mb-[380px] pb-[380px] xl:mb-0 xl:pb-0";
-// 필터바는 xl 미만에서 모바일/태블릿 UI가 동일하므로 compact(<xl)와 desktop(xl 이상)만 구분합니다.
+// 필터바는 xl 미만에서 모바일/태블릿 UI가 동일하므로 nonDesktop(<xl)와 desktop(xl 이상)만 구분합니다.
 const DESKTOP_SORT_MEDIA_QUERY = `(min-width: ${BREAKPOINT_XL_PX}px)`;
 
 export function SessionListFilterBar({
@@ -97,7 +97,7 @@ export function SessionListFilterBar({
 
     if (
       (layout === "desktop" && !isDesktopViewport) ||
-      (layout === "compact" && isDesktopViewport)
+      (layout === "nonDesktop" && isDesktopViewport)
     ) {
       return;
     }
@@ -166,9 +166,9 @@ export function SessionListFilterBar({
           </div>
 
           <SortFilter
-            isOpen={openFilter === "sort" && openSortLayout === "compact"}
+            isOpen={openFilter === "sort" && openSortLayout === "nonDesktop"}
             value={values.sort}
-            onOpenChange={(isOpen) => handleSortOpenChange(isOpen, "compact")}
+            onOpenChange={(isOpen) => handleSortOpenChange(isOpen, "nonDesktop")}
             onSelect={onSetSort}
             className="ml-auto shrink-0 xl:hidden"
           />

--- a/src/features/session/components/SessionList/SessionListFilterBar.tsx
+++ b/src/features/session/components/SessionList/SessionListFilterBar.tsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 import { Button } from "@/components/Button/Button";
 import type { DateRange } from "@/components/DatePicker/DatePicker.types";
 import { ArrowRotateRightIcon } from "@/components/Icon/ArrowRotateRightIcon";
-import { BREAKPOINT_XL_PX } from "@/lib/constants/breakpoints";
+import { useViewportLayout } from "@/hooks/useViewportLayout";
 import { cn } from "@/lib/utils/utils";
 
 import { DateRangeFilter } from "./DateRangeFilter";
@@ -29,13 +29,10 @@ interface SessionListFilterBarProps {
 }
 
 type OpenFilterKey = "date" | "timeSlot" | "duration" | "participants" | "sort" | null;
-type SortFilterLayout = "nonDesktop" | "desktop";
 
 // 모바일/태블릿에서 overflow-x-auto로 인해 필터 팝업이 잘리는 현상을 방지하기 위한 여백 확보 클래스입니다.
 // 가장 높이가 높은 필터 패널(약 380px)을 기준으로 패딩을 주고, 음수 마진으로 레이아웃 흐름을 유지합니다.
 const FILTER_PANEL_SPACE_CLASS = "-mb-[380px] pb-[380px] xl:mb-0 xl:pb-0";
-// 필터바는 xl 미만에서 모바일/태블릿 UI가 동일하므로 nonDesktop(<xl)와 desktop(xl 이상)만 구분합니다.
-const DESKTOP_SORT_MEDIA_QUERY = `(min-width: ${BREAKPOINT_XL_PX}px)`;
 
 export function SessionListFilterBar({
   values,
@@ -47,7 +44,8 @@ export function SessionListFilterBar({
   onResetFilters,
 }: SessionListFilterBarProps) {
   const [openFilter, setOpenFilter] = useState<OpenFilterKey>(null);
-  const [openSortLayout, setOpenSortLayout] = useState<SortFilterLayout | null>(null);
+  const { layout } = useViewportLayout();
+  const isDesktop = layout === "desktop";
   const isDatePickerOpen = openFilter === "date";
   const isTimeSlotOpen = openFilter === "timeSlot";
   const isDurationOpen = openFilter === "duration";
@@ -73,36 +71,22 @@ export function SessionListFilterBar({
   };
 
   const handleDateOpenChange = (isOpen: boolean) => {
-    setOpenSortLayout(null);
     setOpenFilter(isOpen ? "date" : null);
   };
 
   const handleTimeSlotOpenChange = (isOpen: boolean) => {
-    setOpenSortLayout(null);
     setOpenFilter(isOpen ? "timeSlot" : null);
   };
 
   const handleDurationOpenChange = (isOpen: boolean) => {
-    setOpenSortLayout(null);
     setOpenFilter(isOpen ? "duration" : null);
   };
 
   const handleParticipantsOpenChange = (isOpen: boolean) => {
-    setOpenSortLayout(null);
     setOpenFilter(isOpen ? "participants" : null);
   };
 
-  const handleSortOpenChange = (isOpen: boolean, layout: SortFilterLayout) => {
-    const isDesktopViewport = window.matchMedia?.(DESKTOP_SORT_MEDIA_QUERY).matches ?? false;
-
-    if (
-      (layout === "desktop" && !isDesktopViewport) ||
-      (layout === "nonDesktop" && isDesktopViewport)
-    ) {
-      return;
-    }
-
-    setOpenSortLayout(isOpen ? layout : null);
+  const handleSortOpenChange = (isOpen: boolean) => {
     setOpenFilter(isOpen ? "sort" : null);
   };
 
@@ -165,22 +149,26 @@ export function SessionListFilterBar({
             />
           </div>
 
-          <SortFilter
-            isOpen={openFilter === "sort" && openSortLayout === "nonDesktop"}
-            value={values.sort}
-            onOpenChange={(isOpen) => handleSortOpenChange(isOpen, "nonDesktop")}
-            onSelect={onSetSort}
-            className="ml-auto shrink-0 xl:hidden"
-          />
+          {!isDesktop && (
+            <SortFilter
+              isOpen={openFilter === "sort"}
+              value={values.sort}
+              onOpenChange={handleSortOpenChange}
+              onSelect={onSetSort}
+              className="ml-auto shrink-0"
+            />
+          )}
         </div>
 
-        <SortFilter
-          isOpen={openFilter === "sort" && openSortLayout === "desktop"}
-          value={values.sort}
-          onOpenChange={(isOpen) => handleSortOpenChange(isOpen, "desktop")}
-          onSelect={onSetSort}
-          className="hidden shrink-0 xl:flex"
-        />
+        {isDesktop && (
+          <SortFilter
+            isOpen={openFilter === "sort"}
+            value={values.sort}
+            onOpenChange={handleSortOpenChange}
+            onSelect={onSetSort}
+            className="shrink-0"
+          />
+        )}
       </div>
     </>
   );

--- a/src/features/session/components/SessionList/SessionListFilterBar.tsx
+++ b/src/features/session/components/SessionList/SessionListFilterBar.tsx
@@ -29,11 +29,12 @@ interface SessionListFilterBarProps {
 }
 
 type OpenFilterKey = "date" | "timeSlot" | "duration" | "participants" | "sort" | null;
-type SortFilterLayout = "mobile" | "desktop";
+type SortFilterLayout = "compact" | "desktop";
 
 // 모바일/태블릿에서 overflow-x-auto로 인해 필터 팝업이 잘리는 현상을 방지하기 위한 여백 확보 클래스입니다.
 // 가장 높이가 높은 필터 패널(약 380px)을 기준으로 패딩을 주고, 음수 마진으로 레이아웃 흐름을 유지합니다.
 const FILTER_PANEL_SPACE_CLASS = "-mb-[380px] pb-[380px] xl:mb-0 xl:pb-0";
+// 필터바는 xl 미만에서 모바일/태블릿 UI가 동일하므로 compact(<xl)와 desktop(xl 이상)만 구분합니다.
 const DESKTOP_SORT_MEDIA_QUERY = `(min-width: ${BREAKPOINT_XL_PX}px)`;
 
 export function SessionListFilterBar({
@@ -96,7 +97,7 @@ export function SessionListFilterBar({
 
     if (
       (layout === "desktop" && !isDesktopViewport) ||
-      (layout === "mobile" && isDesktopViewport)
+      (layout === "compact" && isDesktopViewport)
     ) {
       return;
     }
@@ -165,9 +166,9 @@ export function SessionListFilterBar({
           </div>
 
           <SortFilter
-            isOpen={openFilter === "sort" && openSortLayout === "mobile"}
+            isOpen={openFilter === "sort" && openSortLayout === "compact"}
             value={values.sort}
-            onOpenChange={(isOpen) => handleSortOpenChange(isOpen, "mobile")}
+            onOpenChange={(isOpen) => handleSortOpenChange(isOpen, "compact")}
             onSelect={onSetSort}
             className="ml-auto shrink-0 xl:hidden"
           />

--- a/src/features/session/components/SessionList/SessionListFilterBar.tsx
+++ b/src/features/session/components/SessionList/SessionListFilterBar.tsx
@@ -5,6 +5,8 @@ import { useState } from "react";
 import { Button } from "@/components/Button/Button";
 import type { DateRange } from "@/components/DatePicker/DatePicker.types";
 import { ArrowRotateRightIcon } from "@/components/Icon/ArrowRotateRightIcon";
+import { useViewportLayout } from "@/hooks/useViewportLayout";
+import { cn } from "@/lib/utils/utils";
 
 import { DateRangeFilter } from "./DateRangeFilter";
 import { DurationFilter } from "./DurationFilter";
@@ -28,6 +30,8 @@ interface SessionListFilterBarProps {
 
 type OpenFilterKey = "date" | "timeSlot" | "duration" | "participants" | "sort" | null;
 
+const FILTER_PANEL_SPACE_CLASS = "-mb-[380px] pb-[380px] xl:mb-0 xl:pb-0";
+
 export function SessionListFilterBar({
   values,
   onSetDateRange,
@@ -38,11 +42,14 @@ export function SessionListFilterBar({
   onResetFilters,
 }: SessionListFilterBarProps) {
   const [openFilter, setOpenFilter] = useState<OpenFilterKey>(null);
+  const { layout } = useViewportLayout();
   const isDatePickerOpen = openFilter === "date";
   const isTimeSlotOpen = openFilter === "timeSlot";
   const isDurationOpen = openFilter === "duration";
   const isParticipantsOpen = openFilter === "participants";
   const isSortOpen = openFilter === "sort";
+  const shouldReserveFilterPanelSpace = Boolean(openFilter);
+  const isDesktopLayout = layout === "desktop";
 
   const selectedDateRange: DateRange = {
     startDate: parseDateParam(values.startDate),
@@ -89,7 +96,12 @@ export function SessionListFilterBar({
       )}
       <div className="gap-md relative z-20 flex flex-col xl:items-end">
         {/* 좁은 화면에서 필터 조작 공간을 확보하기 위해 정렬까지 같은 스크롤 영역에 둡니다. */}
-        <div className="scrollbar-hide flex w-full items-center gap-[16px] overflow-x-auto xl:w-auto xl:overflow-visible">
+        <div
+          className={cn(
+            "scrollbar-hide flex w-full items-center gap-[16px] overflow-x-auto xl:w-auto xl:overflow-visible",
+            shouldReserveFilterPanelSpace && FILTER_PANEL_SPACE_CLASS
+          )}
+        >
           <DateRangeFilter
             isOpen={isDatePickerOpen}
             label={dateFilterLabel}
@@ -136,24 +148,26 @@ export function SessionListFilterBar({
             />
           </div>
 
-          {/* 좁은 화면에서 정렬 필터가 스크롤 끝으로 밀리지 않도록 남는 공간을 먼저 채웁니다. */}
+          {!isDesktopLayout && (
+            <SortFilter
+              isOpen={isSortOpen}
+              value={values.sort}
+              onOpenChange={handleSortOpenChange}
+              onSelect={onSetSort}
+              className="ml-auto shrink-0"
+            />
+          )}
+        </div>
+
+        {isDesktopLayout && (
           <SortFilter
             isOpen={isSortOpen}
             value={values.sort}
             onOpenChange={handleSortOpenChange}
             onSelect={onSetSort}
-            className="ml-auto shrink-0 xl:hidden"
+            className="shrink-0"
           />
-        </div>
-
-        {/* 넓은 화면에서는 필터 줄 폭을 안정적으로 유지하기 위해 정렬을 별도 행으로 분리합니다. */}
-        <SortFilter
-          isOpen={isSortOpen}
-          value={values.sort}
-          onOpenChange={handleSortOpenChange}
-          onSelect={onSetSort}
-          className="hidden shrink-0 xl:flex"
-        />
+        )}
       </div>
     </>
   );

--- a/src/features/session/components/SessionList/SessionListFilterBar.tsx
+++ b/src/features/session/components/SessionList/SessionListFilterBar.tsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 import { Button } from "@/components/Button/Button";
 import type { DateRange } from "@/components/DatePicker/DatePicker.types";
 import { ArrowRotateRightIcon } from "@/components/Icon/ArrowRotateRightIcon";
-import { useViewportLayout } from "@/hooks/useViewportLayout";
+import { BREAKPOINT_XL_PX } from "@/lib/constants/breakpoints";
 import { cn } from "@/lib/utils/utils";
 
 import { DateRangeFilter } from "./DateRangeFilter";
@@ -29,8 +29,12 @@ interface SessionListFilterBarProps {
 }
 
 type OpenFilterKey = "date" | "timeSlot" | "duration" | "participants" | "sort" | null;
+type SortFilterLayout = "mobile" | "desktop";
 
+// 모바일/태블릿에서 overflow-x-auto로 인해 필터 팝업이 잘리는 현상을 방지하기 위한 여백 확보 클래스입니다.
+// 가장 높이가 높은 필터 패널(약 380px)을 기준으로 패딩을 주고, 음수 마진으로 레이아웃 흐름을 유지합니다.
 const FILTER_PANEL_SPACE_CLASS = "-mb-[380px] pb-[380px] xl:mb-0 xl:pb-0";
+const DESKTOP_SORT_MEDIA_QUERY = `(min-width: ${BREAKPOINT_XL_PX}px)`;
 
 export function SessionListFilterBar({
   values,
@@ -42,14 +46,12 @@ export function SessionListFilterBar({
   onResetFilters,
 }: SessionListFilterBarProps) {
   const [openFilter, setOpenFilter] = useState<OpenFilterKey>(null);
-  const { layout } = useViewportLayout();
+  const [openSortLayout, setOpenSortLayout] = useState<SortFilterLayout | null>(null);
   const isDatePickerOpen = openFilter === "date";
   const isTimeSlotOpen = openFilter === "timeSlot";
   const isDurationOpen = openFilter === "duration";
   const isParticipantsOpen = openFilter === "participants";
-  const isSortOpen = openFilter === "sort";
   const shouldReserveFilterPanelSpace = Boolean(openFilter);
-  const isDesktopLayout = layout === "desktop";
 
   const selectedDateRange: DateRange = {
     startDate: parseDateParam(values.startDate),
@@ -70,22 +72,36 @@ export function SessionListFilterBar({
   };
 
   const handleDateOpenChange = (isOpen: boolean) => {
+    setOpenSortLayout(null);
     setOpenFilter(isOpen ? "date" : null);
   };
 
   const handleTimeSlotOpenChange = (isOpen: boolean) => {
+    setOpenSortLayout(null);
     setOpenFilter(isOpen ? "timeSlot" : null);
   };
 
   const handleDurationOpenChange = (isOpen: boolean) => {
+    setOpenSortLayout(null);
     setOpenFilter(isOpen ? "duration" : null);
   };
 
   const handleParticipantsOpenChange = (isOpen: boolean) => {
+    setOpenSortLayout(null);
     setOpenFilter(isOpen ? "participants" : null);
   };
 
-  const handleSortOpenChange = (isOpen: boolean) => {
+  const handleSortOpenChange = (isOpen: boolean, layout: SortFilterLayout) => {
+    const isDesktopViewport = window.matchMedia?.(DESKTOP_SORT_MEDIA_QUERY).matches ?? false;
+
+    if (
+      (layout === "desktop" && !isDesktopViewport) ||
+      (layout === "mobile" && isDesktopViewport)
+    ) {
+      return;
+    }
+
+    setOpenSortLayout(isOpen ? layout : null);
     setOpenFilter(isOpen ? "sort" : null);
   };
 
@@ -148,26 +164,22 @@ export function SessionListFilterBar({
             />
           </div>
 
-          {!isDesktopLayout && (
-            <SortFilter
-              isOpen={isSortOpen}
-              value={values.sort}
-              onOpenChange={handleSortOpenChange}
-              onSelect={onSetSort}
-              className="ml-auto shrink-0"
-            />
-          )}
+          <SortFilter
+            isOpen={openFilter === "sort" && openSortLayout === "mobile"}
+            value={values.sort}
+            onOpenChange={(isOpen) => handleSortOpenChange(isOpen, "mobile")}
+            onSelect={onSetSort}
+            className="ml-auto shrink-0 xl:hidden"
+          />
         </div>
 
-        {isDesktopLayout && (
-          <SortFilter
-            isOpen={isSortOpen}
-            value={values.sort}
-            onOpenChange={handleSortOpenChange}
-            onSelect={onSetSort}
-            className="shrink-0"
-          />
-        )}
+        <SortFilter
+          isOpen={openFilter === "sort" && openSortLayout === "desktop"}
+          value={values.sort}
+          onOpenChange={(isOpen) => handleSortOpenChange(isOpen, "desktop")}
+          onSelect={onSetSort}
+          className="hidden shrink-0 xl:flex"
+        />
       </div>
     </>
   );

--- a/src/features/session/components/SessionList/SessionListFilterBar.tsx
+++ b/src/features/session/components/SessionList/SessionListFilterBar.tsx
@@ -44,8 +44,9 @@ export function SessionListFilterBar({
   onResetFilters,
 }: SessionListFilterBarProps) {
   const [openFilter, setOpenFilter] = useState<OpenFilterKey>(null);
-  const { layout } = useViewportLayout();
-  const isDesktop = layout === "desktop";
+  const { layout, isResolved } = useViewportLayout();
+  // isResolved되기 전(SSR)에는 훅이 "desktop"을 반환하므로 desktop SortFilter가 기본 렌더링됩니다.
+  const isDesktop = !isResolved || layout === "desktop";
   const isDatePickerOpen = openFilter === "date";
   const isTimeSlotOpen = openFilter === "timeSlot";
   const isDurationOpen = openFilter === "duration";
@@ -86,6 +87,7 @@ export function SessionListFilterBar({
     setOpenFilter(isOpen ? "participants" : null);
   };
 
+  // viewport 가드 불필요 — 한 번에 하나의 SortFilter 인스턴스만 마운트됩니다.
   const handleSortOpenChange = (isOpen: boolean) => {
     setOpenFilter(isOpen ? "sort" : null);
   };

--- a/src/test/components/SessionListFilterBar.test.tsx
+++ b/src/test/components/SessionListFilterBar.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen } from "@testing-library/react";
 
 import { SessionListFilterBar } from "@/features/session/components/SessionList/SessionListFilterBar";
 import type { SessionListFilterValues } from "@/features/session/hooks/useSessionListFilters";
+import { BREAKPOINT_XL_PX } from "@/lib/constants/breakpoints";
 
 const defaultValues: SessionListFilterValues = {
   startDate: null,
@@ -38,6 +39,19 @@ function getScrollableFilterRow(container: HTMLElement) {
   return row;
 }
 
+function mockDesktopViewport() {
+  window.matchMedia = jest.fn().mockImplementation((query: string) => ({
+    matches: query === `(min-width: ${BREAKPOINT_XL_PX}px)`,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  }));
+}
+
 describe("SessionListFilterBar", () => {
   it("reserves mobile/tablet panel space when a non-sort filter opens", () => {
     const { container } = renderFilterBar();
@@ -58,9 +72,9 @@ describe("SessionListFilterBar", () => {
   it("reserves mobile/tablet panel space for the sort dropdown", () => {
     const { container } = renderFilterBar();
 
-    fireEvent.click(screen.getByRole("button", { name: /인기순/ }));
+    fireEvent.click(screen.getAllByRole("button", { name: /인기순/ })[0]);
 
-    expect(screen.getAllByRole("dialog", { name: "정렬 선택" }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("dialog", { name: "정렬 선택" })).toHaveLength(1);
     expect(getScrollableFilterRow(container)).toHaveClass("pb-[380px]");
     expect(getScrollableFilterRow(container)).toHaveClass("-mb-[380px]");
     expect(getScrollableFilterRow(container)).toHaveClass("xl:pb-0");
@@ -69,20 +83,29 @@ describe("SessionListFilterBar", () => {
 
   it("closes the sort dropdown when the visible sort trigger is clicked again", () => {
     renderFilterBar();
-    const sortTrigger = screen.getByRole("button", { name: /인기순/ });
+    const sortTrigger = screen.getAllByRole("button", { name: /인기순/ })[0];
 
     fireEvent.click(sortTrigger);
-    expect(screen.getAllByRole("dialog", { name: "정렬 선택" }).length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("dialog", { name: "정렬 선택" })).toHaveLength(1);
 
     fireEvent.click(sortTrigger);
 
     expect(screen.queryByRole("dialog", { name: "정렬 선택" })).not.toBeInTheDocument();
   });
 
-  it("renders a single sort filter trigger so hidden duplicates cannot reopen the dropdown", () => {
+  it("renders sort filter triggers for both mobile and desktop layouts", () => {
     renderFilterBar();
 
-    expect(screen.getAllByRole("button", { name: /인기순/ })).toHaveLength(1);
+    expect(screen.getAllByRole("button", { name: /인기순/ })).toHaveLength(2);
+  });
+
+  it("opens only the desktop sort dropdown on desktop viewport", () => {
+    mockDesktopViewport();
+    renderFilterBar();
+
+    fireEvent.click(screen.getAllByRole("button", { name: /인기순/ })[1]);
+
+    expect(screen.getAllByRole("dialog", { name: "정렬 선택" })).toHaveLength(1);
   });
 
   it("keeps filter callbacks wired through the existing selection handlers", () => {

--- a/src/test/components/SessionListFilterBar.test.tsx
+++ b/src/test/components/SessionListFilterBar.test.tsx
@@ -1,0 +1,109 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { SessionListFilterBar } from "@/features/session/components/SessionList/SessionListFilterBar";
+import type { SessionListFilterValues } from "@/features/session/hooks/useSessionListFilters";
+
+const defaultValues: SessionListFilterValues = {
+  startDate: null,
+  endDate: null,
+  timeSlots: [],
+  durationRange: null,
+  participants: null,
+  sort: "POPULAR",
+};
+
+function renderFilterBar(values: Partial<SessionListFilterValues> = {}) {
+  const props = {
+    values: { ...defaultValues, ...values },
+    onSetDateRange: jest.fn(),
+    onToggleTimeSlot: jest.fn(),
+    onSetDurationRange: jest.fn(),
+    onSetParticipants: jest.fn(),
+    onSetSort: jest.fn(),
+    onResetFilters: jest.fn(),
+  };
+
+  const view = render(<SessionListFilterBar {...props} />);
+
+  return { ...view, props };
+}
+
+function getScrollableFilterRow(container: HTMLElement) {
+  const row = container.querySelector(".scrollbar-hide");
+
+  if (!(row instanceof HTMLElement)) {
+    throw new Error("SessionListFilterBar scroll row was not rendered");
+  }
+
+  return row;
+}
+
+describe("SessionListFilterBar", () => {
+  it("reserves mobile/tablet panel space when a non-sort filter opens", () => {
+    const { container } = renderFilterBar();
+
+    const row = getScrollableFilterRow(container);
+    expect(row).not.toHaveClass("pb-[380px]");
+    expect(row).not.toHaveClass("-mb-[380px]");
+
+    fireEvent.click(screen.getByRole("button", { name: /시작 시간대/ }));
+
+    expect(screen.getByRole("dialog", { name: "시작 시간대 선택" })).toBeInTheDocument();
+    expect(row).toHaveClass("pb-[380px]");
+    expect(row).toHaveClass("-mb-[380px]");
+    expect(row).toHaveClass("xl:pb-0");
+    expect(row).toHaveClass("xl:mb-0");
+  });
+
+  it("reserves mobile/tablet panel space for the sort dropdown", () => {
+    const { container } = renderFilterBar();
+
+    fireEvent.click(screen.getByRole("button", { name: /인기순/ }));
+
+    expect(screen.getAllByRole("dialog", { name: "정렬 선택" }).length).toBeGreaterThan(0);
+    expect(getScrollableFilterRow(container)).toHaveClass("pb-[380px]");
+    expect(getScrollableFilterRow(container)).toHaveClass("-mb-[380px]");
+    expect(getScrollableFilterRow(container)).toHaveClass("xl:pb-0");
+    expect(getScrollableFilterRow(container)).toHaveClass("xl:mb-0");
+  });
+
+  it("closes the sort dropdown when the visible sort trigger is clicked again", () => {
+    renderFilterBar();
+    const sortTrigger = screen.getByRole("button", { name: /인기순/ });
+
+    fireEvent.click(sortTrigger);
+    expect(screen.getAllByRole("dialog", { name: "정렬 선택" }).length).toBeGreaterThan(0);
+
+    fireEvent.click(sortTrigger);
+
+    expect(screen.queryByRole("dialog", { name: "정렬 선택" })).not.toBeInTheDocument();
+  });
+
+  it("renders a single sort filter trigger so hidden duplicates cannot reopen the dropdown", () => {
+    renderFilterBar();
+
+    expect(screen.getAllByRole("button", { name: /인기순/ })).toHaveLength(1);
+  });
+
+  it("keeps filter callbacks wired through the existing selection handlers", () => {
+    const { props } = renderFilterBar();
+
+    fireEvent.click(screen.getByRole("button", { name: /진행시간/ }));
+    fireEvent.click(screen.getByRole("radio", { name: "30분 ~1시간" }));
+
+    expect(props.onSetDurationRange).toHaveBeenCalledWith("HALF_TO_ONE_HOUR");
+  });
+
+  it("closes a non-sort panel on Escape and removes the reserved panel space", () => {
+    const { container } = renderFilterBar();
+    const trigger = screen.getByRole("button", { name: /인원/ });
+
+    fireEvent.click(trigger);
+    expect(screen.getByRole("dialog", { name: "참여 인원 선택" })).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(screen.queryByRole("dialog", { name: "참여 인원 선택" })).not.toBeInTheDocument();
+    expect(getScrollableFilterRow(container)).not.toHaveClass("pb-[380px]");
+  });
+});

--- a/src/test/components/SessionListFilterBar.test.tsx
+++ b/src/test/components/SessionListFilterBar.test.tsx
@@ -2,7 +2,9 @@ import { fireEvent, render, screen } from "@testing-library/react";
 
 import { SessionListFilterBar } from "@/features/session/components/SessionList/SessionListFilterBar";
 import type { SessionListFilterValues } from "@/features/session/hooks/useSessionListFilters";
-import { BREAKPOINT_XL_PX } from "@/lib/constants/breakpoints";
+import { useViewportLayout } from "@/hooks/useViewportLayout";
+
+jest.mock("@/hooks/useViewportLayout");
 
 const defaultValues: SessionListFilterValues = {
   startDate: null,
@@ -39,20 +41,10 @@ function getScrollableFilterRow(container: HTMLElement) {
   return row;
 }
 
-function mockDesktopViewport() {
-  window.matchMedia = jest.fn().mockImplementation((query: string) => ({
-    matches: query === `(min-width: ${BREAKPOINT_XL_PX}px)`,
-    media: query,
-    onchange: null,
-    addListener: jest.fn(),
-    removeListener: jest.fn(),
-    addEventListener: jest.fn(),
-    removeEventListener: jest.fn(),
-    dispatchEvent: jest.fn(),
-  }));
-}
-
 describe("SessionListFilterBar", () => {
+  beforeEach(() => {
+    (useViewportLayout as jest.Mock).mockReturnValue({ layout: "mobile", isResolved: true });
+  });
   it("reserves mobile/tablet panel space when a non-sort filter opens", () => {
     const { container } = renderFilterBar();
 
@@ -72,9 +64,9 @@ describe("SessionListFilterBar", () => {
   it("reserves nonDesktop (<xl) panel space for the sort dropdown", () => {
     const { container } = renderFilterBar();
 
-    fireEvent.click(screen.getAllByRole("button", { name: /인기순/ })[0]);
+    fireEvent.click(screen.getByRole("button", { name: /인기순/ }));
 
-    expect(screen.getAllByRole("dialog", { name: "정렬 선택" })).toHaveLength(1);
+    expect(screen.getByRole("dialog", { name: "정렬 선택" })).toBeInTheDocument();
     expect(getScrollableFilterRow(container)).toHaveClass("pb-[380px]");
     expect(getScrollableFilterRow(container)).toHaveClass("-mb-[380px]");
     expect(getScrollableFilterRow(container)).toHaveClass("xl:pb-0");
@@ -83,7 +75,7 @@ describe("SessionListFilterBar", () => {
 
   it("closes the sort dropdown when the visible sort trigger is clicked again", () => {
     renderFilterBar();
-    const sortTrigger = screen.getAllByRole("button", { name: /인기순/ })[0];
+    const sortTrigger = screen.getByRole("button", { name: /인기순/ });
 
     fireEvent.click(sortTrigger);
     expect(screen.getAllByRole("dialog", { name: "정렬 선택" })).toHaveLength(1);
@@ -93,25 +85,20 @@ describe("SessionListFilterBar", () => {
     expect(screen.queryByRole("dialog", { name: "정렬 선택" })).not.toBeInTheDocument();
   });
 
-  it("renders sort filter triggers for both mobile and desktop layouts", () => {
+  it("renders one sort filter trigger for the current viewport", () => {
     renderFilterBar();
 
-    expect(screen.getAllByRole("button", { name: /인기순/ })).toHaveLength(2);
+    expect(screen.getAllByRole("button", { name: /인기순/ })).toHaveLength(1);
   });
 
-  it("opens only the desktop sort dropdown on desktop viewport and ignores the nonDesktop trigger", () => {
-    mockDesktopViewport();
+  it("renders and opens the sort filter on desktop viewport", () => {
+    (useViewportLayout as jest.Mock).mockReturnValue({ layout: "desktop", isResolved: true });
     renderFilterBar();
-    const [nonDesktopSortTrigger, desktopSortTrigger] = screen.getAllByRole("button", {
-      name: /인기순/,
-    });
 
-    fireEvent.click(nonDesktopSortTrigger);
-    expect(screen.queryByRole("dialog", { name: "정렬 선택" })).not.toBeInTheDocument();
+    const sortTrigger = screen.getByRole("button", { name: /인기순/ });
+    fireEvent.click(sortTrigger);
 
-    fireEvent.click(desktopSortTrigger);
-
-    expect(screen.getAllByRole("dialog", { name: "정렬 선택" })).toHaveLength(1);
+    expect(screen.getByRole("dialog", { name: "정렬 선택" })).toBeInTheDocument();
   });
 
   it("keeps filter callbacks wired through the existing selection handlers", () => {

--- a/src/test/components/SessionListFilterBar.test.tsx
+++ b/src/test/components/SessionListFilterBar.test.tsx
@@ -69,7 +69,7 @@ describe("SessionListFilterBar", () => {
     expect(row).toHaveClass("xl:mb-0");
   });
 
-  it("reserves compact (<xl) panel space for the sort dropdown", () => {
+  it("reserves nonDesktop (<xl) panel space for the sort dropdown", () => {
     const { container } = renderFilterBar();
 
     fireEvent.click(screen.getAllByRole("button", { name: /인기순/ })[0]);
@@ -99,14 +99,14 @@ describe("SessionListFilterBar", () => {
     expect(screen.getAllByRole("button", { name: /인기순/ })).toHaveLength(2);
   });
 
-  it("opens only the desktop sort dropdown on desktop viewport and ignores the compact trigger", () => {
+  it("opens only the desktop sort dropdown on desktop viewport and ignores the nonDesktop trigger", () => {
     mockDesktopViewport();
     renderFilterBar();
-    const [compactSortTrigger, desktopSortTrigger] = screen.getAllByRole("button", {
+    const [nonDesktopSortTrigger, desktopSortTrigger] = screen.getAllByRole("button", {
       name: /인기순/,
     });
 
-    fireEvent.click(compactSortTrigger);
+    fireEvent.click(nonDesktopSortTrigger);
     expect(screen.queryByRole("dialog", { name: "정렬 선택" })).not.toBeInTheDocument();
 
     fireEvent.click(desktopSortTrigger);

--- a/src/test/components/SessionListFilterBar.test.tsx
+++ b/src/test/components/SessionListFilterBar.test.tsx
@@ -69,7 +69,7 @@ describe("SessionListFilterBar", () => {
     expect(row).toHaveClass("xl:mb-0");
   });
 
-  it("reserves mobile/tablet panel space for the sort dropdown", () => {
+  it("reserves compact (<xl) panel space for the sort dropdown", () => {
     const { container } = renderFilterBar();
 
     fireEvent.click(screen.getAllByRole("button", { name: /인기순/ })[0]);
@@ -99,11 +99,17 @@ describe("SessionListFilterBar", () => {
     expect(screen.getAllByRole("button", { name: /인기순/ })).toHaveLength(2);
   });
 
-  it("opens only the desktop sort dropdown on desktop viewport", () => {
+  it("opens only the desktop sort dropdown on desktop viewport and ignores the compact trigger", () => {
     mockDesktopViewport();
     renderFilterBar();
+    const [compactSortTrigger, desktopSortTrigger] = screen.getAllByRole("button", {
+      name: /인기순/,
+    });
 
-    fireEvent.click(screen.getAllByRole("button", { name: /인기순/ })[1]);
+    fireEvent.click(compactSortTrigger);
+    expect(screen.queryByRole("dialog", { name: "정렬 선택" })).not.toBeInTheDocument();
+
+    fireEvent.click(desktopSortTrigger);
 
     expect(screen.getAllByRole("dialog", { name: "정렬 선택" })).toHaveLength(1);
   });


### PR DESCRIPTION
## 작업 내용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 필터 패널과 정렬 UI가 뷰포트별로 분리되어 모바일/데스크톱에서 일관된 동작 및 표시를 제공합니다.
  * 필터 패널이 열릴 때 스크롤 영역에 예약 여백을 적용해 내용이 잘리지 않도록 개선했습니다.

* **테스트**
  * 다양한 화면 크기와 상호작용(열기/닫기, 키보드, 정렬/기간 선택)을 검증하는 테스트 스위트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

- mobile/tablet에서 홈 세션 필터 패널이 잘려 보이지 않는 문제 수정
- SortFilter 재클릭 시 닫히지 않고 다시 열리는 문제 수정
- 회귀 테스트 추가

## 참고 사항

- desktop 동작 변경 없음
- 신규 dependency 없음

## 연관 이슈

close #270
