### PR TITLE
feat: 세션 시작 페이지 반응형 레이아웃 추가

### DIFF
--- a/src/features/session/components/SessionDetailSection.tsx
+++ b/src/features/session/components/SessionDetailSection.tsx
@@ -29,10 +29,12 @@ export function SessionDetailSection({
   notice,
 }: SessionDetailSectionProps) {
   return (
-    <section className={`gap-lg flex flex-col rounded-lg xl:flex-row ${className ?? ""}`}>
-      {/* 썸네일: 모바일·태블릿 full-width 고정 높이, 데스크탑 30% */}
-      <div className="h-[200px] xl:h-auto xl:flex-3">
-        <Thumbnail src={thumbnailUrl} alt={title} radius="lg" className="h-full" />
+    <section
+      className={`gap-lg flex flex-col rounded-lg xl:flex-row xl:items-start ${className ?? ""}`}
+    >
+      {/* 썸네일: Thumbnail 내장 aspect-ratio(276/146) 사용, 데스크탑 30% */}
+      <div className="xl:flex-3">
+        <Thumbnail src={thumbnailUrl} alt={title} radius="lg" />
       </div>
 
       {/* 정보 영역: 데스크탑 70% */}

--- a/src/features/session/components/SessionDetailSection.tsx
+++ b/src/features/session/components/SessionDetailSection.tsx
@@ -29,14 +29,14 @@ export function SessionDetailSection({
   notice,
 }: SessionDetailSectionProps) {
   return (
-    <section className={`gap-lg flex rounded-lg ${className ?? ""}`}>
-      {/* 왼쪽: 썸네일 (30%) */}
-      <div className="flex-3">
+    <section className={`gap-lg flex flex-col rounded-lg xl:flex-row ${className ?? ""}`}>
+      {/* 썸네일: 모바일·태블릿 full-width 고정 높이, 데스크탑 30% */}
+      <div className="h-[200px] xl:h-auto xl:flex-3">
         <Thumbnail src={thumbnailUrl} alt={title} radius="lg" className="h-full" />
       </div>
 
-      {/* 오른쪽: 정보 영역 (70%) */}
-      <div className="gap-sm flex flex-7 flex-col">
+      {/* 정보 영역: 데스크탑 70% */}
+      <div className="gap-sm flex flex-col xl:flex-7">
         {/* 카테고리 Badge */}
         <ChipBadge radius="xs" className="w-fit border-0">
           {category}

--- a/src/features/session/components/SessionGoalAndTodoCard/SessionGoalAndTodoCard.tsx
+++ b/src/features/session/components/SessionGoalAndTodoCard/SessionGoalAndTodoCard.tsx
@@ -40,7 +40,7 @@ export function SessionGoalAndTodoCard({
 
   return (
     <div
-      className={`gap-lg border-gray p-lg flex h-157 flex-6 flex-col rounded-lg border ${className ?? ""}`}
+      className={`gap-lg border-gray p-lg flex h-auto flex-col rounded-lg border xl:h-157 xl:flex-6 ${className ?? ""}`}
     >
       {/* 헤더 */}
       <div className="flex items-center justify-between">

--- a/src/features/session/components/SessionPageContent.tsx
+++ b/src/features/session/components/SessionPageContent.tsx
@@ -168,7 +168,7 @@ export function SessionPageContent({ sessionId }: SessionPageContentProps) {
         totalCount={inProgressData?.participantCount ?? session.currentParticipants}
         className="mt-xl"
       />
-      <div className="gap-lg mt-xl flex">
+      <div className="gap-lg mt-xl flex flex-col xl:flex-row">
         <SessionGoalAndTodoCard
           goal={myMember?.task?.goal ?? ""}
           todos={myMember?.task?.todos ?? []}

--- a/src/features/session/components/SessionPageSkeleton.tsx
+++ b/src/features/session/components/SessionPageSkeleton.tsx
@@ -16,9 +16,9 @@ export function SessionPageSkeleton({
         <SkeletonBlock className="h-9 w-20 rounded-md" />
       </header>
 
-      <div className="gap-lg flex flex-col rounded-lg lg:flex-row">
-        <SkeletonBlock className="h-[200px] w-full rounded-lg lg:flex-3" />
-        <div className="gap-sm flex flex-col lg:flex-7">
+      <div className="gap-lg flex flex-col rounded-lg xl:flex-row xl:items-start">
+        <SkeletonBlock className="h-[200px] w-full rounded-lg xl:flex-3" />
+        <div className="gap-sm flex flex-col xl:flex-7">
           <SkeletonBlock className="h-6 w-16" />
           <SkeletonBlock className="h-8 w-56 max-w-full" />
           <SkeletonBlock className="h-5 w-full" />
@@ -27,13 +27,14 @@ export function SessionPageSkeleton({
         </div>
       </div>
 
-      <div className="mt-xl">
-        <SkeletonBlock className="h-[240px] w-full rounded-2xl" />
+      <div className="gap-lg mt-xl flex flex-col md:flex-row">
+        <SkeletonBlock className="h-[240px] rounded-2xl md:flex-6" />
+        <SkeletonBlock className="h-[240px] rounded-2xl md:flex-4" />
       </div>
 
-      <div className="gap-lg mt-xl flex flex-col lg:flex-row">
-        <SkeletonBlock className="h-[280px] flex-1 rounded-2xl" />
-        <SkeletonBlock className="h-[280px] flex-1 rounded-2xl" />
+      <div className="gap-lg mt-xl flex flex-col xl:flex-row">
+        <SkeletonBlock className="h-[280px] rounded-2xl xl:flex-6" />
+        <SkeletonBlock className="h-[280px] rounded-2xl xl:flex-4" />
       </div>
     </div>
   );

--- a/src/features/session/components/SessionParticipantListCard/SessionParticipantListCard.tsx
+++ b/src/features/session/components/SessionParticipantListCard/SessionParticipantListCard.tsx
@@ -30,7 +30,7 @@ export function SessionParticipantListCard({
   return (
     <>
       <div
-        className={`gap-lg border-gray p-lg flex h-157 flex-4 flex-col rounded-lg border ${className ?? ""}`}
+        className={`gap-lg border-gray p-lg flex h-auto flex-col rounded-lg border xl:h-157 xl:flex-4 ${className ?? ""}`}
       >
         {/* 헤더 */}
         <div className="flex items-center justify-between">

--- a/src/features/session/components/SessionTimerSection.tsx
+++ b/src/features/session/components/SessionTimerSection.tsx
@@ -32,12 +32,12 @@ export function SessionTimerSection({
   );
 
   return (
-    <section className={`gap-lg flex items-stretch ${className ?? ""}`}>
-      <div className="flex-6">
+    <section className={`gap-lg flex flex-col items-stretch md:flex-row ${className ?? ""}`}>
+      <div className="md:flex-6">
         <MyTimer sessionId={sessionId} sessionDurationMinutes={sessionDurationMinutes} />
       </div>
 
-      <div className="flex-4">
+      <div className="md:flex-4">
         <TotalTimer
           sessionEndTime={sessionEndTime}
           sessionDurationMinutes={sessionDurationMinutes}


### PR DESCRIPTION
## 작업 내용

> Tailwind breakpoint(`md:`, `xl:`)를 추가해 세션 진행 페이지의 모바일(<768px), 태블릿(768–1279px) 반응형 레이아웃을 구현했습니다. 아울러 로딩 스켈레톤(`SessionPageSkeleton`)의 breakpoint·비율도 실제 컴포넌트에 맞춰 동기화했습니다.

| 섹션 | Mobile | Tablet | Desktop |
|------|--------|--------|---------|
| SessionDetailSection | 썸네일 위 / 정보 아래 (col) | 썸네일 위 / 정보 아래 (col) | 썸네일 좌 30% / 정보 우 70% (row) |
| SessionTimerSection | MyTimer 위 / TotalTimer 아래 (col) | 좌우 나란히 (row) | 좌우 나란히 (row) |
| 하단 카드 | Goal 위 / Participant 아래 (col) | Goal 위 / Participant 아래 (col) | Goal 좌 60% / Participant 우 40% (row) |
| SessionPageSkeleton | 실제 컴포넌트와 동일한 반응형 구조 반영 | ← | ← |

## 참고 사항

> - 기존 코드에 breakpoint prefix(`md:`, `xl:`)만 추가했으며 구조 변경 없음
> - 카드(`SessionGoalAndTodoCard`, `SessionParticipantListCard`)는 모바일·태블릿에서 `h-auto`로 전환해 페이지 스크롤로 동작
> - 스켈레톤: `lg:` → `xl:` 수정, Timer 단일 블록 → `md:flex-row` 2-column, 하단 카드 비율 `1:1` → `6:4`
> - 375px / 768px / 1280px 스크린샷은 UI 확인 후 추가 예정

## 연관 이슈

> close #278

## CodeRabbit 운영 메모

- 증분 리뷰 재실행: `@coderabbitai review`
- 전체 PR 재검토: `@coderabbitai full review`