### PR TITLE
feat: MSW 로컬 mock backend 구성

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "jest": "^30.2.0",
     "jest-environment-jsdom": "^30.2.0",
     "lint-staged": "^16.2.7",
+    "msw": "^2.14.6",
     "orval": "^8.0.2",
     "playwright": "^1.57.0",
     "prettier": "^3.8.0",
@@ -97,5 +98,10 @@
     "typescript": "^5",
     "vite": "^7.3.1",
     "vitest": "^4.0.17"
+  },
+  "msw": {
+    "workerDirectory": [
+      "public"
+    ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,7 +80,7 @@ importers:
         version: 10.2.9(storybook@10.2.9(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       '@storybook/addon-vitest':
         specifier: ^10.1.11
-        version: 10.2.9(@vitest/browser-playwright@4.0.18)(@vitest/browser@4.0.18(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.0.18))(@vitest/runner@4.0.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.2.9(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vitest@4.0.18)
+        version: 10.2.9(@vitest/browser-playwright@4.0.18)(@vitest/browser@4.0.18(msw@2.14.6(@types/node@20.19.33)(typescript@5.9.3))(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.0.18))(@vitest/runner@4.0.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.2.9(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vitest@4.0.18)
       '@storybook/nextjs-vite':
         specifier: ^10.1.11
         version: 10.2.9(@babel/core@7.29.0)(esbuild@0.27.3)(next@16.1.4(@babel/core@7.29.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.57.1)(storybook@10.2.9(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
@@ -119,10 +119,10 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitest/browser-playwright':
         specifier: ^4.0.17
-        version: 4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.0.18)
+        version: 4.0.18(msw@2.14.6(@types/node@20.19.33)(typescript@5.9.3))(playwright@1.58.2)(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.0.18)
       '@vitest/coverage-v8':
         specifier: ^4.0.17
-        version: 4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.0.18))(vitest@4.0.18)
+        version: 4.0.18(@vitest/browser@4.0.18(msw@2.14.6(@types/node@20.19.33)(typescript@5.9.3))(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.0.18))(vitest@4.0.18)
       chokidar-cli:
         specifier: ^3.0.0
         version: 3.0.0
@@ -162,6 +162,9 @@ importers:
       lint-staged:
         specifier: ^16.2.7
         version: 16.2.7
+      msw:
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@20.19.33)(typescript@5.9.3)
       orval:
         specifier: ^8.0.2
         version: 8.4.0(typescript@5.9.3)
@@ -200,7 +203,7 @@ importers:
         version: 7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
       vitest:
         specifier: ^4.0.17
-        version: 4.0.18(@edge-runtime/vm@5.0.0)(@types/node@20.19.33)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(yaml@2.8.2)
+        version: 4.0.18(@edge-runtime/vm@5.0.0)(@types/node@20.19.33)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.14.6(@types/node@20.19.33)(typescript@5.9.3))(yaml@2.8.2)
 
 packages:
 
@@ -887,6 +890,41 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@inquirer/ansi@2.0.7':
+    resolution: {integrity: sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+
+  '@inquirer/confirm@6.1.1':
+    resolution: {integrity: sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@11.2.1':
+    resolution: {integrity: sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@2.0.7':
+    resolution: {integrity: sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+
+  '@inquirer/type@4.0.7':
+    resolution: {integrity: sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -1165,6 +1203,10 @@ packages:
       '@types/react': '>=16'
       react: '>=16'
 
+  '@mswjs/interceptors@0.41.9':
+    resolution: {integrity: sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==}
+    engines: {node: '>=18'}
+
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
@@ -1243,6 +1285,18 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@open-draft/deferred-promise@2.2.0':
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+
+  '@open-draft/deferred-promise@3.0.0':
+    resolution: {integrity: sha512-XW375UK8/9SqUVNVa6M0yEy8+iTi4QN5VZ7aZuRFQmy76LRwI9wy5F4YIBU6T+eTe2/DNDo8tqu8RHlwLHM6RA==}
+
+  '@open-draft/logger@0.3.0':
+    resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
+
+  '@open-draft/until@2.1.0':
+    resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
   '@orval/angular@8.4.0':
     resolution: {integrity: sha512-VrqVO1ibZGoxrvHuVIWQ7vHqjQJmGxxJP+xlLK2tJCQW/DKelelQ4wyR0wkpldO8DCwInA8xqLreKWcnqqnvNQ==}
@@ -1833,8 +1887,14 @@ packages:
   '@types/resolve@1.20.6':
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
 
+  '@types/set-cookie-parser@2.4.10':
+    resolution: {integrity: sha512-GGmQVGpQWUe5qglJozEjZV/5dyxbOOZ0LHe/lqyWssB88Y4svNfst0uqBVscdDeIKl5Jy5+aPSvy7mI9tYRguw==}
+
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+
+  '@types/statuses@2.0.6':
+    resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
@@ -2433,6 +2493,10 @@ packages:
     resolution: {integrity: sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A==}
     engines: {node: '>=20'}
 
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
+
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
@@ -2514,6 +2578,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   cosmiconfig-typescript-loader@6.2.0:
     resolution: {integrity: sha512-GEN39v7TgdxgIoNcdkRE3uiAzQt3UXLyHbRHD6YoL048XAeOomyxaP+Hh/+2C6C2wYjxJ2onhJcsQp+L4YEkVQ==}
@@ -2986,8 +3054,17 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -3197,6 +3274,10 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
+  graphql@16.14.2:
+    resolution: {integrity: sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
   handlebars@4.7.8:
     resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
     engines: {node: '>=0.4.7'}
@@ -3228,6 +3309,9 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  headers-polyfill@5.0.1:
+    resolution: {integrity: sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==}
 
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
@@ -3427,6 +3511,9 @@ packages:
   is-negative-zero@2.0.3:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
+
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
   is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
@@ -4053,6 +4140,20 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  msw@2.14.6:
+    resolution: {integrity: sha512-ALe+N10S72cyx94cMcy3Zs4HhXCj35sgeAL4c+WTvKi0zWnbd8/h0lcFqv0mb2P+aSgAdD7p9HzvA0DiUPxsyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>= 4.8.x'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  mute-stream@3.0.0:
+    resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   nano-spawn@2.0.0:
     resolution: {integrity: sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw==}
     engines: {node: '>=20.17'}
@@ -4182,6 +4283,9 @@ packages:
     engines: {node: '>=22.18.0'}
     hasBin: true
 
+  outvariant@1.4.3:
+    resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
+
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
@@ -4266,6 +4370,9 @@ packages:
   path-scurry@2.0.1:
     resolution: {integrity: sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==}
     engines: {node: 20 || >=22}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   path-unified@0.2.0:
     resolution: {integrity: sha512-MNKqvrKbbbb5p7XHXV6ZAsf/1f/yJQa13S/fcX0uua8ew58Tgc6jXV+16JyAbnR/clgCH+euKDxrF2STxMHdrg==}
@@ -4553,6 +4660,9 @@ packages:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
 
+  rettime@0.11.11:
+    resolution: {integrity: sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -4614,6 +4724,9 @@ packages:
 
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+
+  set-cookie-parser@3.1.0:
+    resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -4713,6 +4826,10 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
@@ -4731,6 +4848,9 @@ packages:
 
   stream@0.0.3:
     resolution: {integrity: sha512-aMsbn7VKrl4A2T7QAQQbzgN7NVc70vgF5INQrBXqn4dCXN1zy3L9HGgLO5s7PExmdrzTJ8uR/27aviW8or8/+A==}
+
+  strict-event-emitter@0.5.1:
+    resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
 
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
@@ -4863,6 +4983,10 @@ packages:
     resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   tailwind-merge@3.4.1:
     resolution: {integrity: sha512-2OA0rFqWOkITEAOFWSBSApYkDeH9t2B3XSJuI4YztKBzK3mX0737A2qtxDZ7xkw9Zfh0bWl+r34sF3HXV+Ig7Q==}
 
@@ -4915,8 +5039,15 @@ packages:
   tldts-core@6.1.86:
     resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
 
+  tldts-core@7.4.4:
+    resolution: {integrity: sha512-vwVLJVvvpslm7vqAH7+XNj/neA/Ynq7DT2EEcMuwc5YzN5XaMyRAqxwU+uX3azZ1FQtB2gvrvnLnAEkvYlVdfg==}
+
   tldts@6.1.86:
     resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
+  tldts@7.4.4:
+    resolution: {integrity: sha512-kFXFK7O4WPextIUAOk8qtnw9dxR9UIXP9CjuH1cTBVBZMDeQcUPgr/IazGiw1B0Yiw5L75gHLWeW4iD793r90g==}
     hasBin: true
 
   tmpl@1.0.5:
@@ -4932,6 +5063,10 @@ packages:
 
   tough-cookie@5.1.2:
     resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
 
   tr46@5.1.1:
@@ -5038,6 +5173,10 @@ packages:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
 
+  type-fest@5.7.0:
+    resolution: {integrity: sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==}
+    engines: {node: '>=20'}
+
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
     engines: {node: '>= 0.4'}
@@ -5118,6 +5257,9 @@ packages:
 
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
+
+  until-async@3.0.2:
+    resolution: {integrity: sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -6081,6 +6223,33 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
+  '@inquirer/ansi@2.0.7': {}
+
+  '@inquirer/confirm@6.1.1(@types/node@20.19.33)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@20.19.33)
+      '@inquirer/type': 4.0.7(@types/node@20.19.33)
+    optionalDependencies:
+      '@types/node': 20.19.33
+
+  '@inquirer/core@11.2.1(@types/node@20.19.33)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@20.19.33)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.2
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 20.19.33
+
+  '@inquirer/figures@2.0.7': {}
+
+  '@inquirer/type@4.0.7(@types/node@20.19.33)':
+    optionalDependencies:
+      '@types/node': 20.19.33
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -6486,6 +6655,15 @@ snapshots:
       '@types/react': 19.2.14
       react: 19.2.3
 
+  '@mswjs/interceptors@0.41.9':
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      strict-event-emitter: 0.5.1
+
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.8.1
@@ -6540,6 +6718,17 @@ snapshots:
       fastq: 1.20.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@open-draft/deferred-promise@2.2.0': {}
+
+  '@open-draft/deferred-promise@3.0.0': {}
+
+  '@open-draft/logger@0.3.0':
+    dependencies:
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+
+  '@open-draft/until@2.1.0': {}
 
   '@orval/angular@8.4.0(typescript@5.9.3)':
     dependencies:
@@ -6839,16 +7028,16 @@ snapshots:
       storybook: 10.2.9(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-vitest@10.2.9(@vitest/browser-playwright@4.0.18)(@vitest/browser@4.0.18(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.0.18))(@vitest/runner@4.0.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.2.9(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vitest@4.0.18)':
+  '@storybook/addon-vitest@10.2.9(@vitest/browser-playwright@4.0.18)(@vitest/browser@4.0.18(msw@2.14.6(@types/node@20.19.33)(typescript@5.9.3))(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.0.18))(@vitest/runner@4.0.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.2.9(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vitest@4.0.18)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       storybook: 10.2.9(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     optionalDependencies:
-      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.0.18)
-      '@vitest/browser-playwright': 4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.0.18)
+      '@vitest/browser': 4.0.18(msw@2.14.6(@types/node@20.19.33)(typescript@5.9.3))(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.0.18)
+      '@vitest/browser-playwright': 4.0.18(msw@2.14.6(@types/node@20.19.33)(typescript@5.9.3))(playwright@1.58.2)(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.0.18)
       '@vitest/runner': 4.0.18
-      vitest: 4.0.18(@edge-runtime/vm@5.0.0)(@types/node@20.19.33)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(yaml@2.8.2)
+      vitest: 4.0.18(@edge-runtime/vm@5.0.0)(@types/node@20.19.33)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.14.6(@types/node@20.19.33)(typescript@5.9.3))(yaml@2.8.2)
     transitivePeerDependencies:
       - react
       - react-dom
@@ -7169,7 +7358,13 @@ snapshots:
 
   '@types/resolve@1.20.6': {}
 
+  '@types/set-cookie-parser@2.4.10':
+    dependencies:
+      '@types/node': 20.19.33
+
   '@types/stack-utils@2.0.3': {}
+
+  '@types/statuses@2.0.6': {}
 
   '@types/tough-cookie@4.0.5': {}
 
@@ -7333,29 +7528,29 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitest/browser-playwright@4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.0.18)':
+  '@vitest/browser-playwright@4.0.18(msw@2.14.6(@types/node@20.19.33)(typescript@5.9.3))(playwright@1.58.2)(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.0.18)':
     dependencies:
-      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.0.18)
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      '@vitest/browser': 4.0.18(msw@2.14.6(@types/node@20.19.33)(typescript@5.9.3))(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.0.18)
+      '@vitest/mocker': 4.0.18(msw@2.14.6(@types/node@20.19.33)(typescript@5.9.3))(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
       playwright: 1.58.2
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@edge-runtime/vm@5.0.0)(@types/node@20.19.33)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(yaml@2.8.2)
+      vitest: 4.0.18(@edge-runtime/vm@5.0.0)(@types/node@20.19.33)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.14.6(@types/node@20.19.33)(typescript@5.9.3))(yaml@2.8.2)
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.0.18(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.0.18)':
+  '@vitest/browser@4.0.18(msw@2.14.6(@types/node@20.19.33)(typescript@5.9.3))(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.0.18)':
     dependencies:
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.18(msw@2.14.6(@types/node@20.19.33)(typescript@5.9.3))(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
       '@vitest/utils': 4.0.18
       magic-string: 0.30.21
       pixelmatch: 7.1.0
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@edge-runtime/vm@5.0.0)(@types/node@20.19.33)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(yaml@2.8.2)
+      vitest: 4.0.18(@edge-runtime/vm@5.0.0)(@types/node@20.19.33)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.14.6(@types/node@20.19.33)(typescript@5.9.3))(yaml@2.8.2)
       ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
@@ -7363,7 +7558,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.0.18))(vitest@4.0.18)':
+  '@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(msw@2.14.6(@types/node@20.19.33)(typescript@5.9.3))(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.0.18))(vitest@4.0.18)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -7375,9 +7570,9 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@edge-runtime/vm@5.0.0)(@types/node@20.19.33)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(yaml@2.8.2)
+      vitest: 4.0.18(@edge-runtime/vm@5.0.0)(@types/node@20.19.33)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.14.6(@types/node@20.19.33)(typescript@5.9.3))(yaml@2.8.2)
     optionalDependencies:
-      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.0.18)
+      '@vitest/browser': 4.0.18(msw@2.14.6(@types/node@20.19.33)(typescript@5.9.3))(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.0.18)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -7396,12 +7591,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))':
+  '@vitest/mocker@4.0.18(msw@2.14.6(@types/node@20.19.33)(typescript@5.9.3))(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
+      msw: 2.14.6(@types/node@20.19.33)(typescript@5.9.3)
       vite: 7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
 
   '@vitest/pretty-format@3.2.4':
@@ -7830,6 +8026,8 @@ snapshots:
       slice-ansi: 7.1.2
       string-width: 8.1.1
 
+  cli-width@4.1.0: {}
+
   client-only@0.0.1: {}
 
   cliui@5.0.0:
@@ -7903,6 +8101,8 @@ snapshots:
       meow: 13.2.0
 
   convert-source-map@2.0.0: {}
+
+  cookie@1.1.1: {}
 
   cosmiconfig-typescript-loader@6.2.0(@types/node@20.19.33)(cosmiconfig@9.0.0(typescript@5.9.3))(typescript@5.9.3):
     dependencies:
@@ -8516,7 +8716,17 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
   fast-uri@3.1.0: {}
+
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
 
   fastq@1.20.1:
     dependencies:
@@ -8730,6 +8940,8 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  graphql@16.14.2: {}
+
   handlebars@4.7.8:
     dependencies:
       minimist: 1.2.8
@@ -8760,6 +8972,11 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  headers-polyfill@5.0.1:
+    dependencies:
+      '@types/set-cookie-parser': 2.4.10
+      set-cookie-parser: 3.1.0
 
   hermes-estree@0.25.1: {}
 
@@ -8939,6 +9156,8 @@ snapshots:
       define-properties: 1.2.1
 
   is-negative-zero@2.0.3: {}
+
+  is-node-process@1.2.0: {}
 
   is-number-object@1.1.1:
     dependencies:
@@ -9749,6 +9968,33 @@ snapshots:
 
   ms@2.1.3: {}
 
+  msw@2.14.6(@types/node@20.19.33)(typescript@5.9.3):
+    dependencies:
+      '@inquirer/confirm': 6.1.1(@types/node@20.19.33)
+      '@mswjs/interceptors': 0.41.9
+      '@open-draft/deferred-promise': 3.0.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
+      graphql: 16.14.2
+      headers-polyfill: 5.0.1
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.11.11
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.1
+      type-fest: 5.7.0
+      until-async: 3.0.2
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+
+  mute-stream@3.0.0: {}
+
   nano-spawn@2.0.0: {}
 
   nanoid@3.3.11: {}
@@ -9921,6 +10167,8 @@ snapshots:
       - supports-color
       - typescript
 
+  outvariant@1.4.3: {}
+
   own-keys@1.0.1:
     dependencies:
       get-intrinsic: 1.3.0
@@ -9997,6 +10245,8 @@ snapshots:
     dependencies:
       lru-cache: 11.2.6
       minipass: 7.1.2
+
+  path-to-regexp@6.3.0: {}
 
   path-unified@0.2.0: {}
 
@@ -10226,6 +10476,8 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
+  rettime@0.11.11: {}
+
   reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
@@ -10307,6 +10559,8 @@ snapshots:
   semver@7.7.4: {}
 
   set-blocking@2.0.0: {}
+
+  set-cookie-parser@3.1.0: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -10440,6 +10694,8 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  statuses@2.0.2: {}
+
   std-env@3.10.0: {}
 
   stop-iteration-iterator@1.1.0:
@@ -10473,6 +10729,8 @@ snapshots:
   stream@0.0.3:
     dependencies:
       component-emitter: 2.0.0
+
+  strict-event-emitter@0.5.1: {}
 
   string-argv@0.3.2: {}
 
@@ -10633,6 +10891,8 @@ snapshots:
     dependencies:
       '@pkgr/core': 0.2.9
 
+  tagged-tag@1.0.0: {}
+
   tailwind-merge@3.4.1: {}
 
   tailwindcss@4.1.18: {}
@@ -10670,9 +10930,15 @@ snapshots:
 
   tldts-core@6.1.86: {}
 
+  tldts-core@7.4.4: {}
+
   tldts@6.1.86:
     dependencies:
       tldts-core: 6.1.86
+
+  tldts@7.4.4:
+    dependencies:
+      tldts-core: 7.4.4
 
   tmpl@1.0.5: {}
 
@@ -10685,6 +10951,10 @@ snapshots:
   tough-cookie@5.1.2:
     dependencies:
       tldts: 6.1.86
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.4.4
 
   tr46@5.1.1:
     dependencies:
@@ -10771,6 +11041,10 @@ snapshots:
   type-fest@0.21.3: {}
 
   type-fest@4.41.0: {}
+
+  type-fest@5.7.0:
+    dependencies:
+      tagged-tag: 1.0.0
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -10886,6 +11160,8 @@ snapshots:
       '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
       '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
 
+  until-async@3.0.2: {}
+
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
       browserslist: 4.28.1
@@ -10966,10 +11242,10 @@ snapshots:
       lightningcss: 1.30.2
       yaml: 2.8.2
 
-  vitest@4.0.18(@edge-runtime/vm@5.0.0)(@types/node@20.19.33)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(yaml@2.8.2):
+  vitest@4.0.18(@edge-runtime/vm@5.0.0)(@types/node@20.19.33)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(msw@2.14.6(@types/node@20.19.33)(typescript@5.9.3))(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.18(msw@2.14.6(@types/node@20.19.33)(typescript@5.9.3))(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -10991,7 +11267,7 @@ snapshots:
     optionalDependencies:
       '@edge-runtime/vm': 5.0.0
       '@types/node': 20.19.33
-      '@vitest/browser-playwright': 4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.0.18)
+      '@vitest/browser-playwright': 4.0.18(msw@2.14.6(@types/node@20.19.33)(typescript@5.9.3))(playwright@1.58.2)(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.0.18)
       jsdom: 26.1.0
     transitivePeerDependencies:
       - jiti

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -1,0 +1,349 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ */
+
+const PACKAGE_VERSION = '2.14.6'
+const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
+
+addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+addEventListener('message', async function (event) {
+  const clientId = Reflect.get(event.source || {}, 'id')
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      })
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+addEventListener('fetch', function (event) {
+  const requestInterceptedAt = Date.now()
+
+  // Bypass navigation requests.
+  if (event.request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been terminated (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId, requestInterceptedAt))
+})
+
+/**
+ * @param {FetchEvent} event
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ */
+async function handleRequest(event, requestId, requestInterceptedAt) {
+  const client = await resolveMainClient(event)
+  const requestCloneForEvents = event.request.clone()
+  const response = await getResponse(
+    event,
+    client,
+    requestId,
+    requestInterceptedAt,
+  )
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    const serializedRequest = await serializeRequest(requestCloneForEvents)
+
+    // Clone the response so both the client and the library could consume it.
+    const responseClone = response.clone()
+
+    sendToClient(
+      client,
+      {
+        type: 'RESPONSE',
+        payload: {
+          isMockedResponse: IS_MOCKED_RESPONSE in response,
+          request: {
+            id: requestId,
+            ...serializedRequest,
+          },
+          response: {
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+            body: responseClone.body,
+          },
+        },
+      },
+      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
+    )
+  }
+
+  return response
+}
+
+/**
+ * Resolve the main client for the given event.
+ * Client that issues a request doesn't necessarily equal the client
+ * that registered the worker. It's with the latter the worker should
+ * communicate with during the response resolving phase.
+ * @param {FetchEvent} event
+ * @returns {Promise<Client | undefined>}
+ */
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (activeClientIds.has(event.clientId)) {
+    return client
+  }
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+/**
+ * @param {FetchEvent} event
+ * @param {Client | undefined} client
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ * @returns {Promise<Response>}
+ */
+async function getResponse(event, client, requestId, requestInterceptedAt) {
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = event.request.clone()
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers)
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get('accept')
+    if (acceptHeader) {
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
+
+      if (filteredValues.length > 0) {
+        headers.set('accept', filteredValues.join(', '))
+      } else {
+        headers.delete('accept')
+      }
+    }
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const serializedRequest = await serializeRequest(event.request)
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        interceptedAt: requestInterceptedAt,
+        ...serializedRequest,
+      },
+    },
+    [serializedRequest.body],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+/**
+ * @param {Client} client
+ * @param {any} message
+ * @param {Array<Transferable>} transferrables
+ * @returns {Promise<any>}
+ */
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ])
+  })
+}
+
+/**
+ * @param {Response} response
+ * @returns {Response}
+ */
+function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}
+
+/**
+ * @param {Request} request
+ */
+async function serializeRequest(request) {
+  return {
+    url: request.url,
+    mode: request.mode,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    cache: request.cache,
+    credentials: request.credentials,
+    destination: request.destination,
+    integrity: request.integrity,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    body: await request.arrayBuffer(),
+    keepalive: request.keepalive,
+  }
+}

--- a/src/app/(with-header)/session/[sessionId]/page.tsx
+++ b/src/app/(with-header)/session/[sessionId]/page.tsx
@@ -12,6 +12,7 @@ import { sessionQueries } from "@/features/session/hooks/useSessionHooks";
 import { isWaitingStatus } from "@/features/session/types";
 import { getQueryClient } from "@/lib/getQueryClient";
 import { createPageMetadata } from "@/lib/seo/metadata";
+import { isMockModeEnabled } from "@/mocks/is-mock-mode-enabled";
 
 interface SessionPageProps {
   params: Promise<{ sessionId: string }>;
@@ -44,8 +45,8 @@ export default async function SessionPage({ params }: SessionPageProps) {
 
   const sessionData = await queryClient.fetchQuery(sessionQueries.detail(sessionId));
 
-  // 대기 중인 세션이면 대기실로 리다이렉트
-  if (isWaitingStatus(sessionData.result.status)) {
+  // mock mode에서는 UI 확인을 위해 세션 화면에 직접 접근할 수 있도록 상태 기반 redirect를 제한한다.
+  if (!isMockModeEnabled() && isWaitingStatus(sessionData.result.status)) {
     redirect(`/session/${sessionId}/waiting`);
   }
 

--- a/src/app/(with-header)/session/[sessionId]/waiting/page.tsx
+++ b/src/app/(with-header)/session/[sessionId]/waiting/page.tsx
@@ -8,6 +8,7 @@ import type { GetMeResponse } from "@/features/member/types";
 import { sessionQueries } from "@/features/session/hooks/useSessionHooks";
 import { isInProgressStatus } from "@/features/session/types";
 import { getQueryClient } from "@/lib/getQueryClient";
+import { isMockModeEnabled } from "@/mocks/is-mock-mode-enabled";
 
 export const metadata = { title: "대기실" };
 
@@ -21,8 +22,8 @@ export default async function WaitingRoomPage({ params }: WaitingRoomPageProps) 
 
   const sessionData = await queryClient.fetchQuery(sessionQueries.detail(sessionId));
 
-  // 이미 진행 중인 세션이면 대기실을 거치지 않고 바로 세션 페이지로 이동
-  if (isInProgressStatus(sessionData.result.status)) {
+  // mock mode에서는 UI 확인을 위해 대기방 화면에 직접 접근할 수 있도록 상태 기반 redirect를 제한한다.
+  if (!isMockModeEnabled() && isInProgressStatus(sessionData.result.status)) {
     redirect(`/session/${sessionId}`);
   }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { getQueryClient } from "@/lib/getQueryClient";
 import GoogleAnalytics from "@/lib/GoogleAnalytics";
 import { rootMetadata } from "@/lib/seo/metadata";
 import { AuthStateProvider } from "@/providers/AuthStateProvider";
+import { MockProvider } from "@/providers/MockProvider";
 import { QueryProvider } from "@/providers/QueryProvider";
 
 import { geistMono, geistSans, pretendard } from "./fonts";
@@ -31,13 +32,15 @@ export default async function RootLayout({
         {process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS ? (
           <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS} />
         ) : null}
-        <QueryProvider dehydratedState={dehydrate(queryClient)}>
-          <AuthStateProvider hasAuthCookies={hasAuthCookies}>
-            {children}
-            {modal}
-            <ToastViewport />
-          </AuthStateProvider>
-        </QueryProvider>
+        <MockProvider>
+          <QueryProvider dehydratedState={dehydrate(queryClient)}>
+            <AuthStateProvider hasAuthCookies={hasAuthCookies}>
+              {children}
+              {modal}
+              <ToastViewport />
+            </AuthStateProvider>
+          </QueryProvider>
+        </MockProvider>
       </body>
     </html>
   );

--- a/src/features/lobby/components/WaitingRoomContent.tsx
+++ b/src/features/lobby/components/WaitingRoomContent.tsx
@@ -14,6 +14,7 @@ import { useSessionStatusSSE } from "@/features/session/hooks/useSessionStatusSS
 import { usePreventBackNavigation } from "@/hooks/usePreventBackNavigation";
 import { navigateWithHardReload } from "@/lib/navigation/hardNavigate";
 import { LOGIN_ROUTE } from "@/lib/routes/route-paths";
+import { isMockModeEnabled } from "@/mocks/is-mock-mode-enabled";
 
 import { useLeaveOnUnmount } from "../hooks/useLeaveOnUnmount";
 import { useWaitingMembersSSE } from "../hooks/useWaitingMembersSSE";
@@ -47,6 +48,7 @@ export function WaitingRoomContent({ sessionId }: WaitingRoomContentProps) {
 
   const authState = useAuthState();
   const isAuthenticated = authState.status === "authenticated";
+  const isMockMode = isMockModeEnabled();
   const { data, isLoading, error, refetch } = useSessionDetail(sessionId);
   const { data: meData, isLoading: isMeLoading } = useMe({ enabled: isAuthenticated });
   // 초기 데이터: REST API로 조회
@@ -82,10 +84,11 @@ export function WaitingRoomContent({ sessionId }: WaitingRoomContentProps) {
   });
 
   // 세션 상태 SSE - 대기 상태가 아니면 적절한 페이지로 이동
+  // mock mode에서는 UI 확인을 위해 대기방 화면에 직접 접근할 수 있도록 자동 이동을 제한한다.
   // hard navigation을 사용하여 modal interceptor routing 우회
   useSessionStatusSSE({
     sessionId,
-    enabled: true,
+    enabled: !isMockMode,
     onStatusChange: (eventData) => {
       const { status } = eventData;
       let targetUrl: string | null = null;

--- a/src/features/member/api.ts
+++ b/src/features/member/api.ts
@@ -19,6 +19,8 @@ import type {
   UpdateProfileImageResponse,
 } from "./types";
 
+export const MEMBER_PROFILE_IMAGE_FORM_KEY = "profileImage";
+
 const AUTH_MEMBER_QUERY_OPTIONS = {
   // 인증 실패를 빠르게 surface하고, 지수 백오프로 인한 초기 로딩 지연을 방지한다.
   retry: { maxRetries: 0 },
@@ -67,7 +69,7 @@ export const memberApi = {
     body: UpdateProfileImageRequest
   ): Promise<UpdateProfileImageResponse> => {
     const formData = new FormData();
-    formData.append("profileImage", body.profileImage);
+    formData.append(MEMBER_PROFILE_IMAGE_FORM_KEY, body.profileImage);
 
     return patchProfileImage<UpdateProfileImageResponse>("/api/members/me/profile-image", formData);
   },

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,8 @@
+export async function register() {
+  if (process.env.NEXT_PUBLIC_USE_MOCK !== "true") return;
+
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    const { server } = await import("./mocks/server");
+    server.listen({ onUnhandledRequest: "bypass" });
+  }
+}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,8 +1,5 @@
 export async function register() {
-  if (process.env.NEXT_PUBLIC_USE_MOCK !== "true") return;
+  const { ensureMockServer } = await import("./mocks/server-control");
 
-  if (process.env.NEXT_RUNTIME === "nodejs") {
-    const { server } = await import("./mocks/server");
-    server.listen({ onUnhandledRequest: "bypass" });
-  }
+  await ensureMockServer();
 }

--- a/src/lib/api/api.ts
+++ b/src/lib/api/api.ts
@@ -1,4 +1,5 @@
 import { ACCESS_TOKEN_COOKIE } from "@/lib/auth/cookie-constants";
+import { isMockModeEnabled } from "@/mocks/is-mock-mode-enabled";
 
 import {
   API_URL,
@@ -19,10 +20,6 @@ interface RequestOptions {
 }
 
 const FRONTEND_ORIGIN = process.env.FRONTEND_ORIGIN ?? process.env.NEXT_PUBLIC_FRONTEND_ORIGIN;
-
-function isMockModeEnabled(): boolean {
-  return process.env.NEXT_PUBLIC_USE_MOCK === "true";
-}
 
 function toMockApiEndpoint(endpoint: string): string {
   if (/^\/api(?:\/|$)/.test(endpoint)) return endpoint;

--- a/src/lib/api/api.ts
+++ b/src/lib/api/api.ts
@@ -125,7 +125,8 @@ async function buildHeaders(
   }
 
   // 서버 사이드에서만 httpOnly 쿠키 접근 가능
-  if (isServer && !options?.skipAuth) {
+  // Mock 모드에서는 MSW가 인증 응답을 제공하므로 request scope 쿠키 접근을 생략한다.
+  if (isServer && !options?.skipAuth && !isMockModeEnabled()) {
     // 서버에서 내부 /api 호출 시에는 Authorization 대신 현재 요청의 쿠키를 전달한다.
     if (isLocalApiEndpoint && !headers.Cookie) {
       const requestHeaders = await getHeadersFn();

--- a/src/lib/api/api.ts
+++ b/src/lib/api/api.ts
@@ -20,6 +20,23 @@ interface RequestOptions {
 
 const FRONTEND_ORIGIN = process.env.FRONTEND_ORIGIN ?? process.env.NEXT_PUBLIC_FRONTEND_ORIGIN;
 
+function isMockModeEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_USE_MOCK === "true";
+}
+
+function toMockApiEndpoint(endpoint: string): string {
+  if (/^\/api(?:\/|$)/.test(endpoint)) return endpoint;
+
+  return `/api${endpoint.startsWith("/") ? endpoint : `/${endpoint}`}`;
+}
+
+async function ensureServerMockIfNeeded(isServer: boolean): Promise<void> {
+  if (!isServer || !isMockModeEnabled()) return;
+
+  const { ensureMockServer } = await import("@/mocks/server-control");
+  await ensureMockServer();
+}
+
 // next/headers 모듈 캐싱 — 매 요청마다 동적 import를 반복하지 않음
 let cachedCookiesFn:
   | (() => Promise<{ get: (name: string) => { value: string } | undefined }>)
@@ -55,11 +72,11 @@ function buildUrl(endpoint: string, isServer: boolean, params?: RequestOptions["
   } else if (isServer) {
     const isLocalApiEndpoint = /^\/api(?:\/|$)/.test(endpoint);
 
-    if (isLocalApiEndpoint) {
+    if (isLocalApiEndpoint || isMockModeEnabled()) {
       if (!FRONTEND_ORIGIN) {
         throw new Error("Frontend origin is not configured for /api endpoints");
       }
-      url = new URL(endpoint, FRONTEND_ORIGIN);
+      url = new URL(isMockModeEnabled() ? toMockApiEndpoint(endpoint) : endpoint, FRONTEND_ORIGIN);
     } else {
       const baseUrl = SERVER_API_URL || API_URL;
       if (!baseUrl) {
@@ -140,6 +157,9 @@ async function createRequestContext(
   const hasBody = data !== undefined && method !== "GET";
   const isFormData = data instanceof FormData;
   const isRawBody = data instanceof ArrayBuffer || ArrayBuffer.isView(data);
+
+  await ensureServerMockIfNeeded(isServer);
+
   const url = buildUrl(endpoint, isServer, options?.params);
   const headers = await buildHeaders(isServer, endpoint, options, hasBody, isFormData);
 

--- a/src/lib/auth/prepare-auth-me-query.ts
+++ b/src/lib/auth/prepare-auth-me-query.ts
@@ -1,4 +1,5 @@
 import { memberKeys, memberQueries } from "@/features/member/hooks/useMemberHooks";
+import { isMockModeEnabled } from "@/mocks/is-mock-mode-enabled";
 
 import { getServerAuthCookieState } from "./auth-cookie-state";
 
@@ -6,7 +7,7 @@ import type { QueryClient } from "@tanstack/react-query";
 
 export async function prepareAuthMeQuery(queryClient: QueryClient) {
   const { hasAuthCookies } = await getServerAuthCookieState();
-  const shouldUseMockAuth = process.env.NEXT_PUBLIC_USE_MOCK === "true";
+  const shouldUseMockAuth = isMockModeEnabled();
   const effectiveHasAuthCookies = hasAuthCookies || shouldUseMockAuth;
 
   if (!effectiveHasAuthCookies) {

--- a/src/lib/auth/prepare-auth-me-query.ts
+++ b/src/lib/auth/prepare-auth-me-query.ts
@@ -6,9 +6,11 @@ import type { QueryClient } from "@tanstack/react-query";
 
 export async function prepareAuthMeQuery(queryClient: QueryClient) {
   const { hasAuthCookies } = await getServerAuthCookieState();
+  const shouldUseMockAuth = process.env.NEXT_PUBLIC_USE_MOCK === "true";
+  const effectiveHasAuthCookies = hasAuthCookies || shouldUseMockAuth;
 
-  if (!hasAuthCookies) {
-    return { hasAuthCookies };
+  if (!effectiveHasAuthCookies) {
+    return { hasAuthCookies: false };
   }
 
   try {
@@ -17,5 +19,5 @@ export async function prepareAuthMeQuery(queryClient: QueryClient) {
     queryClient.removeQueries({ queryKey: memberKeys.me(), exact: true });
   }
 
-  return { hasAuthCookies };
+  return { hasAuthCookies: effectiveHasAuthCookies };
 }

--- a/src/mocks/browser.ts
+++ b/src/mocks/browser.ts
@@ -1,0 +1,5 @@
+import { setupWorker } from "msw/browser";
+
+import { handlers } from "./handlers";
+
+export const worker = setupWorker(...handlers);

--- a/src/mocks/handlers/auth.ts
+++ b/src/mocks/handlers/auth.ts
@@ -3,12 +3,12 @@ import { http, HttpResponse } from "msw";
 import { ok } from "./utils";
 
 export const authHandlers = [
-  http.get("*/api/auth/login", () => {
-    return HttpResponse.redirect(new URL("/", "http://localhost:3000"));
+  http.get("*/api/auth/login", ({ request }) => {
+    return HttpResponse.redirect(new URL("/", request.url));
   }),
 
-  http.get("*/api/auth/callback/:provider", () => {
-    return HttpResponse.redirect(new URL("/", "http://localhost:3000"));
+  http.get("*/api/auth/callback/:provider", ({ request }) => {
+    return HttpResponse.redirect(new URL("/", request.url));
   }),
 
   http.post("*/api/auth/logout", () => {

--- a/src/mocks/handlers/auth.ts
+++ b/src/mocks/handlers/auth.ts
@@ -1,0 +1,17 @@
+import { http, HttpResponse } from "msw";
+
+import { ok } from "./utils";
+
+export const authHandlers = [
+  http.get("*/api/auth/login", () => {
+    return HttpResponse.redirect(new URL("/", "http://localhost:3000"));
+  }),
+
+  http.get("*/api/auth/callback/:provider", () => {
+    return HttpResponse.redirect(new URL("/", "http://localhost:3000"));
+  }),
+
+  http.post("*/api/auth/logout", () => {
+    return HttpResponse.json(ok(null));
+  }),
+];

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -1,0 +1,3 @@
+import { sessionHandlers } from "./session";
+
+export const handlers = [...sessionHandlers];

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -1,3 +1,11 @@
+import { authHandlers } from "./auth";
+import { memberHandlers } from "./member";
 import { sessionHandlers } from "./session";
 
-export const handlers = [...sessionHandlers];
+export const handlerRegistry = [
+  { name: "auth", handlers: authHandlers },
+  { name: "member", handlers: memberHandlers },
+  { name: "session", handlers: sessionHandlers },
+] as const;
+
+export const handlers = handlerRegistry.flatMap(({ handlers }) => handlers);

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -2,6 +2,7 @@ import { authHandlers } from "./auth";
 import { memberHandlers } from "./member";
 import { mockControlHandlers } from "./mock-control";
 import { sessionHandlers } from "./session";
+import { sseHandlers } from "./sse";
 import { taskHandlers } from "./task";
 
 export const handlerRegistry = [
@@ -9,6 +10,7 @@ export const handlerRegistry = [
   { name: "member", handlers: memberHandlers },
   { name: "session", handlers: sessionHandlers },
   { name: "task", handlers: taskHandlers },
+  { name: "sse", handlers: sseHandlers },
   { name: "mock-control", handlers: mockControlHandlers },
 ] as const;
 

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -1,11 +1,15 @@
 import { authHandlers } from "./auth";
 import { memberHandlers } from "./member";
+import { mockControlHandlers } from "./mock-control";
 import { sessionHandlers } from "./session";
+import { taskHandlers } from "./task";
 
 export const handlerRegistry = [
   { name: "auth", handlers: authHandlers },
   { name: "member", handlers: memberHandlers },
   { name: "session", handlers: sessionHandlers },
+  { name: "task", handlers: taskHandlers },
+  { name: "mock-control", handlers: mockControlHandlers },
 ] as const;
 
 export const handlers = handlerRegistry.flatMap(({ handlers }) => handlers);

--- a/src/mocks/handlers/json.ts
+++ b/src/mocks/handlers/json.ts
@@ -1,0 +1,50 @@
+export class MockJsonParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MockJsonParseError";
+  }
+}
+
+export function parseRequiredJsonText<T>(text: string, context: string): T {
+  if (!text) {
+    throw new MockJsonParseError(`${context} payload is required`);
+  }
+
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    throw new MockJsonParseError(`${context} payload must be valid JSON`);
+  }
+}
+
+export async function readRequiredJson<T>(request: Request, context: string): Promise<T> {
+  return parseRequiredJsonText<T>(await request.text(), context);
+}
+
+export async function readRequiredMultipartJsonPart<T>(
+  request: Request,
+  key: string,
+  context: string
+): Promise<T> {
+  const formData = await request.formData();
+  const part = formData.get(key);
+  if (!(part instanceof Blob)) {
+    throw new MockJsonParseError(`${context} ${key} part is required`);
+  }
+
+  return parseRequiredJsonText<T>(await part.text(), context);
+}
+
+export async function requireMultipartPart(
+  request: Request,
+  key: string,
+  context: string
+): Promise<FormDataEntryValue> {
+  const formData = await request.formData();
+  const part = formData.get(key);
+  if (!part) {
+    throw new MockJsonParseError(`${context} ${key} part is required`);
+  }
+
+  return part;
+}

--- a/src/mocks/handlers/member.ts
+++ b/src/mocks/handlers/member.ts
@@ -1,0 +1,161 @@
+import { http, HttpResponse } from "msw";
+
+import type {
+  MemberEditInfo,
+  MemberProfileView,
+  MemberReportSessions,
+  MemberReportStats,
+} from "@/features/member/types";
+
+import { MockJsonParseError, readRequiredJson, requireMultipartPart } from "./json";
+import { fail, ok } from "./utils";
+
+const MOCK_ME: MemberProfileView = {
+  id: 1,
+  nickname: "모각작러",
+  profileImageUrl: null,
+  email: "mock@gak.today",
+  bio: "MSW 테스트 계정",
+  socialProvider: "google",
+  totalParticipationTime: 7200,
+  focusedTime: 5400,
+  focusRate: 75,
+  totalTodoCount: 8,
+  completedTodoCount: 5,
+  todoCompletionRate: 63,
+  participationSessionCount: 1,
+  firstLogin: false,
+  firstInterestCategory: "DEVELOPMENT",
+  secondInterestCategory: "DESIGN",
+  thirdInterestCategory: "PLANNING_PM",
+};
+
+const MOCK_ME_EDIT: MemberEditInfo = {
+  id: MOCK_ME.id,
+  nickname: MOCK_ME.nickname,
+  profileImageUrl: MOCK_ME.profileImageUrl ?? "",
+  email: MOCK_ME.email,
+  bio: MOCK_ME.bio,
+  firstInterestCategory: "DEVELOPMENT",
+  secondInterestCategory: "DESIGN",
+  thirdInterestCategory: "PLANNING_PM",
+};
+
+const MOCK_REPORT_STATS: MemberReportStats = {
+  focusedTime: MOCK_ME.focusedTime,
+  totalParticipationTime: MOCK_ME.totalParticipationTime,
+  todoCompletionRate: MOCK_ME.todoCompletionRate,
+  focusRate: MOCK_ME.focusRate,
+  sessionParticipationStats: [{ categoryName: "DEVELOPMENT", count: 1, rate: 100 }],
+  receivedEmojis: [
+    { emojiName: "HEART", count: 3 },
+    { emojiName: "STAR", count: 1 },
+  ],
+};
+
+const MOCK_REPORT_SESSIONS: MemberReportSessions = {
+  sessions: [
+    {
+      sessionId: "900",
+      title: "같이 사이드 프로젝트 완성해봐요",
+      category: "DEVELOPMENT",
+      currentCount: 3,
+      maxCapacity: 6,
+      durationTime: 7200,
+      startTime: new Date(Date.now() - 30 * 60 * 1000).toISOString(),
+      focusedTime: 5400,
+      focusRate: 75,
+      todoCompletionRate: 63,
+    },
+  ],
+  totalPage: 1,
+  listSize: 1,
+  totalElements: 1,
+  first: true,
+  last: true,
+};
+
+function badRequestJson(error: unknown) {
+  if (error instanceof MockJsonParseError) {
+    return HttpResponse.json(fail("COMMON400", error.message, "BAD_REQUEST"), { status: 400 });
+  }
+
+  throw error;
+}
+
+export const memberHandlers = [
+  http.get("*/api/members/me/profile", () => {
+    return HttpResponse.json(ok(MOCK_ME));
+  }),
+
+  http.get("*/api/members/me/edit", () => {
+    return HttpResponse.json(ok(MOCK_ME_EDIT));
+  }),
+
+  http.patch("*/api/members/me/profile-image", async ({ request }) => {
+    try {
+      await requireMultipartPart(request, "profileImage", "member profile image update");
+      return HttpResponse.json(ok(MOCK_ME_EDIT));
+    } catch (error) {
+      return badRequestJson(error);
+    }
+  }),
+
+  http.delete("*/api/members/me/profile-image", () => {
+    return HttpResponse.json(ok(null));
+  }),
+
+  http.patch("*/api/members/me/nickname", async ({ request }) => {
+    try {
+      const body = await readRequiredJson<{ nickname: string }>(request, "member nickname update");
+      return HttpResponse.json(ok({ ...MOCK_ME_EDIT, nickname: body.nickname }));
+    } catch (error) {
+      return badRequestJson(error);
+    }
+  }),
+
+  http.patch("*/api/members/me", async ({ request }) => {
+    try {
+      const body = await readRequiredJson<Partial<MemberEditInfo>>(
+        request,
+        "member profile update"
+      );
+      return HttpResponse.json(ok({ ...MOCK_ME_EDIT, ...body }));
+    } catch (error) {
+      return badRequestJson(error);
+    }
+  }),
+
+  http.patch("*/api/members/me/email", async ({ request }) => {
+    try {
+      const body = await readRequiredJson<{ email: string | null }>(request, "member email update");
+      return HttpResponse.json(ok({ ...MOCK_ME_EDIT, email: body.email }));
+    } catch (error) {
+      return badRequestJson(error);
+    }
+  }),
+
+  http.patch("*/api/members/me/interest-categories", async ({ request }) => {
+    try {
+      const body = await readRequiredJson<Partial<MemberEditInfo>>(
+        request,
+        "member interest categories update"
+      );
+      return HttpResponse.json(ok({ ...MOCK_ME_EDIT, ...body }));
+    } catch (error) {
+      return badRequestJson(error);
+    }
+  }),
+
+  http.get("*/api/members/me/report-stats", () => {
+    return HttpResponse.json(ok(MOCK_REPORT_STATS));
+  }),
+
+  http.get("*/api/members/me/report-sessions", () => {
+    return HttpResponse.json(ok(MOCK_REPORT_SESSIONS));
+  }),
+
+  http.delete("*/api/members/me", () => {
+    return HttpResponse.json(ok(null));
+  }),
+];

--- a/src/mocks/handlers/member.ts
+++ b/src/mocks/handlers/member.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from "msw";
 
+import { MEMBER_PROFILE_IMAGE_FORM_KEY } from "@/features/member/api";
 import type {
   MemberEditInfo,
   MemberProfileView,
@@ -94,7 +95,11 @@ export const memberHandlers = [
 
   http.patch("*/api/members/me/profile-image", async ({ request }) => {
     try {
-      await requireMultipartPart(request, "profileImage", "member profile image update");
+      await requireMultipartPart(
+        request,
+        MEMBER_PROFILE_IMAGE_FORM_KEY,
+        "member profile image update"
+      );
       return HttpResponse.json(ok(MOCK_ME_EDIT));
     } catch (error) {
       return badRequestJson(error);

--- a/src/mocks/handlers/mock-control.ts
+++ b/src/mocks/handlers/mock-control.ts
@@ -1,0 +1,11 @@
+import { http, HttpResponse } from "msw";
+
+import { resetMockSessions } from "./session-state";
+import { ok } from "./utils";
+
+export const mockControlHandlers = [
+  http.post("*/api/mock/reset", () => {
+    resetMockSessions();
+    return HttpResponse.json(ok(null));
+  }),
+];

--- a/src/mocks/handlers/session-state.ts
+++ b/src/mocks/handlers/session-state.ts
@@ -351,10 +351,9 @@ function calculateFocusRate(result?: MockMemberResult): number {
 }
 
 function applyMemberDerivedRates(member: MockSessionMember): MockSessionMember {
-  const focusRate = calculateFocusRate(member.result);
   return {
     ...member,
-    focusRate: focusRate || member.focusRate,
+    focusRate: member.result ? calculateFocusRate(member.result) : member.focusRate,
     achievementRate: calculateAchievementRate(member),
   };
 }
@@ -546,7 +545,6 @@ export function submitMockSessionResult(
     totalFocusSeconds: body.totalFocusSeconds,
     overallSeconds: body.overallSeconds,
   };
-  member.focusRate = calculateFocusRate(member.result);
   member.achievementRate = calculateAchievementRate(member);
   if (!session.members.find((candidate) => candidate.memberId === member.memberId)) {
     session.members.push(member);

--- a/src/mocks/handlers/session-state.ts
+++ b/src/mocks/handlers/session-state.ts
@@ -325,7 +325,8 @@ function getSessionOrThrow(sessionId: number): MockSessionRecord {
 }
 
 function getMemberOrDefault(session: MockSessionRecord): MockSessionMember {
-  if (session.members[0]) return session.members[0];
+  const currentMember = session.members.find((member) => member.memberId === MOCK_MEMBER_ID);
+  if (currentMember) return currentMember;
 
   return {
     memberId: MOCK_MEMBER_ID,

--- a/src/mocks/handlers/session-state.ts
+++ b/src/mocks/handlers/session-state.ts
@@ -1,0 +1,737 @@
+import type {
+  CreateSessionRequest,
+  CreateSessionResponse,
+  EmojiType,
+  InProgressEventData,
+  InProgressMemberStatus,
+  JoinSessionRequest,
+  JoinSessionResponse,
+  MemberEmojiResult,
+  MyReportResponse,
+  SessionDetailResponse,
+  SessionListParams,
+  SessionListResponse,
+  SessionReportResponse,
+  SubmitSessionResultRequest,
+  SubmitSessionResultResponse,
+  ToggleMyStatusResponse,
+  WaitingRoomResponse,
+} from "@/features/session/types";
+import type { CreateSubtaskItem, CreateSubtaskResponse } from "@/features/task/api";
+import { getCategoryLabel, type Category } from "@/lib/constants/category";
+
+const MOCK_MEMBER_ID = 1;
+const MOCK_NICKNAME = "모각작러";
+
+type MockSessionStatus = "WAITING" | "IN_PROGRESS" | "COMPLETED";
+
+interface MockTodo {
+  subtaskId: number;
+  content: string;
+  isCompleted: boolean;
+}
+
+interface MockMemberResult {
+  totalFocusSeconds: number;
+  overallSeconds: number;
+}
+
+interface MockSessionMember {
+  memberId: number;
+  nickname: string;
+  profileImageUrl?: string;
+  role: "HOST" | "PARTICIPANT";
+  focusRate: number;
+  achievementRate: number;
+  status: InProgressMemberStatus;
+  task: {
+    taskId: number;
+    goal: string;
+    todos: MockTodo[];
+  } | null;
+  result?: MockMemberResult;
+  emojiResult: MemberEmojiResult;
+}
+
+interface MockSessionRecord {
+  sessionId: number;
+  category: Category;
+  title: string;
+  hostNickname: string;
+  status: MockSessionStatus;
+  maxParticipants: number;
+  sessionDurationMinutes: number;
+  startTime: string;
+  imageUrl: string;
+  summary: string;
+  notice: string;
+  requiredFocusRate?: number;
+  requiredAchievementRate?: number;
+  members: MockSessionMember[];
+}
+
+let nextSessionId = 901;
+let nextTaskId = 1000;
+let nextSubtaskId = 5000;
+let sessions = createInitialSessions();
+
+export class MockSessionNotFoundError extends Error {
+  constructor(sessionId: number) {
+    super(`Mock session not found: ${sessionId}`);
+    this.name = "MockSessionNotFoundError";
+  }
+}
+
+export class MockTaskNotFoundError extends Error {
+  constructor(taskId: number) {
+    super(`Mock task not found: ${taskId}`);
+    this.name = "MockTaskNotFoundError";
+  }
+}
+
+export class MockSubtaskNotFoundError extends Error {
+  constructor(subtaskId: number) {
+    super(`Mock subtask not found: ${subtaskId}`);
+    this.name = "MockSubtaskNotFoundError";
+  }
+}
+
+export class MockMemberNotFoundError extends Error {
+  constructor(memberId: number) {
+    super(`Mock member not found: ${memberId}`);
+    this.name = "MockMemberNotFoundError";
+  }
+}
+
+function createInitialSessions(): MockSessionRecord[] {
+  return [
+    {
+      sessionId: 900,
+      category: "DEVELOPMENT",
+      title: "같이 사이드 프로젝트 완성해봐요",
+      hostNickname: MOCK_NICKNAME,
+      status: "IN_PROGRESS",
+      maxParticipants: 10,
+      sessionDurationMinutes: 120,
+      startTime: new Date(Date.now() - 30 * 60 * 1000).toISOString(),
+      imageUrl: "",
+      summary: "각자 맡은 기능 구현 후 PR 올리기",
+      notice: "마이크 켜도 됩니다. 편하게 오세요!",
+      requiredFocusRate: 60,
+      requiredAchievementRate: 50,
+      members: [
+        {
+          memberId: MOCK_MEMBER_ID,
+          nickname: MOCK_NICKNAME,
+          role: "HOST",
+          focusRate: 85,
+          achievementRate: 60,
+          status: "FOCUSED",
+          task: {
+            taskId: 1,
+            goal: "MSW 로컬 mock 백엔드 완성하기",
+            todos: [
+              { subtaskId: 1, content: "세션 상세 mock 데이터 확인", isCompleted: true },
+              { subtaskId: 2, content: "나의 목표 카드 UI 점검", isCompleted: true },
+              { subtaskId: 3, content: "참여자 목록 10명 노출 확인", isCompleted: true },
+              { subtaskId: 4, content: "할 일 완료 토글 동작 확인", isCompleted: false },
+              { subtaskId: 5, content: "세션 종료 후 리포트 확인", isCompleted: false },
+            ],
+          },
+          emojiResult: emptyEmojiResult(),
+        },
+        {
+          memberId: 2,
+          nickname: "기획하는 다람쥐",
+          role: "PARTICIPANT",
+          focusRate: 78,
+          achievementRate: 40,
+          status: "FOCUSED",
+          task: {
+            taskId: 2,
+            goal: "서비스 플로우 문서 정리",
+            todos: [
+              { subtaskId: 6, content: "로그인 플로우 정리", isCompleted: true },
+              { subtaskId: 7, content: "세션 생성 플로우 정리", isCompleted: false },
+            ],
+          },
+          emojiResult: emptyEmojiResult(),
+        },
+        {
+          memberId: 3,
+          nickname: "디자인하는 고양이",
+          role: "PARTICIPANT",
+          focusRate: 92,
+          achievementRate: 100,
+          status: "FOCUSED",
+          task: {
+            taskId: 3,
+            goal: "세션 화면 QA 체크리스트 만들기",
+            todos: [
+              { subtaskId: 8, content: "대기방 화면 캡처", isCompleted: true },
+              { subtaskId: 9, content: "진행 중 화면 캡처", isCompleted: true },
+            ],
+          },
+          emojiResult: emptyEmojiResult(),
+        },
+        {
+          memberId: 4,
+          nickname: "개발하는 판다",
+          role: "PARTICIPANT",
+          focusRate: 66,
+          achievementRate: 50,
+          status: "REST",
+          task: {
+            taskId: 4,
+            goal: "API 응답 타입 점검",
+            todos: [
+              { subtaskId: 10, content: "session 타입 확인", isCompleted: true },
+              { subtaskId: 11, content: "member 타입 확인", isCompleted: false },
+            ],
+          },
+          emojiResult: emptyEmojiResult(),
+        },
+        {
+          memberId: 5,
+          nickname: "테스트하는 여우",
+          role: "PARTICIPANT",
+          focusRate: 73,
+          achievementRate: 50,
+          status: "FOCUSED",
+          task: {
+            taskId: 5,
+            goal: "MSW 테스트 케이스 보강",
+            todos: [
+              { subtaskId: 12, content: "coverage 테스트 확인", isCompleted: true },
+              { subtaskId: 13, content: "state 테스트 확인", isCompleted: false },
+            ],
+          },
+          emojiResult: emptyEmojiResult(),
+        },
+        {
+          memberId: 6,
+          nickname: "문서쓰는 코알라",
+          role: "PARTICIPANT",
+          focusRate: 81,
+          achievementRate: 0,
+          status: "FOCUSED",
+          task: {
+            taskId: 6,
+            goal: "README용 mock 사용법 초안 작성",
+            todos: [
+              { subtaskId: 14, content: "실행 명령어 정리", isCompleted: false },
+              { subtaskId: 15, content: "reset API 설명 추가", isCompleted: false },
+            ],
+          },
+          emojiResult: emptyEmojiResult(),
+        },
+        {
+          memberId: 7,
+          nickname: "리뷰하는 수달",
+          role: "PARTICIPANT",
+          focusRate: 88,
+          achievementRate: 50,
+          status: "FOCUSED",
+          task: {
+            taskId: 7,
+            goal: "코드 리뷰 체크포인트 확인",
+            todos: [
+              { subtaskId: 16, content: "strict unhandled 정책 확인", isCompleted: true },
+              { subtaskId: 17, content: "SSE 이벤트명 확인", isCompleted: false },
+            ],
+          },
+          emojiResult: emptyEmojiResult(),
+        },
+        {
+          memberId: 8,
+          nickname: "집중하는 부엉이",
+          role: "PARTICIPANT",
+          focusRate: 95,
+          achievementRate: 100,
+          status: "FOCUSED",
+          task: {
+            taskId: 8,
+            goal: "개인 작업 몰입하기",
+            todos: [
+              { subtaskId: 18, content: "핵심 작업 1 완료", isCompleted: true },
+              { subtaskId: 19, content: "핵심 작업 2 완료", isCompleted: true },
+            ],
+          },
+          emojiResult: emptyEmojiResult(),
+        },
+        {
+          memberId: 9,
+          nickname: "정리하는 햄스터",
+          role: "PARTICIPANT",
+          focusRate: 69,
+          achievementRate: 50,
+          status: "REST",
+          task: {
+            taskId: 9,
+            goal: "회의 메모 정리",
+            todos: [
+              { subtaskId: 20, content: "논의 내용 요약", isCompleted: true },
+              { subtaskId: 21, content: "후속 액션 정리", isCompleted: false },
+            ],
+          },
+          emojiResult: emptyEmojiResult(),
+        },
+        {
+          memberId: 10,
+          nickname: "배포보는 라쿤",
+          role: "PARTICIPANT",
+          focusRate: 76,
+          achievementRate: 0,
+          status: "FOCUSED",
+          task: {
+            taskId: 10,
+            goal: "로컬 QA 환경 확인",
+            todos: [
+              { subtaskId: 22, content: "mock mode 실행", isCompleted: false },
+              { subtaskId: 23, content: "브라우저 플로우 확인", isCompleted: false },
+            ],
+          },
+          emojiResult: emptyEmojiResult(),
+        },
+      ],
+    },
+  ];
+}
+
+function emptyEmojiResult(): MemberEmojiResult {
+  return {
+    heartCount: 0,
+    starCount: 0,
+    thumbsUpCount: 0,
+    thumbsDownCount: 0,
+  };
+}
+
+function toDetailStatus(status: MockSessionStatus): SessionDetailResponse["status"] {
+  if (status === "WAITING") return "대기";
+  if (status === "COMPLETED") return "종료";
+  return "진행중";
+}
+
+function toListStatus(status: MockSessionStatus): "WAITING" | "IN_PROGRESS" {
+  return status === "WAITING" ? "WAITING" : "IN_PROGRESS";
+}
+
+function getSessionOrThrow(sessionId: number): MockSessionRecord {
+  const session = sessions.find((candidate) => candidate.sessionId === sessionId);
+  if (!session) throw new MockSessionNotFoundError(sessionId);
+
+  return session;
+}
+
+function getMemberOrDefault(session: MockSessionRecord): MockSessionMember {
+  if (session.members[0]) return session.members[0];
+
+  return {
+    memberId: MOCK_MEMBER_ID,
+    nickname: MOCK_NICKNAME,
+    role: "HOST",
+    focusRate: 0,
+    achievementRate: 0,
+    status: "FOCUSED",
+    task: null,
+    emojiResult: emptyEmojiResult(),
+  };
+}
+
+function calculateAchievementRate(member: MockSessionMember): number {
+  const todos = member.task?.todos ?? [];
+  if (todos.length === 0) return 0;
+  return Math.round((todos.filter((todo) => todo.isCompleted).length / todos.length) * 100);
+}
+
+function calculateFocusRate(result?: MockMemberResult): number {
+  if (!result || result.overallSeconds <= 0) return 0;
+  return Math.round((result.totalFocusSeconds / result.overallSeconds) * 100);
+}
+
+function applyMemberDerivedRates(member: MockSessionMember): MockSessionMember {
+  const focusRate = calculateFocusRate(member.result);
+  return {
+    ...member,
+    focusRate: focusRate || member.focusRate,
+    achievementRate: calculateAchievementRate(member),
+  };
+}
+
+export function resetMockSessions(): void {
+  nextSessionId = 901;
+  nextTaskId = 1000;
+  nextSubtaskId = 5000;
+  sessions = createInitialSessions();
+}
+
+export function createMockSession(body: CreateSessionRequest): CreateSessionResponse {
+  const sessionId = nextSessionId++;
+  sessions.unshift({
+    sessionId,
+    category: body.category,
+    title: body.title,
+    hostNickname: MOCK_NICKNAME,
+    status: "WAITING",
+    maxParticipants: body.maxParticipants,
+    sessionDurationMinutes: body.sessionDurationMinutes,
+    startTime: body.startTime,
+    imageUrl: "",
+    summary: body.summary,
+    notice: body.notice,
+    requiredFocusRate: body.requiredFocusRate,
+    requiredAchievementRate: body.requiredAchievementRate,
+    members: [],
+  });
+
+  return { createdSessionId: sessionId };
+}
+
+export function getMockSessionList(params: SessionListParams = {}): SessionListResponse {
+  const keyword = params.keyword?.trim().toLowerCase();
+  const page = Math.max((params.page ?? 1) - 1, 0);
+  const size = params.size ?? 10;
+  const filteredSessions = sessions.filter((session) => {
+    const matchesKeyword = keyword
+      ? `${session.title} ${session.summary}`.toLowerCase().includes(keyword)
+      : true;
+    const matchesCategory =
+      params.category && params.category !== "ALL" ? session.category === params.category : true;
+    return matchesKeyword && matchesCategory;
+  });
+  const pagedSessions = filteredSessions.slice(page * size, page * size + size);
+  const totalPage = Math.ceil(filteredSessions.length / size);
+
+  return {
+    listSize: pagedSessions.length,
+    totalPage,
+    totalElements: filteredSessions.length,
+    isFirst: page === 0,
+    isLast: totalPage === 0 || page >= totalPage - 1,
+    sessions: pagedSessions.map((session) => ({
+      sessionId: session.sessionId,
+      category: session.category,
+      title: session.title,
+      hostNickname: session.hostNickname,
+      status: toListStatus(session.status),
+      currentParticipants: session.members.length,
+      maxParticipants: session.maxParticipants,
+      sessionDurationMinutes: session.sessionDurationMinutes,
+      startTime: session.startTime,
+      imageUrl: session.imageUrl,
+    })),
+  };
+}
+
+export function getMockSessionDetail(sessionId: number): SessionDetailResponse {
+  const session = getSessionOrThrow(sessionId);
+  return {
+    sessionId: session.sessionId,
+    category: getCategoryLabel(session.category),
+    title: session.title,
+    hostNickname: session.hostNickname,
+    status: toDetailStatus(session.status),
+    currentParticipants: session.members.length,
+    maxParticipants: session.maxParticipants,
+    sessionDurationMinutes: session.sessionDurationMinutes,
+    startTime: session.startTime,
+    imageUrl: session.imageUrl,
+    summary: session.summary,
+    notice: session.notice,
+    requiredFocusRate: session.requiredFocusRate,
+    requiredAchievementRate: session.requiredAchievementRate,
+  };
+}
+
+export function joinMockSession(sessionId: number, body: JoinSessionRequest): JoinSessionResponse {
+  const session = getSessionOrThrow(sessionId);
+  const existingMember = session.members.find((member) => member.memberId === MOCK_MEMBER_ID);
+  const task = {
+    taskId: existingMember?.task?.taskId ?? nextTaskId++,
+    goal: body.goal,
+    todos: body.todos.map((content) => ({
+      subtaskId: nextSubtaskId++,
+      content,
+      isCompleted: false,
+    })),
+  };
+
+  if (existingMember) {
+    existingMember.task = task;
+    existingMember.achievementRate = calculateAchievementRate(existingMember);
+  } else {
+    session.members.push({
+      memberId: MOCK_MEMBER_ID,
+      nickname: MOCK_NICKNAME,
+      role: session.members.length === 0 ? "HOST" : "PARTICIPANT",
+      focusRate: 0,
+      achievementRate: 0,
+      status: "FOCUSED",
+      task,
+      emojiResult: emptyEmojiResult(),
+    });
+  }
+
+  const joinedMember = session.members.find((member) => member.memberId === MOCK_MEMBER_ID)!;
+  return {
+    sessionId: session.sessionId,
+    memberId: joinedMember.memberId,
+    role: joinedMember.role,
+  };
+}
+
+export function getMockWaitingRoom(sessionId: number): WaitingRoomResponse {
+  const session = getSessionOrThrow(sessionId);
+  return {
+    participantCount: session.members.length,
+    members: session.members.map((member) => ({
+      memberId: member.memberId,
+      nickname: member.nickname,
+      profileImageUrl: member.profileImageUrl,
+      focusRate: member.focusRate,
+      achievementRate: member.achievementRate,
+      role: member.role,
+      task: member.task
+        ? {
+            taskId: member.task.taskId,
+            goal: member.task.goal,
+            todos: member.task.todos.map((todo) => ({
+              subtaskId: todo.subtaskId,
+              content: todo.content,
+            })),
+          }
+        : null,
+    })),
+  };
+}
+
+export function getMockInProgress(sessionId: number): InProgressEventData {
+  const session = getSessionOrThrow(sessionId);
+  if (session.status === "WAITING" && session.members.length > 0) {
+    session.status = "IN_PROGRESS";
+  }
+  const members = session.members.map(applyMemberDerivedRates);
+  const achievementSum = members.reduce((sum, member) => sum + member.achievementRate, 0);
+
+  return {
+    participantCount: members.length,
+    averageAchievementRate: members.length ? Math.round(achievementSum / members.length) : 0,
+    members: members.map((member) => ({
+      memberId: member.memberId,
+      nickname: member.nickname,
+      profileImageUrl: member.profileImageUrl,
+      role: member.role,
+      achievementRate: member.achievementRate,
+      status: member.status,
+      task: member.task
+        ? {
+            taskId: member.task.taskId,
+            goal: member.task.goal,
+            todos: member.task.todos.map((todo) => ({ ...todo })),
+          }
+        : null,
+    })),
+  };
+}
+
+export function submitMockSessionResult(
+  sessionId: number,
+  body: SubmitSessionResultRequest
+): SubmitSessionResultResponse {
+  const session = getSessionOrThrow(sessionId);
+  session.status = "COMPLETED";
+  const member = getMemberOrDefault(session);
+  member.result = {
+    totalFocusSeconds: body.totalFocusSeconds,
+    overallSeconds: body.overallSeconds,
+  };
+  member.focusRate = calculateFocusRate(member.result);
+  member.achievementRate = calculateAchievementRate(member);
+  if (!session.members.find((candidate) => candidate.memberId === member.memberId)) {
+    session.members.push(member);
+  }
+
+  return { sessionId: session.sessionId };
+}
+
+export function getMockMyReport(sessionId: number): MyReportResponse {
+  const session = getSessionOrThrow(sessionId);
+  const member = applyMemberDerivedRates(getMemberOrDefault(session));
+  return {
+    sessionId: session.sessionId,
+    currentParticipants: session.members.length,
+    sessionMemberResult: {
+      memberId: member.memberId,
+      nickname: member.nickname,
+      profileImageUrl: member.profileImageUrl,
+      role: member.role,
+      focusRate: member.focusRate,
+      totalFocusSeconds: member.result?.totalFocusSeconds ?? 0,
+      overallFocusSeconds: member.result?.overallSeconds ?? 0,
+      achievementRate: member.achievementRate,
+      task: member.task
+        ? {
+            taskId: member.task.taskId,
+            goal: member.task.goal,
+            todos: member.task.todos.map((todo) => ({ ...todo })),
+          }
+        : null,
+      emojiResult: member.emojiResult,
+    },
+  };
+}
+
+export function getMockSessionReport(sessionId: number): SessionReportResponse {
+  const session = getSessionOrThrow(sessionId);
+  const members = session.members.map(applyMemberDerivedRates);
+  const totalFocus = members.reduce(
+    (sum, member) => sum + (member.result?.totalFocusSeconds ?? 0),
+    0
+  );
+  const overall = members.reduce((sum, member) => sum + (member.result?.overallSeconds ?? 0), 0);
+  const achievement = members.reduce((sum, member) => sum + member.achievementRate, 0);
+  const focus = members.reduce((sum, member) => sum + member.focusRate, 0);
+  const count = members.length || 1;
+
+  return {
+    averageTotalFocusSeconds: Math.round(totalFocus / count),
+    averageOverallSeconds: Math.round(overall / count),
+    averageAchievementRate: Math.round(achievement / count),
+    averageFocusRate: Math.round(focus / count),
+    members: members.map((member) => ({
+      memberId: member.memberId,
+      nickname: member.nickname,
+      profileImageUrl: member.profileImageUrl,
+      role: member.role,
+      goal: member.task?.goal ?? "",
+      focusRate: member.focusRate,
+      achievementRate: member.achievementRate,
+    })),
+    emojiResult: members.reduce(
+      (acc, member) => ({
+        heartCount: acc.heartCount + member.emojiResult.heartCount,
+        starCount: acc.starCount + member.emojiResult.starCount,
+        thumbsUpCount: acc.thumbsUpCount + member.emojiResult.thumbsUpCount,
+        thumbsDownCount: acc.thumbsDownCount + member.emojiResult.thumbsDownCount,
+      }),
+      emptyEmojiResult()
+    ),
+  };
+}
+
+export function sendMockReaction(
+  sessionId: number,
+  targetMemberId: number,
+  emojiType: EmojiType
+): { targetMemberId: number; emojiType: EmojiType; result: string } {
+  const session = getSessionOrThrow(sessionId);
+  const member = session.members.find((candidate) => candidate.memberId === targetMemberId);
+  if (!member) throw new MockMemberNotFoundError(targetMemberId);
+
+  if (emojiType === "HEART") member.emojiResult.heartCount += 1;
+  if (emojiType === "STAR") member.emojiResult.starCount += 1;
+  if (emojiType === "THUMBS_UP") member.emojiResult.thumbsUpCount += 1;
+  if (emojiType === "THUMBS_DOWN") member.emojiResult.thumbsDownCount += 1;
+
+  return { targetMemberId, emojiType, result: "SUCCESS" };
+}
+
+export function toggleMockMyStatus(sessionId: number): ToggleMyStatusResponse {
+  const session = getSessionOrThrow(sessionId);
+  const member = getMemberOrDefault(session);
+  member.status = member.status === "FOCUSED" ? "REST" : "FOCUSED";
+  return { currentStatus: member.status };
+}
+
+function findTask(taskId: number): MockSessionMember["task"] | null {
+  for (const session of sessions) {
+    const task = session.members.find((member) => member.task?.taskId === taskId)?.task;
+    if (task) return task;
+  }
+  return null;
+}
+
+function findTodo(subtaskId: number): MockTodo | null {
+  for (const session of sessions) {
+    for (const member of session.members) {
+      const todo = member.task?.todos.find((candidate) => candidate.subtaskId === subtaskId);
+      if (todo) return todo;
+    }
+  }
+  return null;
+}
+
+function getTaskOrThrow(taskId: number): NonNullable<MockSessionMember["task"]> {
+  const task = findTask(taskId);
+  if (!task) throw new MockTaskNotFoundError(taskId);
+
+  return task;
+}
+
+function getTodoOrThrow(subtaskId: number): MockTodo {
+  const todo = findTodo(subtaskId);
+  if (!todo) throw new MockSubtaskNotFoundError(subtaskId);
+
+  return todo;
+}
+
+export function updateMockTaskGoal(taskId: number, goalContent: string): void {
+  getTaskOrThrow(taskId).goal = goalContent;
+}
+
+export function createMockSubtasks(
+  taskId: number,
+  subtasks: CreateSubtaskItem[]
+): CreateSubtaskResponse {
+  const task = getTaskOrThrow(taskId);
+
+  const subtaskIds = subtasks.map((subtask) => {
+    const subtaskId = nextSubtaskId++;
+    task.todos.push({
+      subtaskId,
+      content: subtask.todoContent,
+      isCompleted: false,
+    });
+    return subtaskId;
+  });
+
+  return { subtaskIds };
+}
+
+export function updateMockSubtask(subtaskId: number, todoContent: string): void {
+  getTodoOrThrow(subtaskId).content = todoContent;
+}
+
+export function deleteMockSubtask(subtaskId: number): void {
+  getTodoOrThrow(subtaskId);
+
+  for (const session of sessions) {
+    for (const member of session.members) {
+      if (member.task) {
+        member.task.todos = member.task.todos.filter((todo) => todo.subtaskId !== subtaskId);
+      }
+    }
+  }
+}
+
+export function toggleMockSubtaskCompletion(subtaskId: number): void {
+  const todo = getTodoOrThrow(subtaskId);
+  todo.isCompleted = !todo.isCompleted;
+}
+
+export function leaveMockSession(sessionId: number): void {
+  const session = getSessionOrThrow(sessionId);
+  session.members = session.members.filter((member) => member.memberId !== MOCK_MEMBER_ID);
+}
+
+export function kickMockSessionMembers(sessionId: number, memberIds: number[]): void {
+  const session = getSessionOrThrow(sessionId);
+  for (const memberId of memberIds) {
+    if (!session.members.some((member) => member.memberId === memberId)) {
+      throw new MockMemberNotFoundError(memberId);
+    }
+  }
+
+  session.members = session.members.filter((member) => !memberIds.includes(member.memberId));
+}

--- a/src/mocks/handlers/session.ts
+++ b/src/mocks/handlers/session.ts
@@ -1,261 +1,149 @@
 import { http, HttpResponse } from "msw";
 
 import type {
-  InProgressEventData,
-  SessionDetailResponse,
-  WaitingRoomResponse,
+  CreateSessionRequest,
+  JoinSessionRequest,
+  SendReactionRequest,
+  SessionListParams,
+  SubmitSessionResultRequest,
 } from "@/features/session/types";
-import type { ApiSuccessResponse } from "@/types/shared/types";
 
-// 브라우저 요청의 Referer 헤더에서 현재 페이지 URL의 ?scenario= 파라미터를 읽어 분기
-// SSR(instrumentation.ts / msw/node)에서는 Referer가 없으므로 'default' 반환
-function getScenario(request: Request): string {
-  const referer = request.headers.get("referer") ?? "";
+import { MockJsonParseError, readRequiredJson, readRequiredMultipartJsonPart } from "./json";
+import {
+  createMockSession,
+  getMockInProgress,
+  getMockMyReport,
+  getMockSessionDetail,
+  getMockSessionList,
+  getMockSessionReport,
+  getMockWaitingRoom,
+  joinMockSession,
+  kickMockSessionMembers,
+  leaveMockSession,
+  sendMockReaction,
+  submitMockSessionResult,
+  toggleMockMyStatus,
+  MockMemberNotFoundError,
+  MockSessionNotFoundError,
+} from "./session-state";
+import { fail, ok } from "./utils";
+
+function toSessionId(value: string | readonly string[] | undefined): number {
+  return Number(Array.isArray(value) ? value[0] : value);
+}
+
+async function sessionJson<T>(producer: () => T | Promise<T>) {
   try {
-    return new URL(referer).searchParams.get("scenario") ?? "default";
-  } catch {
-    return "default";
+    return HttpResponse.json(ok(await producer()));
+  } catch (error) {
+    if (error instanceof MockSessionNotFoundError) {
+      return HttpResponse.json(fail("SESSION404_1", "존재하지 않는 세션입니다.", "NOT_FOUND"), {
+        status: 404,
+      });
+    }
+    if (error instanceof MockMemberNotFoundError) {
+      return HttpResponse.json(fail("MEMBER404_1", "존재하지 않는 멤버입니다.", "NOT_FOUND"), {
+        status: 404,
+      });
+    }
+    if (error instanceof MockJsonParseError) {
+      return HttpResponse.json(fail("COMMON400", error.message, "BAD_REQUEST"), { status: 400 });
+    }
+
+    throw error;
   }
 }
 
-function ok<T>(result: T): ApiSuccessResponse<T> {
-  return { isSuccess: true, code: "COMMON200", message: "OK", result };
+function getListParams(request: Request): SessionListParams {
+  const url = new URL(request.url);
+  return {
+    keyword: url.searchParams.get("keyword") ?? undefined,
+    category: (url.searchParams.get("category") as SessionListParams["category"]) ?? undefined,
+    sort: (url.searchParams.get("sort") as SessionListParams["sort"]) ?? undefined,
+    startDate: url.searchParams.get("startDate") ?? undefined,
+    endDate: url.searchParams.get("endDate") ?? undefined,
+    page: url.searchParams.get("page") ? Number(url.searchParams.get("page")) : undefined,
+    size: url.searchParams.get("size") ? Number(url.searchParams.get("size")) : undefined,
+  };
 }
 
-// ============================================================
-// Mock 데이터
-// ============================================================
-
-const MOCK_DETAIL: Record<string, SessionDetailResponse> = {
-  default: {
-    sessionId: 1,
-    category: "개발",
-    title: "같이 사이드 프로젝트 완성해봐요",
-    hostNickname: "모각작러",
-    status: "진행중",
-    currentParticipants: 3,
-    maxParticipants: 6,
-    sessionDurationMinutes: 120,
-    startTime: new Date(Date.now() - 30 * 60 * 1000).toISOString(),
-    imageUrl: "",
-    summary: "각자 맡은 기능 구현 후 PR 올리기",
-    notice: "마이크 켜도 됩니다. 편하게 오세요!",
-    requiredFocusRate: 60,
-    requiredAchievementRate: 50,
-  },
-  empty: {
-    sessionId: 1,
-    category: "개발",
-    title: "혼자서 시작한 세션",
-    hostNickname: "모각작러",
-    status: "진행중",
-    currentParticipants: 0,
-    maxParticipants: 6,
-    sessionDurationMinutes: 120,
-    startTime: new Date(Date.now() - 10 * 60 * 1000).toISOString(),
-    imageUrl: "",
-    summary: "참여자가 없는 empty state 확인용",
-    notice: "",
-  },
-  ended: {
-    sessionId: 1,
-    category: "디자인",
-    title: "종료된 세션입니다",
-    hostNickname: "모각작러",
-    status: "종료",
-    currentParticipants: 4,
-    maxParticipants: 6,
-    sessionDurationMinutes: 90,
-    startTime: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
-    imageUrl: "",
-    summary: "세션이 종료된 상태의 UI 확인용",
-    notice: "",
-  },
-};
-
-const MOCK_IN_PROGRESS: Record<string, InProgressEventData> = {
-  default: {
-    participantCount: 3,
-    averageAchievementRate: 65,
-    members: [
-      {
-        memberId: 1,
-        nickname: "모각작러",
-        profileImageUrl: undefined,
-        role: "HOST",
-        achievementRate: 80,
-        status: "FOCUSED",
-        task: {
-          taskId: 1,
-          goal: "MSW 핸들러 작성 완료하기",
-          todos: [
-            { subtaskId: 1, content: "session 핸들러 작성", isCompleted: true },
-            { subtaskId: 2, content: "browser.ts 작성", isCompleted: false },
-            { subtaskId: 3, content: "server.ts 작성", isCompleted: false },
-          ],
-        },
-      },
-      {
-        memberId: 2,
-        nickname: "열공러",
-        profileImageUrl: undefined,
-        role: "PARTICIPANT",
-        achievementRate: 50,
-        status: "REST",
-        task: {
-          taskId: 2,
-          goal: "알고리즘 문제 5개 풀기",
-          todos: [
-            { subtaskId: 4, content: "BFS 문제 풀기", isCompleted: true },
-            { subtaskId: 5, content: "DP 문제 풀기", isCompleted: false },
-          ],
-        },
-      },
-      {
-        memberId: 3,
-        nickname: "디자인러",
-        profileImageUrl: undefined,
-        role: "PARTICIPANT",
-        achievementRate: 65,
-        status: "FOCUSED",
-        task: {
-          taskId: 3,
-          goal: "피그마 컴포넌트 정리",
-          todos: [{ subtaskId: 6, content: "버튼 컴포넌트 정리", isCompleted: true }],
-        },
-      },
-    ],
-  },
-  empty: {
-    participantCount: 0,
-    averageAchievementRate: 0,
-    members: [],
-  },
-  ended: {
-    participantCount: 4,
-    averageAchievementRate: 72,
-    members: [],
-  },
-};
-
-const MOCK_WAITING_ROOM: Record<string, WaitingRoomResponse> = {
-  default: {
-    participantCount: 3,
-    members: [
-      {
-        memberId: 1,
-        nickname: "모각작러",
-        profileImageUrl: undefined,
-        focusRate: 85,
-        achievementRate: 78,
-        role: "HOST",
-        task: {
-          taskId: 1,
-          goal: "MSW 핸들러 작성 완료하기",
-          todos: [
-            { subtaskId: 1, content: "session 핸들러 작성" },
-            { subtaskId: 2, content: "browser.ts 작성" },
-          ],
-        },
-      },
-      {
-        memberId: 2,
-        nickname: "열공러",
-        profileImageUrl: undefined,
-        focusRate: 70,
-        achievementRate: 60,
-        role: "PARTICIPANT",
-        task: null,
-      },
-      {
-        memberId: 3,
-        nickname: "디자인러",
-        profileImageUrl: undefined,
-        focusRate: 90,
-        achievementRate: 88,
-        role: "PARTICIPANT",
-        task: {
-          taskId: 3,
-          goal: "피그마 컴포넌트 정리",
-          todos: [{ subtaskId: 6, content: "버튼 컴포넌트 정리" }],
-        },
-      },
-    ],
-  },
-  empty: {
-    participantCount: 0,
-    members: [],
-  },
-  ended: {
-    participantCount: 4,
-    members: [],
-  },
-};
-
-// ============================================================
-// 핸들러
-// ============================================================
-
 export const sessionHandlers = [
-  // 세션 상세
-  http.get("/api/sessions/:sessionId", ({ request, params }) => {
-    const scenario = getScenario(request);
+  http.get("*/api/sessions", ({ request }) => {
+    return HttpResponse.json(ok(getMockSessionList(getListParams(request))));
+  }),
 
-    if (scenario === "error") {
-      return HttpResponse.json(
-        {
-          isSuccess: false,
-          code: "INTERNAL_ERROR",
-          message: "서버 오류가 발생했습니다.",
-          result: null,
-        },
-        { status: 500 }
-      );
-    }
-
-    const data = MOCK_DETAIL[scenario] ?? MOCK_DETAIL.default;
-    return HttpResponse.json(
-      ok({ ...data, sessionId: Number(params.sessionId) || data.sessionId })
+  http.post("*/api/sessions/create", ({ request }) => {
+    return sessionJson(async () =>
+      createMockSession(
+        await readRequiredMultipartJsonPart<CreateSessionRequest>(
+          request,
+          "request",
+          "session create"
+        )
+      )
     );
   }),
 
-  // 진행 중 참여자 상태
-  http.get("/api/sessions/:sessionId/in-progress", ({ request }) => {
-    const scenario = getScenario(request);
-
-    if (scenario === "error") {
-      return HttpResponse.json(
-        {
-          isSuccess: false,
-          code: "INTERNAL_ERROR",
-          message: "서버 오류가 발생했습니다.",
-          result: null,
-        },
-        { status: 500 }
-      );
-    }
-
-    const data = MOCK_IN_PROGRESS[scenario] ?? MOCK_IN_PROGRESS.default;
-    return HttpResponse.json(ok(data));
+  http.get("*/api/sessions/:sessionId", ({ params }) => {
+    return sessionJson(() => getMockSessionDetail(toSessionId(params.sessionId)));
   }),
 
-  // 대기방 참여자
-  http.get("/api/sessions/:sessionId/waiting-room", ({ request }) => {
-    const scenario = getScenario(request);
+  http.get("*/api/sessions/:sessionId/report", ({ params }) => {
+    return sessionJson(() => getMockSessionReport(toSessionId(params.sessionId)));
+  }),
 
-    if (scenario === "error") {
-      return HttpResponse.json(
-        {
-          isSuccess: false,
-          code: "INTERNAL_ERROR",
-          message: "서버 오류가 발생했습니다.",
-          result: null,
-        },
-        { status: 500 }
+  http.get("*/api/sessions/:sessionId/me/report", ({ params }) => {
+    return sessionJson(() => getMockMyReport(toSessionId(params.sessionId)));
+  }),
+
+  http.get("*/api/sessions/:sessionId/in-progress", ({ params }) => {
+    return sessionJson(() => getMockInProgress(toSessionId(params.sessionId)));
+  }),
+
+  http.get("*/api/sessions/:sessionId/waiting-room", ({ params }) => {
+    return sessionJson(() => getMockWaitingRoom(toSessionId(params.sessionId)));
+  }),
+
+  http.post("*/api/sessions/:sessionId/join", async ({ request, params }) => {
+    return sessionJson(async () => {
+      const body = await readRequiredJson<JoinSessionRequest>(request, "session join");
+      return joinMockSession(toSessionId(params.sessionId), body);
+    });
+  }),
+
+  http.post("*/api/sessions/:sessionId/reaction", async ({ request, params }) => {
+    return sessionJson(async () => {
+      const body = await readRequiredJson<SendReactionRequest>(request, "session reaction");
+      return sendMockReaction(toSessionId(params.sessionId), body.targetMemberId, body.emojiType);
+    });
+  }),
+
+  http.patch("*/api/sessions/:sessionId/me/status", ({ params }) => {
+    return sessionJson(() => toggleMockMyStatus(toSessionId(params.sessionId)));
+  }),
+
+  http.post("*/api/sessions/:sessionId/results", async ({ request, params }) => {
+    return sessionJson(async () => {
+      const body = await readRequiredJson<SubmitSessionResultRequest>(
+        request,
+        "session result submit"
       );
-    }
+      return submitMockSessionResult(toSessionId(params.sessionId), body);
+    });
+  }),
 
-    const data = MOCK_WAITING_ROOM[scenario] ?? MOCK_WAITING_ROOM.default;
-    return HttpResponse.json(ok(data));
+  http.delete("*/api/sessions/:sessionId/leave", ({ params }) => {
+    return sessionJson(() => {
+      leaveMockSession(toSessionId(params.sessionId));
+      return null;
+    });
+  }),
+
+  http.delete("*/api/sessions/:sessionId/members", async ({ request, params }) => {
+    return sessionJson(async () => {
+      const body = await readRequiredJson<{ memberIds: number[] }>(request, "session members kick");
+      kickMockSessionMembers(toSessionId(params.sessionId), body.memberIds);
+      return null;
+    });
   }),
 ];

--- a/src/mocks/handlers/session.ts
+++ b/src/mocks/handlers/session.ts
@@ -1,0 +1,261 @@
+import { http, HttpResponse } from "msw";
+
+import type {
+  InProgressEventData,
+  SessionDetailResponse,
+  WaitingRoomResponse,
+} from "@/features/session/types";
+import type { ApiSuccessResponse } from "@/types/shared/types";
+
+// 브라우저 요청의 Referer 헤더에서 현재 페이지 URL의 ?scenario= 파라미터를 읽어 분기
+// SSR(instrumentation.ts / msw/node)에서는 Referer가 없으므로 'default' 반환
+function getScenario(request: Request): string {
+  const referer = request.headers.get("referer") ?? "";
+  try {
+    return new URL(referer).searchParams.get("scenario") ?? "default";
+  } catch {
+    return "default";
+  }
+}
+
+function ok<T>(result: T): ApiSuccessResponse<T> {
+  return { isSuccess: true, code: "COMMON200", message: "OK", result };
+}
+
+// ============================================================
+// Mock 데이터
+// ============================================================
+
+const MOCK_DETAIL: Record<string, SessionDetailResponse> = {
+  default: {
+    sessionId: 1,
+    category: "개발",
+    title: "같이 사이드 프로젝트 완성해봐요",
+    hostNickname: "모각작러",
+    status: "진행중",
+    currentParticipants: 3,
+    maxParticipants: 6,
+    sessionDurationMinutes: 120,
+    startTime: new Date(Date.now() - 30 * 60 * 1000).toISOString(),
+    imageUrl: "",
+    summary: "각자 맡은 기능 구현 후 PR 올리기",
+    notice: "마이크 켜도 됩니다. 편하게 오세요!",
+    requiredFocusRate: 60,
+    requiredAchievementRate: 50,
+  },
+  empty: {
+    sessionId: 1,
+    category: "개발",
+    title: "혼자서 시작한 세션",
+    hostNickname: "모각작러",
+    status: "진행중",
+    currentParticipants: 0,
+    maxParticipants: 6,
+    sessionDurationMinutes: 120,
+    startTime: new Date(Date.now() - 10 * 60 * 1000).toISOString(),
+    imageUrl: "",
+    summary: "참여자가 없는 empty state 확인용",
+    notice: "",
+  },
+  ended: {
+    sessionId: 1,
+    category: "디자인",
+    title: "종료된 세션입니다",
+    hostNickname: "모각작러",
+    status: "종료",
+    currentParticipants: 4,
+    maxParticipants: 6,
+    sessionDurationMinutes: 90,
+    startTime: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
+    imageUrl: "",
+    summary: "세션이 종료된 상태의 UI 확인용",
+    notice: "",
+  },
+};
+
+const MOCK_IN_PROGRESS: Record<string, InProgressEventData> = {
+  default: {
+    participantCount: 3,
+    averageAchievementRate: 65,
+    members: [
+      {
+        memberId: 1,
+        nickname: "모각작러",
+        profileImageUrl: undefined,
+        role: "HOST",
+        achievementRate: 80,
+        status: "FOCUSED",
+        task: {
+          taskId: 1,
+          goal: "MSW 핸들러 작성 완료하기",
+          todos: [
+            { subtaskId: 1, content: "session 핸들러 작성", isCompleted: true },
+            { subtaskId: 2, content: "browser.ts 작성", isCompleted: false },
+            { subtaskId: 3, content: "server.ts 작성", isCompleted: false },
+          ],
+        },
+      },
+      {
+        memberId: 2,
+        nickname: "열공러",
+        profileImageUrl: undefined,
+        role: "PARTICIPANT",
+        achievementRate: 50,
+        status: "REST",
+        task: {
+          taskId: 2,
+          goal: "알고리즘 문제 5개 풀기",
+          todos: [
+            { subtaskId: 4, content: "BFS 문제 풀기", isCompleted: true },
+            { subtaskId: 5, content: "DP 문제 풀기", isCompleted: false },
+          ],
+        },
+      },
+      {
+        memberId: 3,
+        nickname: "디자인러",
+        profileImageUrl: undefined,
+        role: "PARTICIPANT",
+        achievementRate: 65,
+        status: "FOCUSED",
+        task: {
+          taskId: 3,
+          goal: "피그마 컴포넌트 정리",
+          todos: [{ subtaskId: 6, content: "버튼 컴포넌트 정리", isCompleted: true }],
+        },
+      },
+    ],
+  },
+  empty: {
+    participantCount: 0,
+    averageAchievementRate: 0,
+    members: [],
+  },
+  ended: {
+    participantCount: 4,
+    averageAchievementRate: 72,
+    members: [],
+  },
+};
+
+const MOCK_WAITING_ROOM: Record<string, WaitingRoomResponse> = {
+  default: {
+    participantCount: 3,
+    members: [
+      {
+        memberId: 1,
+        nickname: "모각작러",
+        profileImageUrl: undefined,
+        focusRate: 85,
+        achievementRate: 78,
+        role: "HOST",
+        task: {
+          taskId: 1,
+          goal: "MSW 핸들러 작성 완료하기",
+          todos: [
+            { subtaskId: 1, content: "session 핸들러 작성" },
+            { subtaskId: 2, content: "browser.ts 작성" },
+          ],
+        },
+      },
+      {
+        memberId: 2,
+        nickname: "열공러",
+        profileImageUrl: undefined,
+        focusRate: 70,
+        achievementRate: 60,
+        role: "PARTICIPANT",
+        task: null,
+      },
+      {
+        memberId: 3,
+        nickname: "디자인러",
+        profileImageUrl: undefined,
+        focusRate: 90,
+        achievementRate: 88,
+        role: "PARTICIPANT",
+        task: {
+          taskId: 3,
+          goal: "피그마 컴포넌트 정리",
+          todos: [{ subtaskId: 6, content: "버튼 컴포넌트 정리" }],
+        },
+      },
+    ],
+  },
+  empty: {
+    participantCount: 0,
+    members: [],
+  },
+  ended: {
+    participantCount: 4,
+    members: [],
+  },
+};
+
+// ============================================================
+// 핸들러
+// ============================================================
+
+export const sessionHandlers = [
+  // 세션 상세
+  http.get("/api/sessions/:sessionId", ({ request, params }) => {
+    const scenario = getScenario(request);
+
+    if (scenario === "error") {
+      return HttpResponse.json(
+        {
+          isSuccess: false,
+          code: "INTERNAL_ERROR",
+          message: "서버 오류가 발생했습니다.",
+          result: null,
+        },
+        { status: 500 }
+      );
+    }
+
+    const data = MOCK_DETAIL[scenario] ?? MOCK_DETAIL.default;
+    return HttpResponse.json(
+      ok({ ...data, sessionId: Number(params.sessionId) || data.sessionId })
+    );
+  }),
+
+  // 진행 중 참여자 상태
+  http.get("/api/sessions/:sessionId/in-progress", ({ request }) => {
+    const scenario = getScenario(request);
+
+    if (scenario === "error") {
+      return HttpResponse.json(
+        {
+          isSuccess: false,
+          code: "INTERNAL_ERROR",
+          message: "서버 오류가 발생했습니다.",
+          result: null,
+        },
+        { status: 500 }
+      );
+    }
+
+    const data = MOCK_IN_PROGRESS[scenario] ?? MOCK_IN_PROGRESS.default;
+    return HttpResponse.json(ok(data));
+  }),
+
+  // 대기방 참여자
+  http.get("/api/sessions/:sessionId/waiting-room", ({ request }) => {
+    const scenario = getScenario(request);
+
+    if (scenario === "error") {
+      return HttpResponse.json(
+        {
+          isSuccess: false,
+          code: "INTERNAL_ERROR",
+          message: "서버 오류가 발생했습니다.",
+          result: null,
+        },
+        { status: 500 }
+      );
+    }
+
+    const data = MOCK_WAITING_ROOM[scenario] ?? MOCK_WAITING_ROOM.default;
+    return HttpResponse.json(ok(data));
+  }),
+];

--- a/src/mocks/handlers/sse-payloads.ts
+++ b/src/mocks/handlers/sse-payloads.ts
@@ -1,0 +1,15 @@
+import type { WaitingMembersSSEPayload } from "@/features/lobby/types";
+import type { InProgressEventData } from "@/features/session/types";
+
+import { getMockInProgress, getMockWaitingRoom } from "./session-state";
+
+export function getMockWaitingMembersSSEPayload(sessionId: number): WaitingMembersSSEPayload {
+  return {
+    eventType: "ROOM_UPDATE",
+    data: getMockWaitingRoom(sessionId),
+  };
+}
+
+export function getMockInProgressMembersSSEPayload(sessionId: number): InProgressEventData {
+  return getMockInProgress(sessionId);
+}

--- a/src/mocks/handlers/sse.ts
+++ b/src/mocks/handlers/sse.ts
@@ -1,0 +1,58 @@
+import { http, HttpResponse } from "msw";
+
+import {
+  getMockInProgressMembersSSEPayload,
+  getMockWaitingMembersSSEPayload,
+} from "./sse-payloads";
+
+function sseStream(event: string, data: unknown) {
+  return new HttpResponse(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`, {
+    headers: {
+      "Cache-Control": "no-cache",
+      "Content-Type": "text/event-stream",
+      Connection: "keep-alive",
+    },
+  });
+}
+
+function toSessionId(value: string | readonly string[] | undefined): number {
+  return Number(Array.isArray(value) ? value[0] : value);
+}
+
+export const sseHandlers = [
+  http.get("*/api/sse/waiting/:sessionId", ({ params }) => {
+    return sseStream(
+      "waiting-members-updated",
+      getMockWaitingMembersSSEPayload(toSessionId(params.sessionId))
+    );
+  }),
+
+  http.get("*/api/sse/in-progress/:sessionId", ({ params }) => {
+    return sseStream(
+      "in-progress-members-updated",
+      getMockInProgressMembersSSEPayload(toSessionId(params.sessionId))
+    );
+  }),
+
+  http.get("*/api/sse/session-status/:sessionId", () => {
+    return sseStream("session-status-updated", { status: "IN_PROGRESS" });
+  }),
+
+  http.get("*/api/sse/reaction/:sessionId", () => {
+    return sseStream("reaction-updated", {
+      heartCount: 0,
+      starCount: 0,
+      thumbsUpCount: 0,
+      thumbsDownCount: 0,
+    });
+  }),
+
+  http.get("*/api/sse/reaction/:sessionId/members/:memberId", () => {
+    return sseStream("member-reaction-updated", {
+      heartCount: 0,
+      starCount: 0,
+      thumbsUpCount: 0,
+      thumbsDownCount: 0,
+    });
+  }),
+];

--- a/src/mocks/handlers/task.ts
+++ b/src/mocks/handlers/task.ts
@@ -1,0 +1,84 @@
+import { http, HttpResponse } from "msw";
+
+import type {
+  CreateSubtaskRequest,
+  UpdateGoalRequest,
+  UpdateTodoRequest,
+} from "@/features/task/api";
+
+import { MockJsonParseError, readRequiredJson } from "./json";
+import {
+  createMockSubtasks,
+  deleteMockSubtask,
+  MockSubtaskNotFoundError,
+  MockTaskNotFoundError,
+  toggleMockSubtaskCompletion,
+  updateMockSubtask,
+  updateMockTaskGoal,
+} from "./session-state";
+import { fail, ok } from "./utils";
+
+function toNumber(value: string | readonly string[] | undefined): number {
+  return Number(Array.isArray(value) ? value[0] : value) || 0;
+}
+
+async function taskJson<T>(producer: () => T | Promise<T>) {
+  try {
+    return HttpResponse.json(ok(await producer()));
+  } catch (error) {
+    if (error instanceof MockTaskNotFoundError) {
+      return HttpResponse.json(fail("TASK404_1", "존재하지 않는 목표입니다.", "NOT_FOUND"), {
+        status: 404,
+      });
+    }
+    if (error instanceof MockSubtaskNotFoundError) {
+      return HttpResponse.json(fail("SUBTASK404_1", "존재하지 않는 할 일입니다.", "NOT_FOUND"), {
+        status: 404,
+      });
+    }
+    if (error instanceof MockJsonParseError) {
+      return HttpResponse.json(fail("COMMON400", error.message, "BAD_REQUEST"), { status: 400 });
+    }
+
+    throw error;
+  }
+}
+
+export const taskHandlers = [
+  http.patch("*/api/tasks/:taskId", ({ request, params }) => {
+    return taskJson(async () => {
+      const body = await readRequiredJson<UpdateGoalRequest>(request, "task goal update");
+      updateMockTaskGoal(toNumber(params.taskId), body.goalContent);
+      return null;
+    });
+  }),
+
+  http.post("*/api/tasks/:taskId/subtasks", ({ request, params }) => {
+    return taskJson(async () => {
+      const body = await readRequiredJson<CreateSubtaskRequest>(request, "subtask create");
+      return createMockSubtasks(toNumber(params.taskId), body);
+    });
+  }),
+
+  http.patch("*/api/subtasks/:subtaskId", ({ request, params }) => {
+    return taskJson(async () => {
+      const body = await readRequiredJson<UpdateTodoRequest>(request, "subtask update");
+      updateMockSubtask(toNumber(params.subtaskId), body.todoContent);
+      return null;
+    });
+  }),
+
+  http.delete("*/api/subtasks/:subtaskId", ({ params }) => {
+    return taskJson(() => {
+      deleteMockSubtask(toNumber(params.subtaskId));
+      return null;
+    });
+  }),
+
+  http.post("*/api/subtasks/:subtaskId/completion", ({ params }) => {
+    return taskJson(() => {
+      toggleMockSubtaskCompletion(toNumber(params.subtaskId));
+      return null;
+    });
+  }),
+];

--- a/src/mocks/handlers/utils.ts
+++ b/src/mocks/handlers/utils.ts
@@ -1,0 +1,13 @@
+import type { ApiErrorResponse, ApiSuccessResponse } from "@/types/shared/types";
+
+export function ok<T>(result: T): ApiSuccessResponse<T> {
+  return { isSuccess: true, code: "COMMON200", message: "OK", result };
+}
+
+export function fail(
+  code: string,
+  message: string,
+  httpStatus: ApiErrorResponse["httpStatus"] = "BAD_REQUEST"
+): ApiErrorResponse {
+  return { isSuccess: false, code, message, httpStatus };
+}

--- a/src/mocks/is-mock-mode-enabled.ts
+++ b/src/mocks/is-mock-mode-enabled.ts
@@ -1,0 +1,3 @@
+export function isMockModeEnabled(): boolean {
+  return process.env.NODE_ENV !== "production" && process.env.NEXT_PUBLIC_USE_MOCK === "true";
+}

--- a/src/mocks/server-control.ts
+++ b/src/mocks/server-control.ts
@@ -1,0 +1,24 @@
+const MOCK_SERVER_STARTED_KEY = "__gak_msw_server_started__";
+
+type GlobalWithMockServerState = typeof globalThis & {
+  [MOCK_SERVER_STARTED_KEY]?: boolean;
+};
+
+export function isMockModeEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_USE_MOCK === "true";
+}
+
+export async function ensureMockServer(): Promise<void> {
+  if (!isMockModeEnabled()) return;
+  if (typeof window !== "undefined") return;
+  if (process.env.NEXT_RUNTIME === "edge") return;
+
+  const globalWithMockState = globalThis as GlobalWithMockServerState;
+  if (globalWithMockState[MOCK_SERVER_STARTED_KEY]) return;
+
+  const { server } = await import("./server");
+  const { strictUnhandledApiRequest } = await import("./unhandled-request");
+
+  server.listen({ onUnhandledRequest: strictUnhandledApiRequest });
+  globalWithMockState[MOCK_SERVER_STARTED_KEY] = true;
+}

--- a/src/mocks/server-control.ts
+++ b/src/mocks/server-control.ts
@@ -1,12 +1,10 @@
+import { isMockModeEnabled } from "./is-mock-mode-enabled";
+
 const MOCK_SERVER_STARTED_KEY = "__gak_msw_server_started__";
 
 type GlobalWithMockServerState = typeof globalThis & {
   [MOCK_SERVER_STARTED_KEY]?: boolean;
 };
-
-export function isMockModeEnabled(): boolean {
-  return process.env.NEXT_PUBLIC_USE_MOCK === "true";
-}
 
 export async function ensureMockServer(): Promise<void> {
   if (!isMockModeEnabled()) return;

--- a/src/mocks/server.ts
+++ b/src/mocks/server.ts
@@ -1,0 +1,5 @@
+import { setupServer } from "msw/node";
+
+import { handlers } from "./handlers";
+
+export const server = setupServer(...handlers);

--- a/src/mocks/unhandled-request.ts
+++ b/src/mocks/unhandled-request.ts
@@ -1,0 +1,15 @@
+interface UnhandledRequestLike {
+  url: string;
+  method: string;
+}
+
+export function isUnhandledBackendApiRequest(request: UnhandledRequestLike): boolean {
+  const { pathname } = new URL(request.url);
+  return pathname === "/api" || pathname.startsWith("/api/");
+}
+
+export function strictUnhandledApiRequest(request: UnhandledRequestLike): void {
+  if (!isUnhandledBackendApiRequest(request)) return;
+
+  throw new Error(`[MSW] Unhandled backend API request: ${request.method} ${request.url}`);
+}

--- a/src/providers/MockProvider.tsx
+++ b/src/providers/MockProvider.tsx
@@ -6,7 +6,8 @@ const isMockEnabled = process.env.NEXT_PUBLIC_USE_MOCK === "true";
 
 async function startWorker() {
   const { worker } = await import("@/mocks/browser");
-  await worker.start({ onUnhandledRequest: "bypass" });
+  const { strictUnhandledApiRequest } = await import("@/mocks/unhandled-request");
+  await worker.start({ onUnhandledRequest: strictUnhandledApiRequest });
 }
 
 interface MockProviderProps {

--- a/src/providers/MockProvider.tsx
+++ b/src/providers/MockProvider.tsx
@@ -2,7 +2,9 @@
 
 import { type ReactNode, useEffect, useState } from "react";
 
-const isMockEnabled = process.env.NEXT_PUBLIC_USE_MOCK === "true";
+import { isMockModeEnabled } from "@/mocks/is-mock-mode-enabled";
+
+const isMockEnabled = isMockModeEnabled();
 
 async function startWorker() {
   const { worker } = await import("@/mocks/browser");

--- a/src/providers/MockProvider.tsx
+++ b/src/providers/MockProvider.tsx
@@ -18,12 +18,17 @@ interface MockProviderProps {
 
 export function MockProvider({ children }: MockProviderProps) {
   const [ready, setReady] = useState(!isMockEnabled);
+  const [error, setError] = useState<unknown>(null);
 
   useEffect(() => {
     if (!isMockEnabled) return;
-    startWorker().then(() => setReady(true));
+
+    startWorker()
+      .then(() => setReady(true))
+      .catch(setError);
   }, []);
 
+  if (error) throw error;
   if (!ready) return null;
   return <>{children}</>;
 }

--- a/src/providers/MockProvider.tsx
+++ b/src/providers/MockProvider.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { type ReactNode, useEffect, useState } from "react";
+
+const isMockEnabled = process.env.NEXT_PUBLIC_USE_MOCK === "true";
+
+async function startWorker() {
+  const { worker } = await import("@/mocks/browser");
+  await worker.start({ onUnhandledRequest: "bypass" });
+}
+
+interface MockProviderProps {
+  children: ReactNode;
+}
+
+export function MockProvider({ children }: MockProviderProps) {
+  const [ready, setReady] = useState(!isMockEnabled);
+
+  useEffect(() => {
+    if (!isMockEnabled) return;
+    startWorker().then(() => setReady(true));
+  }, []);
+
+  if (!ready) return null;
+  return <>{children}</>;
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -44,6 +44,10 @@ interface AuthFailureResponseOptions {
 type RefreshFailureReason = "http_error" | "invalid_response" | "timeout" | "network_error";
 type RouteType = "public" | "protected" | "api";
 
+function isMockModeEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_USE_MOCK === "true";
+}
+
 export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const isPublicPageRoute = isKnownPublicPageRoute(pathname);
@@ -51,6 +55,11 @@ export async function proxy(request: NextRequest) {
 
   // well-known 경로는 인증 처리 없이 통과한다.
   if (pathname.startsWith("/.well-known")) {
+    return NextResponse.next();
+  }
+
+  // 로컬 mock 모드에서는 MSW가 인증 API 응답을 담당하므로 proxy 인증 관문을 통과시킨다.
+  if (isMockModeEnabled()) {
     return NextResponse.next();
   }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -13,6 +13,7 @@ import { isKnownPublicPageRoute, isProtectedPageRoute } from "@/lib/auth/route-a
 import { getErrorCodeFromResponse, parseRefreshTokenPair } from "@/lib/auth/token-refresh-utils";
 import { BACKEND_ERROR_CODES, LOGIN_INTERNAL_ERROR_CODES } from "@/lib/error/error-codes";
 import { LOGIN_ROUTE } from "@/lib/routes/route-paths";
+import { isMockModeEnabled } from "@/mocks/is-mock-mode-enabled";
 
 // 공개 API 라우트 (인증 불필요)
 const PUBLIC_API_ROUTE_PATTERNS = [
@@ -43,10 +44,6 @@ interface AuthFailureResponseOptions {
 
 type RefreshFailureReason = "http_error" | "invalid_response" | "timeout" | "network_error";
 type RouteType = "public" | "protected" | "api";
-
-function isMockModeEnabled(): boolean {
-  return process.env.NEXT_PUBLIC_USE_MOCK === "true";
-}
 
 export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;

--- a/src/test/api-mock-server-routing.test.ts
+++ b/src/test/api-mock-server-routing.test.ts
@@ -92,6 +92,30 @@ describe("server api mock routing", () => {
     );
   });
 
+  it("production에서는 NEXT_PUBLIC_USE_MOCK=true여도 backend base URL을 사용한다", async () => {
+    Object.defineProperty(process.env, "NODE_ENV", {
+      value: "production",
+      configurable: true,
+      writable: true,
+    });
+    process.env.NEXT_PUBLIC_USE_MOCK = "true";
+    process.env.BACKEND_API_BASE = "https://backend.example.com";
+    const ensureMockServer = jest.fn().mockResolvedValue(undefined);
+    jest.doMock("@/mocks/server-control", () => ({ ensureMockServer }));
+    const fetchMock = jest.fn().mockResolvedValue(mockJsonResponse({ isSuccess: true }));
+    global.fetch = fetchMock as typeof fetch;
+
+    const { api } = await import("@/lib/api/api");
+
+    await api.server.get("/sessions/900", { skipAuth: true });
+
+    expect(ensureMockServer).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://backend.example.com/sessions/900",
+      expect.objectContaining({ method: "GET" })
+    );
+  });
+
   it("uses the backend base URL when mock mode is disabled", async () => {
     process.env.NEXT_PUBLIC_USE_MOCK = "false";
     process.env.BACKEND_API_BASE = "https://backend.example.com";

--- a/src/test/api-mock-server-routing.test.ts
+++ b/src/test/api-mock-server-routing.test.ts
@@ -1,0 +1,78 @@
+/**
+ * @jest-environment node
+ */
+
+function mockJsonResponse(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("server api mock routing", () => {
+  const originalEnv = process.env;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    global.fetch = originalFetch;
+  });
+
+  it("starts the MSW server before server-side mock requests and rewrites backend paths to /api", async () => {
+    process.env.NEXT_PUBLIC_USE_MOCK = "true";
+    process.env.FRONTEND_ORIGIN = "http://localhost:3000";
+    const ensureMockServer = jest.fn().mockResolvedValue(undefined);
+    jest.doMock("@/mocks/server-control", () => ({ ensureMockServer }));
+    const fetchMock = jest.fn().mockResolvedValue(mockJsonResponse({ isSuccess: true }));
+    global.fetch = fetchMock as typeof fetch;
+
+    const { api } = await import("@/lib/api/api");
+
+    await api.server.get("/sessions/900", { skipAuth: true });
+
+    expect(ensureMockServer).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:3000/api/sessions/900",
+      expect.objectContaining({ method: "GET" })
+    );
+  });
+
+  it("keeps existing /api paths on the frontend origin in mock mode", async () => {
+    process.env.NEXT_PUBLIC_USE_MOCK = "true";
+    process.env.FRONTEND_ORIGIN = "http://localhost:3000";
+    jest.doMock("@/mocks/server-control", () => ({ ensureMockServer: jest.fn() }));
+    const fetchMock = jest.fn().mockResolvedValue(mockJsonResponse({ isSuccess: true }));
+    global.fetch = fetchMock as typeof fetch;
+
+    const { api } = await import("@/lib/api/api");
+
+    await api.get("/api/sessions/900", { skipAuth: true });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:3000/api/sessions/900",
+      expect.objectContaining({ method: "GET" })
+    );
+  });
+
+  it("uses the backend base URL when mock mode is disabled", async () => {
+    process.env.NEXT_PUBLIC_USE_MOCK = "false";
+    process.env.BACKEND_API_BASE = "https://backend.example.com";
+    const fetchMock = jest.fn().mockResolvedValue(mockJsonResponse({ isSuccess: true }));
+    global.fetch = fetchMock as typeof fetch;
+
+    const { api } = await import("@/lib/api/api");
+
+    await api.server.get("/sessions/900", { skipAuth: true });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://backend.example.com/sessions/900",
+      expect.objectContaining({ method: "GET" })
+    );
+  });
+});

--- a/src/test/api-mock-server-routing.test.ts
+++ b/src/test/api-mock-server-routing.test.ts
@@ -60,6 +60,38 @@ describe("server api mock routing", () => {
     );
   });
 
+  it("routes profile settings and report APIs to local mock endpoints in mock mode", async () => {
+    process.env.NEXT_PUBLIC_USE_MOCK = "true";
+    process.env.FRONTEND_ORIGIN = "http://localhost:3000";
+    jest.doMock("@/mocks/server-control", () => ({ ensureMockServer: jest.fn() }));
+    const fetchMock = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve(mockJsonResponse({ isSuccess: true })));
+    global.fetch = fetchMock as typeof fetch;
+
+    const { memberApi } = await import("@/features/member/api");
+
+    await memberApi.getMeForEdit();
+    await memberApi.getMyReportStats();
+    await memberApi.getMyReportSessions({ page: 2, size: 4 });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "http://localhost:3000/api/members/me/edit",
+      expect.objectContaining({ method: "GET" })
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "http://localhost:3000/api/members/me/report-stats",
+      expect.objectContaining({ method: "GET" })
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      "http://localhost:3000/api/members/me/report-sessions?page=2&size=4",
+      expect.objectContaining({ method: "GET" })
+    );
+  });
+
   it("uses the backend base URL when mock mode is disabled", async () => {
     process.env.NEXT_PUBLIC_USE_MOCK = "false";
     process.env.BACKEND_API_BASE = "https://backend.example.com";

--- a/src/test/auth/resolve-server-auth-state.test.ts
+++ b/src/test/auth/resolve-server-auth-state.test.ts
@@ -29,6 +29,32 @@ describe("RootLayout auth prefetch flow", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
+  it("mock mode에서는 인증 쿠키가 없어도 mock me prefetch를 수행하고 인증 힌트를 반환해야 한다", async () => {
+    const previousUseMock = process.env.NEXT_PUBLIC_USE_MOCK;
+    process.env.NEXT_PUBLIC_USE_MOCK = "true";
+    mockedGetServerAuthCookieState.mockResolvedValue({
+      hasAccessToken: false,
+      hasRefreshToken: false,
+      hasAuthCookies: false,
+    });
+    const queryClient = new QueryClient();
+    const fetchSpy = jest.spyOn(queryClient, "fetchQuery").mockResolvedValue({
+      isSuccess: true,
+      result: { id: 1 },
+    } as never);
+
+    try {
+      await expect(prepareAuthMeQuery(queryClient)).resolves.toEqual({ hasAuthCookies: true });
+      expect(fetchSpy).toHaveBeenCalledWith(memberQueries.me());
+    } finally {
+      if (previousUseMock === undefined) {
+        delete process.env.NEXT_PUBLIC_USE_MOCK;
+      } else {
+        process.env.NEXT_PUBLIC_USE_MOCK = previousUseMock;
+      }
+    }
+  });
+
   it("인증 쿠키가 있으면 me prefetch를 수행해야 한다", async () => {
     mockedGetServerAuthCookieState.mockResolvedValue({
       hasAccessToken: true,

--- a/src/test/msw/mock-mode.test.ts
+++ b/src/test/msw/mock-mode.test.ts
@@ -1,0 +1,44 @@
+import { isMockModeEnabled } from "@/mocks/is-mock-mode-enabled";
+
+function setNodeEnv(value: string | undefined) {
+  Object.defineProperty(process.env, "NODE_ENV", {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
+describe("isMockModeEnabled", () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalUseMock = process.env.NEXT_PUBLIC_USE_MOCK;
+
+  afterEach(() => {
+    setNodeEnv(originalNodeEnv);
+    if (originalUseMock === undefined) {
+      delete process.env.NEXT_PUBLIC_USE_MOCK;
+    } else {
+      process.env.NEXT_PUBLIC_USE_MOCK = originalUseMock;
+    }
+  });
+
+  it("non-production에서 NEXT_PUBLIC_USE_MOCK=true이면 mock mode를 활성화한다", () => {
+    setNodeEnv("test");
+    process.env.NEXT_PUBLIC_USE_MOCK = "true";
+
+    expect(isMockModeEnabled()).toBe(true);
+  });
+
+  it("production에서는 NEXT_PUBLIC_USE_MOCK=true여도 mock mode를 비활성화한다", () => {
+    setNodeEnv("production");
+    process.env.NEXT_PUBLIC_USE_MOCK = "true";
+
+    expect(isMockModeEnabled()).toBe(false);
+  });
+
+  it("NEXT_PUBLIC_USE_MOCK=true가 아니면 mock mode를 비활성화한다", () => {
+    setNodeEnv("test");
+    process.env.NEXT_PUBLIC_USE_MOCK = "false";
+
+    expect(isMockModeEnabled()).toBe(false);
+  });
+});

--- a/src/test/msw/msw-api-coverage.test.ts
+++ b/src/test/msw/msw-api-coverage.test.ts
@@ -1,0 +1,179 @@
+import fs from "node:fs";
+import path from "node:path";
+
+interface ExpectedEndpoint {
+  method: "get" | "post" | "patch" | "delete";
+  pattern: string;
+  source: string;
+}
+
+const handlersDirectory = path.join(process.cwd(), "src/mocks/handlers");
+
+function readHandlerSources() {
+  return fs
+    .readdirSync(handlersDirectory)
+    .filter((file) => file.endsWith(".ts"))
+    .map((file) => fs.readFileSync(path.join(handlersDirectory, file), "utf8"))
+    .join("\n");
+}
+
+const expectedEndpoints: ExpectedEndpoint[] = [
+  { method: "get", pattern: "*/api/auth/login", source: "src/app/api/auth/login/route.ts" },
+  {
+    method: "get",
+    pattern: "*/api/auth/callback/:provider",
+    source: "src/app/api/auth/callback/[provider]/route.ts",
+  },
+  { method: "post", pattern: "*/api/auth/logout", source: "src/features/auth/api.ts" },
+  { method: "post", pattern: "*/api/mock/reset", source: "src/mocks/handlers/mock-control.ts" },
+  { method: "get", pattern: "*/api/members/me/profile", source: "src/features/member/api.ts" },
+  { method: "get", pattern: "*/api/members/me/edit", source: "src/features/member/api.ts" },
+  {
+    method: "patch",
+    pattern: "*/api/members/me/profile-image",
+    source: "src/features/member/api.ts",
+  },
+  {
+    method: "delete",
+    pattern: "*/api/members/me/profile-image",
+    source: "src/features/member/api.ts",
+  },
+  { method: "patch", pattern: "*/api/members/me/nickname", source: "src/features/member/api.ts" },
+  { method: "patch", pattern: "*/api/members/me", source: "src/features/member/api.ts" },
+  { method: "patch", pattern: "*/api/members/me/email", source: "src/features/member/api.ts" },
+  {
+    method: "patch",
+    pattern: "*/api/members/me/interest-categories",
+    source: "src/features/member/api.ts",
+  },
+  { method: "get", pattern: "*/api/members/me/report-stats", source: "src/features/member/api.ts" },
+  {
+    method: "get",
+    pattern: "*/api/members/me/report-sessions",
+    source: "src/features/member/api.ts",
+  },
+  { method: "delete", pattern: "*/api/members/me", source: "src/features/member/api.ts" },
+  { method: "get", pattern: "*/api/sessions", source: "src/features/session/api.ts" },
+  { method: "get", pattern: "*/api/sessions/:sessionId", source: "src/features/session/api.ts" },
+  { method: "post", pattern: "*/api/sessions/create", source: "src/features/session/api.ts" },
+  {
+    method: "post",
+    pattern: "*/api/sessions/:sessionId/join",
+    source: "src/features/session/api.ts",
+  },
+  {
+    method: "get",
+    pattern: "*/api/sessions/:sessionId/waiting-room",
+    source: "src/features/session/api.ts",
+  },
+  {
+    method: "get",
+    pattern: "*/api/sessions/:sessionId/in-progress",
+    source: "src/features/session/api.ts",
+  },
+  {
+    method: "delete",
+    pattern: "*/api/sessions/:sessionId/leave",
+    source: "src/features/session/api.ts",
+  },
+  {
+    method: "get",
+    pattern: "*/api/sessions/:sessionId/report",
+    source: "src/features/session/api.ts",
+  },
+  {
+    method: "get",
+    pattern: "*/api/sessions/:sessionId/me/report",
+    source: "src/features/session/api.ts",
+  },
+  {
+    method: "post",
+    pattern: "*/api/sessions/:sessionId/reaction",
+    source: "src/features/session/api.ts",
+  },
+  {
+    method: "delete",
+    pattern: "*/api/sessions/:sessionId/members",
+    source: "src/features/session/api.ts",
+  },
+  {
+    method: "post",
+    pattern: "*/api/sessions/:sessionId/results",
+    source: "src/features/session/api.ts",
+  },
+  {
+    method: "patch",
+    pattern: "*/api/sessions/:sessionId/me/status",
+    source: "src/features/session/api.ts",
+  },
+  { method: "patch", pattern: "*/api/tasks/:taskId", source: "src/features/task/api.ts" },
+  { method: "post", pattern: "*/api/tasks/:taskId/subtasks", source: "src/features/task/api.ts" },
+  { method: "patch", pattern: "*/api/subtasks/:subtaskId", source: "src/features/task/api.ts" },
+  { method: "delete", pattern: "*/api/subtasks/:subtaskId", source: "src/features/task/api.ts" },
+  {
+    method: "post",
+    pattern: "*/api/subtasks/:subtaskId/completion",
+    source: "src/features/session/api.ts",
+  },
+  { method: "get", pattern: "*/api/sse/waiting/:sessionId", source: "src/app/api/sse" },
+  { method: "get", pattern: "*/api/sse/in-progress/:sessionId", source: "src/app/api/sse" },
+  { method: "get", pattern: "*/api/sse/session-status/:sessionId", source: "src/app/api/sse" },
+  { method: "get", pattern: "*/api/sse/reaction/:sessionId", source: "src/app/api/sse" },
+  {
+    method: "get",
+    pattern: "*/api/sse/reaction/:sessionId/members/:memberId",
+    source: "src/app/api/sse",
+  },
+];
+
+describe("MSW backend API coverage", () => {
+  it.each(expectedEndpoints)("covers $method $pattern from $source", ({ method, pattern }) => {
+    const handlerSources = readHandlerSources();
+
+    expect(handlerSources).toContain(`http.${method}("${pattern}"`);
+  });
+
+  it("uses SSE event names consumed by hooks", () => {
+    const handlerSources = readHandlerSources();
+
+    for (const eventName of [
+      "waiting-members-updated",
+      "in-progress-members-updated",
+      "session-status-updated",
+      "reaction-updated",
+      "member-reaction-updated",
+    ]) {
+      expect(handlerSources).toMatch(new RegExp(`sseStream\\(\\s*["\\\']${eventName}["\\\']`));
+    }
+  });
+
+  it("registers every handler module in the exported handler registry", () => {
+    const indexSource = fs.readFileSync(path.join(handlersDirectory, "index.ts"), "utf8");
+
+    expect(indexSource).toContain("handlerRegistry");
+    for (const handlerName of [
+      "authHandlers",
+      "memberHandlers",
+      "sessionHandlers",
+      "taskHandlers",
+      "sseHandlers",
+      "mockControlHandlers",
+    ]) {
+      expect(indexSource).toContain(`handlers: ${handlerName}`);
+    }
+  });
+
+  it("documents currently empty feature API modules as no-op coverage", () => {
+    const resultApi = fs.readFileSync(
+      path.join(process.cwd(), "src/features/result/api.ts"),
+      "utf8"
+    );
+    const workspaceApi = fs.readFileSync(
+      path.join(process.cwd(), "src/features/workspace/api.ts"),
+      "utf8"
+    );
+
+    expect(resultApi.trim()).toBe("");
+    expect(workspaceApi.trim()).toBe("");
+  });
+});

--- a/src/test/msw/msw-api-coverage.test.ts
+++ b/src/test/msw/msw-api-coverage.test.ts
@@ -162,18 +162,4 @@ describe("MSW backend API coverage", () => {
       expect(indexSource).toContain(`handlers: ${handlerName}`);
     }
   });
-
-  it("documents currently empty feature API modules as no-op coverage", () => {
-    const resultApi = fs.readFileSync(
-      path.join(process.cwd(), "src/features/result/api.ts"),
-      "utf8"
-    );
-    const workspaceApi = fs.readFileSync(
-      path.join(process.cwd(), "src/features/workspace/api.ts"),
-      "utf8"
-    );
-
-    expect(resultApi.trim()).toBe("");
-    expect(workspaceApi.trim()).toBe("");
-  });
 });

--- a/src/test/msw/msw-session-state.test.ts
+++ b/src/test/msw/msw-session-state.test.ts
@@ -182,6 +182,21 @@ describe("MSW session state store", () => {
     expect(inProgressSSE.members[0].task?.todos).toHaveLength(5);
   });
 
+  it("result focusRate가 0이면 기존 focusRate로 대체하지 않는다", () => {
+    submitMockSessionResult(900, {
+      totalFocusSeconds: 0,
+      overallSeconds: 2400,
+    });
+
+    expect(getMockMyReport(900).sessionMemberResult.focusRate).toBe(0);
+    expect(getMockSessionReport(900).members[0]).toEqual(
+      expect.objectContaining({
+        memberId: 1,
+        focusRate: 0,
+      })
+    );
+  });
+
   it("unknown session id는 기본 세션으로 조용히 대체하지 않는다", () => {
     expect(() => getMockSessionDetail(404404)).toThrow(MockSessionNotFoundError);
   });

--- a/src/test/msw/msw-session-state.test.ts
+++ b/src/test/msw/msw-session-state.test.ts
@@ -197,6 +197,27 @@ describe("MSW session state store", () => {
     );
   });
 
+  it("현재 사용자가 첫 번째 참여자가 아니어도 내 리포트는 memberId 기준으로 조회한다", () => {
+    kickMockSessionMembers(900, [1]);
+    joinMockSession(900, {
+      goal: "현재 사용자 목표",
+      todos: ["현재 사용자 할 일"],
+    });
+
+    submitMockSessionResult(900, {
+      totalFocusSeconds: 1200,
+      overallSeconds: 2400,
+    });
+
+    expect(getMockMyReport(900).sessionMemberResult).toEqual(
+      expect.objectContaining({
+        memberId: 1,
+        focusRate: 50,
+        task: expect.objectContaining({ goal: "현재 사용자 목표" }),
+      })
+    );
+  });
+
   it("unknown session id는 기본 세션으로 조용히 대체하지 않는다", () => {
     expect(() => getMockSessionDetail(404404)).toThrow(MockSessionNotFoundError);
   });

--- a/src/test/msw/msw-session-state.test.ts
+++ b/src/test/msw/msw-session-state.test.ts
@@ -1,0 +1,267 @@
+import {
+  createMockSession,
+  getMockInProgress,
+  getMockMyReport,
+  getMockSessionDetail,
+  getMockSessionList,
+  getMockSessionReport,
+  getMockWaitingRoom,
+  MockMemberNotFoundError,
+  MockSessionNotFoundError,
+  MockSubtaskNotFoundError,
+  MockTaskNotFoundError,
+  joinMockSession,
+  kickMockSessionMembers,
+  sendMockReaction,
+  resetMockSessions,
+  submitMockSessionResult,
+  updateMockTaskGoal,
+  createMockSubtasks,
+  updateMockSubtask,
+  deleteMockSubtask,
+  toggleMockSubtaskCompletion,
+} from "@/mocks/handlers/session-state";
+import {
+  getMockInProgressMembersSSEPayload,
+  getMockWaitingMembersSSEPayload,
+} from "@/mocks/handlers/sse-payloads";
+
+describe("MSW session state store", () => {
+  beforeEach(() => {
+    resetMockSessions();
+  });
+
+  it("create -> list/detail -> join -> waiting/in-progress -> result/report 흐름을 같은 세션 상태로 이어준다", () => {
+    const createdSessionId = createMockSession({
+      title: "MSW 플로우 점검 세션",
+      summary: "로컬 mock 백엔드로 전체 세션 흐름 확인",
+      notice: "TDD로 상태 일관성을 검증합니다.",
+      category: "DEVELOPMENT",
+      startTime: new Date(Date.now() + 10 * 60 * 1000).toISOString(),
+      sessionDurationMinutes: 60,
+      maxParticipants: 4,
+      requiredFocusRate: 50,
+      requiredAchievementRate: 40,
+    }).createdSessionId;
+
+    expect(getMockSessionList({ keyword: "MSW 플로우", page: 1, size: 10 }).sessions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          sessionId: createdSessionId,
+          title: "MSW 플로우 점검 세션",
+          status: "WAITING",
+        }),
+      ])
+    );
+
+    expect(getMockSessionDetail(createdSessionId)).toEqual(
+      expect.objectContaining({
+        sessionId: createdSessionId,
+        title: "MSW 플로우 점검 세션",
+        status: "대기",
+        currentParticipants: 0,
+      })
+    );
+
+    expect(
+      joinMockSession(createdSessionId, {
+        goal: "MSW 세션 상태 구현",
+        todos: ["세션 생성", "대기방 확인"],
+      })
+    ).toEqual({
+      sessionId: createdSessionId,
+      memberId: 1,
+      role: "HOST",
+    });
+
+    expect(getMockWaitingRoom(createdSessionId)).toEqual(
+      expect.objectContaining({
+        participantCount: 1,
+        members: [
+          expect.objectContaining({
+            memberId: 1,
+            role: "HOST",
+            task: expect.objectContaining({
+              goal: "MSW 세션 상태 구현",
+              todos: [
+                expect.objectContaining({ content: "세션 생성" }),
+                expect.objectContaining({ content: "대기방 확인" }),
+              ],
+            }),
+          }),
+        ],
+      })
+    );
+
+    expect(getMockInProgress(createdSessionId)).toEqual(
+      expect.objectContaining({
+        participantCount: 1,
+        members: [
+          expect.objectContaining({
+            memberId: 1,
+            achievementRate: 0,
+            task: expect.objectContaining({ goal: "MSW 세션 상태 구현" }),
+          }),
+        ],
+      })
+    );
+
+    submitMockSessionResult(createdSessionId, {
+      totalFocusSeconds: 1800,
+      overallSeconds: 2400,
+    });
+
+    expect(getMockMyReport(createdSessionId)).toEqual(
+      expect.objectContaining({
+        sessionId: createdSessionId,
+        currentParticipants: 1,
+        sessionMemberResult: expect.objectContaining({
+          memberId: 1,
+          focusRate: 75,
+          totalFocusSeconds: 1800,
+          overallFocusSeconds: 2400,
+          task: expect.objectContaining({ goal: "MSW 세션 상태 구현" }),
+        }),
+      })
+    );
+
+    expect(getMockSessionReport(createdSessionId)).toEqual(
+      expect.objectContaining({
+        averageTotalFocusSeconds: 1800,
+        averageOverallSeconds: 2400,
+        averageFocusRate: 75,
+        members: [
+          expect.objectContaining({
+            memberId: 1,
+            goal: "MSW 세션 상태 구현",
+            focusRate: 75,
+          }),
+        ],
+      })
+    );
+  });
+
+  it("seeded session 900 exposes my 5 todos and 10 participants through REST and SSE payloads", () => {
+    const waitingRoom = getMockWaitingRoom(900);
+    const inProgress = getMockInProgress(900);
+    const waitingSSE = getMockWaitingMembersSSEPayload(900);
+    const inProgressSSE = getMockInProgressMembersSSEPayload(900);
+
+    expect(waitingRoom.participantCount).toBe(10);
+    expect(waitingRoom.members).toHaveLength(10);
+    expect(waitingRoom.members[0].task?.todos).toHaveLength(5);
+
+    expect(inProgress.participantCount).toBe(10);
+    expect(inProgress.members).toHaveLength(10);
+    expect(inProgress.members[0]).toEqual(
+      expect.objectContaining({
+        memberId: 1,
+        task: expect.objectContaining({
+          goal: "MSW 로컬 mock 백엔드 완성하기",
+          todos: expect.arrayContaining([
+            expect.objectContaining({ content: "세션 상세 mock 데이터 확인" }),
+            expect.objectContaining({ content: "나의 목표 카드 UI 점검" }),
+            expect.objectContaining({ content: "참여자 목록 10명 노출 확인" }),
+            expect.objectContaining({ content: "할 일 완료 토글 동작 확인" }),
+            expect.objectContaining({ content: "세션 종료 후 리포트 확인" }),
+          ]),
+        }),
+      })
+    );
+
+    expect(waitingSSE).toEqual({
+      eventType: "ROOM_UPDATE",
+      data: expect.objectContaining({ participantCount: 10, members: expect.any(Array) }),
+    });
+    if (waitingSSE.eventType !== "ROOM_UPDATE") {
+      throw new Error("Expected ROOM_UPDATE waiting SSE payload");
+    }
+
+    expect(waitingSSE.data.members).toHaveLength(10);
+    expect(inProgressSSE.members).toHaveLength(10);
+    expect(inProgressSSE.members[0].task?.todos).toHaveLength(5);
+  });
+
+  it("unknown session id는 기본 세션으로 조용히 대체하지 않는다", () => {
+    expect(() => getMockSessionDetail(404404)).toThrow(MockSessionNotFoundError);
+  });
+
+  it("task/subtask 변경이 이후 waiting-room과 in-progress 조회에 반영된다", () => {
+    const createdSessionId = createMockSession({
+      title: "Task 변경 세션",
+      summary: "task mock 상태 확인",
+      notice: "",
+      category: "DEVELOPMENT",
+      startTime: new Date(Date.now() + 10 * 60 * 1000).toISOString(),
+      sessionDurationMinutes: 60,
+      maxParticipants: 4,
+    }).createdSessionId;
+    joinMockSession(createdSessionId, {
+      goal: "초기 목표",
+      todos: ["첫 할 일"],
+    });
+
+    const taskId = getMockWaitingRoom(createdSessionId).members[0].task!.taskId;
+    const firstSubtaskId = getMockWaitingRoom(createdSessionId).members[0].task!.todos[0].subtaskId;
+
+    updateMockTaskGoal(taskId, "수정된 목표");
+    updateMockSubtask(firstSubtaskId, "수정된 할 일");
+    const createdSubtaskIds = createMockSubtasks(taskId, [
+      { todoContent: "추가 할 일" },
+    ]).subtaskIds;
+    toggleMockSubtaskCompletion(createdSubtaskIds[0]);
+    deleteMockSubtask(firstSubtaskId);
+
+    expect(getMockWaitingRoom(createdSessionId).members[0].task).toEqual(
+      expect.objectContaining({
+        goal: "수정된 목표",
+        todos: [
+          expect.objectContaining({ subtaskId: createdSubtaskIds[0], content: "추가 할 일" }),
+        ],
+      })
+    );
+
+    expect(getMockInProgress(createdSessionId).members[0].task).toEqual(
+      expect.objectContaining({
+        goal: "수정된 목표",
+        todos: [
+          expect.objectContaining({
+            subtaskId: createdSubtaskIds[0],
+            content: "추가 할 일",
+            isCompleted: true,
+          }),
+        ],
+      })
+    );
+  });
+
+  it("unknown task/subtask id는 성공으로 위장하지 않는다", () => {
+    expect(() => updateMockTaskGoal(999999, "없는 목표 수정")).toThrow(MockTaskNotFoundError);
+    expect(() => createMockSubtasks(999999, [{ todoContent: "없는 task에 추가" }])).toThrow(
+      MockTaskNotFoundError
+    );
+    expect(() => updateMockSubtask(999999, "없는 todo 수정")).toThrow(MockSubtaskNotFoundError);
+    expect(() => deleteMockSubtask(999999)).toThrow(MockSubtaskNotFoundError);
+    expect(() => toggleMockSubtaskCompletion(999999)).toThrow(MockSubtaskNotFoundError);
+  });
+
+  it("unknown reaction/kick member id는 성공으로 위장하지 않는다", () => {
+    const createdSessionId = createMockSession({
+      title: "member mutation strict 세션",
+      summary: "member id strict 처리 확인",
+      notice: "",
+      category: "DEVELOPMENT",
+      startTime: new Date(Date.now() + 10 * 60 * 1000).toISOString(),
+      sessionDurationMinutes: 60,
+      maxParticipants: 4,
+    }).createdSessionId;
+    joinMockSession(createdSessionId, { goal: "member strict", todos: ["확인"] });
+
+    expect(() => sendMockReaction(createdSessionId, 999999, "HEART")).toThrow(
+      MockMemberNotFoundError
+    );
+    expect(() => kickMockSessionMembers(createdSessionId, [999999])).toThrow(
+      MockMemberNotFoundError
+    );
+  });
+});

--- a/src/test/msw/msw-unhandled-policy.test.ts
+++ b/src/test/msw/msw-unhandled-policy.test.ts
@@ -1,0 +1,75 @@
+import {
+  parseRequiredJsonText,
+  readRequiredMultipartJsonPart,
+  requireMultipartPart,
+} from "@/mocks/handlers/json";
+import { isUnhandledBackendApiRequest, strictUnhandledApiRequest } from "@/mocks/unhandled-request";
+
+describe("MSW strict unhandled API policy", () => {
+  it.each([
+    "http://localhost:3000/api/unknown",
+    "http://localhost:3000/api/sessions/unknown/deep/path",
+    "https://example.com/api/unknown",
+  ])("fails unhandled backend API request: %s", (url) => {
+    expect(isUnhandledBackendApiRequest({ url, method: "GET" })).toBe(true);
+    expect(() => strictUnhandledApiRequest({ url, method: "GET" })).toThrow(
+      `[MSW] Unhandled backend API request: GET ${url}`
+    );
+  });
+
+  it.each([
+    "http://localhost:3000/_next/static/chunk.js",
+    "http://localhost:3000/favicon.ico",
+    "http://localhost:3000/images/logo.png",
+    "https://cdn.example.com/api-client.js",
+  ])("does not fail non-backend/static request: %s", (url) => {
+    expect(isUnhandledBackendApiRequest({ url, method: "GET" })).toBe(false);
+    expect(() => strictUnhandledApiRequest({ url, method: "GET" })).not.toThrow();
+  });
+
+  it("malformed or empty mutation payload는 성공 fallback 대신 parse error를 낸다", () => {
+    expect(() => parseRequiredJsonText("", "member nickname update")).toThrow(
+      "member nickname update payload is required"
+    );
+    expect(() => parseRequiredJsonText("{", "member nickname update")).toThrow(
+      "member nickname update payload must be valid JSON"
+    );
+    expect(
+      parseRequiredJsonText<{ nickname: string }>(
+        '{"nickname":"모각작러"}',
+        "member nickname update"
+      )
+    ).toEqual({
+      nickname: "모각작러",
+    });
+  });
+
+  it("multipart mutation payload도 required part가 없으면 parse error를 낸다", async () => {
+    const emptyFormRequest = {
+      formData: async () => new FormData(),
+    } as Request;
+
+    await expect(
+      readRequiredMultipartJsonPart(emptyFormRequest, "request", "session create")
+    ).rejects.toThrow("session create request part is required");
+
+    const emptyImageRequest = {
+      formData: async () => new FormData(),
+    } as Request;
+
+    await expect(
+      requireMultipartPart(emptyImageRequest, "profileImage", "member profile image update")
+    ).rejects.toThrow("member profile image update profileImage part is required");
+  });
+
+  it("multipart profileImage key는 실제 memberApi 필드명과 일치한다", async () => {
+    const formData = new FormData();
+    const profileImage = new Blob(["mock-image"], { type: "image/png" });
+    formData.append("profileImage", profileImage);
+    const request = { formData: async () => formData } as Request;
+
+    await expect(
+      requireMultipartPart(request, "profileImage", "member profile image update")
+    ).resolves.toBeTruthy();
+  });
+});

--- a/src/test/msw/msw-unhandled-policy.test.ts
+++ b/src/test/msw/msw-unhandled-policy.test.ts
@@ -1,3 +1,4 @@
+import { MEMBER_PROFILE_IMAGE_FORM_KEY } from "@/features/member/api";
 import {
   parseRequiredJsonText,
   readRequiredMultipartJsonPart,
@@ -58,18 +59,22 @@ describe("MSW strict unhandled API policy", () => {
     } as Request;
 
     await expect(
-      requireMultipartPart(emptyImageRequest, "profileImage", "member profile image update")
+      requireMultipartPart(
+        emptyImageRequest,
+        MEMBER_PROFILE_IMAGE_FORM_KEY,
+        "member profile image update"
+      )
     ).rejects.toThrow("member profile image update profileImage part is required");
   });
 
   it("multipart profileImage key는 실제 memberApi 필드명과 일치한다", async () => {
     const formData = new FormData();
     const profileImage = new Blob(["mock-image"], { type: "image/png" });
-    formData.append("profileImage", profileImage);
+    formData.append(MEMBER_PROFILE_IMAGE_FORM_KEY, profileImage);
     const request = { formData: async () => formData } as Request;
 
     await expect(
-      requireMultipartPart(request, "profileImage", "member profile image update")
+      requireMultipartPart(request, MEMBER_PROFILE_IMAGE_FORM_KEY, "member profile image update")
     ).resolves.toBeTruthy();
   });
 });

--- a/src/test/proxy.test.ts
+++ b/src/test/proxy.test.ts
@@ -28,6 +28,7 @@ const PROTECTED_PAGE_ACCESS_PATHS = [
   "/session/create",
   "/session/1/result",
 ];
+const originalMockMode = process.env.NEXT_PUBLIC_USE_MOCK;
 
 describe("Proxy Middleware", () => {
   let consoleErrorSpy: jest.SpyInstance;
@@ -55,12 +56,18 @@ describe("Proxy Middleware", () => {
     consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
     // 환경 변수 설정
     process.env.BACKEND_API_BASE = "http://localhost:8080";
+    process.env.NEXT_PUBLIC_USE_MOCK = "false";
   });
 
   afterEach(() => {
     consoleErrorSpy.mockRestore();
     // 환경 변수 정리
     delete process.env.BACKEND_API_BASE;
+    if (originalMockMode === undefined) {
+      delete process.env.NEXT_PUBLIC_USE_MOCK;
+    } else {
+      process.env.NEXT_PUBLIC_USE_MOCK = originalMockMode;
+    }
   });
 
   /**
@@ -361,6 +368,35 @@ describe("Proxy Middleware", () => {
         );
         expect(mockFetch).not.toHaveBeenCalled();
       }
+    });
+  });
+
+  describe("mock 모드 인증 우회", () => {
+    it("mock 모드에서는 보호된 페이지를 토큰 없이 통과시켜야 함", async () => {
+      process.env.NEXT_PUBLIC_USE_MOCK = "true";
+      const request = new NextRequest(`http://localhost:3000${PRIMARY_PROTECTED_PAGE_PATH}`);
+
+      const response = await proxy(request);
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("location")).toBeNull();
+      expect(hasSetCookie(response, (cookie) => cookie.startsWith("redirectAfterLogin="))).toBe(
+        false
+      );
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("mock 모드에서는 보호된 API를 토큰 없이 통과시켜야 함", async () => {
+      process.env.NEXT_PUBLIC_USE_MOCK = "true";
+      const request = new NextRequest("http://localhost:3000/api/members/me/profile");
+
+      const response = await proxy(request);
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("location")).toBeNull();
+      expect(hasSetCookie(response, (cookie) => cookie.startsWith("accessToken=;"))).toBe(false);
+      expect(hasSetCookie(response, (cookie) => cookie.startsWith("refreshToken=;"))).toBe(false);
+      expect(mockFetch).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## 작업 내용

> 해당 PR에서 작업한 내용을 정리해주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MSW 기반 모킹 모드를 도입하고, 백엔드 API 및 SSE를 로컬 목 서버로 재현했습니다.
  * 모킹 활성 시 워커 준비가 완료된 뒤에만 화면을 렌더링하도록 구성했고, `/api` 라우팅 보정 및 인증 우회 흐름을 적용했습니다.
  * 멤버/세션/태스크/인증 핸들러와 `POST /api/mock/reset` 리셋 기능을 추가했습니다.
* **Bug Fixes**
  * 모크 모드에서 인증 쿠키/토큰 주입을 중단하고, 미처리 API 요청은 엄격히 감지하도록 개선했습니다.
* **Tests**
  * 라우팅 재작성, mock 활성 조건, MSW 커버리지, 세션 상태/에러/미처리 정책 검증 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

- MSW 기반 로컬 mock backend 환경을 구성했습니다.
  - `msw` 설치 및 `public/mockServiceWorker.js` 추가
  - `.env.development.local`에서 `NEXT_PUBLIC_USE_MOCK=true` 설정 시 mock mode로 실행
  - 브라우저 mock worker 설정 (`src/mocks/browser.ts`)
  - 서버 mock server 설정 (`src/mocks/server.ts`, `src/instrumentation.ts`)
  - `MockProvider`를 layout에 연결해 mock worker 준비 후 앱을 렌더링하도록 구성

- 주요 프론트 API 호출에 대응하는 MSW handler를 추가했습니다.
  - auth
  - member/profile/report
  - session
  - task/subtask
  - SSE
  - mock reset
  - unhandled `/api/*` 요청 감지 정책

- 세션 플로우용 상태 기반 mock store를 추가했습니다.
  - 세션 생성 → 참여 → 대기방 → 진행 중 → 결과 제출 → 리포트 흐름 지원
  - `/session/900` 확인용 seed 데이터 추가
    - 참여자 10명
    - 내 목표/투두 5개
  - task/subtask 수정, 추가, 삭제, 완료 토글 mock 지원

- 서버 컴포넌트/SSR 환경에서도 MSW mock이 동작하도록 보강했습니다.
  - 서버 fetch 전에 mock server 시작을 보장하는 `ensureMockServer` 추가
  - mock mode에서 backend path를 `/api/*` mock path로 정규화
  - profile settings/report 서버 데이터 요청도 mock endpoint로 라우팅되도록 보강

- mock mode에서 인증 보호 페이지 접근을 허용했습니다.
  - `/session/900`
  - `/profile/settings`
  - `/profile/report`
  - 보호 API 요청도 mock mode에서는 proxy 인증 관문을 통과하도록 처리

- 테스트를 추가했습니다.
  - MSW handler coverage
  - session state flow
  - strict unhandled request policy
  - SSR mock routing
  - mock auth/proxy behavior

## 참고 사항

> 코드 리뷰 시 참고할 만한 사항이나 주의할 점을 작성해주세요.

- 로컬에서 MSW mock backend를 사용하려면 `.env.development.local` 파일에 아래 값을 설정해야 합니다.

```bash
NEXT_PUBLIC_USE_MOCK=true
```

- 현재 SSE mock은 payload shape 중심으로 구성되어 있습니다.
  - `waiting-members-updated`
  - `in-progress-members-updated`
  - `session-status-updated`
  - `reaction-updated`
  - `member-reaction-updated`
- 장시간 연결 유지, heartbeat, reconnect 동작까지 완전하게 모델링하지는 않았습니다.

- 검증한 명령어:

```bash
pnpm typecheck
pnpm test -- api-mock-server-routing.test.ts proxy.test.ts msw-api-coverage.test.ts msw-session-state.test.ts msw-unhandled-policy.test.ts resolve-server-auth-state.test.ts --runInBand --silent
```

## 연관 이슈

> 이 PR과 연관된 이슈 번호를 작성하세요. 예) close #10

close #281

## CodeRabbit 운영 메모

- 증분 리뷰 재실행: `@coderabbitai review`
- 전체 PR 재검토: `@coderabbitai full review`
