### PR TITLE
Feat/#287 my page UI

### DIFF
--- a/src/app/(with-header)/profile/layout.tsx
+++ b/src/app/(with-header)/profile/layout.tsx
@@ -9,9 +9,9 @@ interface ProfileLayoutProps {
 
 export default function ProfileLayout({ children }: ProfileLayoutProps) {
   return (
-    <div className="mx-auto flex w-full flex-col gap-[64px] px-6 py-[64px] md:px-[54px]">
+    <div className="gap-2xl py-2xl mx-auto flex w-full flex-col px-5 md:gap-16 md:px-10 md:py-16 xl:px-[54px]">
       <ProfileSummary />
-      <div className="flex flex-col gap-[64px]">
+      <div className="gap-2xl flex flex-col md:gap-16">
         <ProfileTabs />
         {children}
       </div>

--- a/src/features/member/components/Profile/ProfileAccountContent.tsx
+++ b/src/features/member/components/Profile/ProfileAccountContent.tsx
@@ -61,15 +61,15 @@ export function ProfileAccountContent() {
   const { deleteAccount, isDeleting } = useDeleteAccountFlow();
 
   return (
-    <div className="flex flex-col items-center gap-32">
+    <div className="gap-2xl flex flex-col items-center md:gap-32">
       <div className="gap-xl flex w-full flex-col">
         <h4 className="text-text-primary text-lg font-bold">계정 관리</h4>
-        <div className="gap-lg flex w-full">
-          <aside className="gap-sm flex w-[276px] flex-col">
+        <div className="gap-lg flex w-full flex-col md:flex-row">
+          <aside className="gap-sm flex w-full flex-col md:w-69">
             <SidebarNavButton isActive>회원 탈퇴</SidebarNavButton>
             <SidebarNavButton onClick={() => setIsLogoutModalOpen(true)}>로그아웃</SidebarNavButton>
           </aside>
-          <div className="px-3xl flex flex-1 flex-col gap-20">
+          <div className="md:px-3xl gap-xl flex flex-1 flex-col md:gap-20">
             <DeleteAccountWarnings />
             <AccountProfileCard profile={profile} isLoading={isProfilePending} />
             <DeleteAccountAgreement onAgreementChange={setIsAgreed} />

--- a/src/features/member/components/Profile/ProfileEditForm.tsx
+++ b/src/features/member/components/Profile/ProfileEditForm.tsx
@@ -88,7 +88,7 @@ export function ProfileEditForm() {
   }
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)} className="flex w-full flex-col gap-20">
+    <form onSubmit={handleSubmit(onSubmit)} className="gap-2xl flex w-full flex-col md:gap-20">
       <div className="gap-2xl flex flex-col">
         <h3 className="text-text-primary text-lg font-bold">프로필 정보</h3>
 

--- a/src/features/member/components/Profile/ProfileSummary.tsx
+++ b/src/features/member/components/Profile/ProfileSummary.tsx
@@ -58,37 +58,37 @@ export function ProfileSummary() {
     <div className="gap-3xl flex w-full flex-col items-start">
       <h1 className="text-text-primary text-2xl font-bold">마이페이지</h1>
 
-      <div className="gap-lg flex w-full">
-        <label
-          className="relative h-16 w-16 shrink-0 cursor-pointer"
-          onMouseEnter={() => setIsHovered(true)}
-          onMouseLeave={() => setIsHovered(false)}
-        >
-          <input
-            type="file"
-            className="hidden"
-            accept="image/jpeg,image/png,image/webp"
-            onChange={handleProfileImageChange}
-            disabled={isUpdatingProfileImage}
-          />
-          <Avatar
-            src={profile.profileImageUrl ?? undefined}
-            alt={profile.nickname}
-            size="xlarge"
-            type={profile.profileImageUrl ? "image" : "empty"}
-            edit={!isUpdatingProfileImage && isHovered}
-            className="h-full w-full"
-          />
-        </label>
+      <div className="gap-lg flex w-full flex-col xl:flex-row xl:items-start">
+        <div className="gap-lg flex w-full min-w-0 flex-1">
+          <label
+            className="relative h-16 w-16 shrink-0 cursor-pointer"
+            onMouseEnter={() => setIsHovered(true)}
+            onMouseLeave={() => setIsHovered(false)}
+          >
+            <input
+              type="file"
+              className="hidden"
+              accept="image/jpeg,image/png,image/webp"
+              onChange={handleProfileImageChange}
+              disabled={isUpdatingProfileImage}
+            />
+            <Avatar
+              src={profile.profileImageUrl ?? undefined}
+              alt={profile.nickname}
+              size="xlarge"
+              type={profile.profileImageUrl ? "image" : "empty"}
+              edit={!isUpdatingProfileImage && isHovered}
+              className="h-full w-full"
+            />
+          </label>
 
-        <div className="flex flex-1 justify-between gap-[12px]">
           <div className="gap-2xs flex min-w-0 flex-1 flex-col items-start">
-            <div className="gap-xs flex items-center">
+            <div className="gap-xs flex flex-wrap items-center">
               <h2 className="text-text-primary text-lg font-bold">{profile.nickname}</h2>
               <ChipBadge
                 status="closed"
                 radius="xs"
-                className="bg-alpha-white-8 text-text-secondary px-xs py-2xs"
+                className="bg-alpha-white-8 text-text-secondary px-xs py-2xs max-w-full"
               >
                 {profile.email}
               </ChipBadge>
@@ -97,32 +97,32 @@ export function ProfileSummary() {
               {profile.bio || "아직 한 줄 소개가 없습니다."}
             </p>
           </div>
+        </div>
 
-          <div className="flex shrink-0 items-start justify-end gap-10">
-            <div className="flex w-[88px] flex-col items-start gap-1">
-              <span className="text-text-tertiary text-[15px] font-normal">참여한 세션</span>
-              <span className="text-text-secondary text-lg font-semibold">
-                {profile.participationSessionCount ?? 0}
-              </span>
-            </div>
-            <div className="flex w-[88px] flex-col items-start gap-1">
-              <span className="text-text-tertiary text-[15px] font-normal">누적 시간</span>
-              <span className="text-text-secondary text-lg font-semibold">
-                {formatSecondsToHours(profile.totalParticipationTime ?? 0)}
-              </span>
-            </div>
-            <div className="flex w-[88px] flex-col items-start gap-1">
-              <span className="text-text-tertiary text-[15px] font-normal">투두 달성률</span>
-              <span className="text-text-brand-default text-lg font-semibold">
-                {profile.todoCompletionRate ?? 0}%
-              </span>
-            </div>
-            <div className="flex w-[88px] flex-col items-start gap-1">
-              <span className="text-text-tertiary text-[15px] font-normal">집중률</span>
-              <span className="text-text-status-positive-default text-lg font-semibold">
-                {profile.focusRate ?? 0}%
-              </span>
-            </div>
+        <div className="gap-y-lg grid w-full grid-cols-2 gap-x-10 md:grid-cols-4 xl:flex xl:w-auto xl:shrink-0 xl:justify-end xl:gap-10">
+          <div className="flex w-full flex-col items-start gap-1 xl:w-22">
+            <span className="text-text-tertiary text-[15px] font-normal">참여한 세션</span>
+            <span className="text-text-secondary text-lg font-semibold">
+              {profile.participationSessionCount ?? 0}
+            </span>
+          </div>
+          <div className="flex w-full flex-col items-start gap-1 xl:w-22">
+            <span className="text-text-tertiary text-[15px] font-normal">누적 시간</span>
+            <span className="text-text-secondary text-lg font-semibold">
+              {formatSecondsToHours(profile.totalParticipationTime ?? 0)}
+            </span>
+          </div>
+          <div className="flex w-full flex-col items-start gap-1 xl:w-22">
+            <span className="text-text-tertiary text-[15px] font-normal">투두 달성률</span>
+            <span className="text-text-brand-default text-lg font-semibold">
+              {profile.todoCompletionRate ?? 0}%
+            </span>
+          </div>
+          <div className="flex w-full flex-col items-start gap-1 xl:w-22">
+            <span className="text-text-tertiary text-[15px] font-normal">집중률</span>
+            <span className="text-text-status-positive-default text-lg font-semibold">
+              {profile.focusRate ?? 0}%
+            </span>
           </div>
         </div>
       </div>

--- a/src/features/member/components/Profile/ProfileTabs.tsx
+++ b/src/features/member/components/Profile/ProfileTabs.tsx
@@ -15,7 +15,7 @@ export function ProfileTabs() {
   const pathname = usePathname();
 
   return (
-    <div className="border-border-subtle flex w-full items-center border-b-[2px]">
+    <div className="border-border-subtle scrollbar-hide flex w-full items-center overflow-x-auto border-b-[2px]">
       {TABS.map((tab) => {
         const isActive = pathname === tab.href;
         return (
@@ -23,7 +23,7 @@ export function ProfileTabs() {
             key={tab.href}
             href={tab.href}
             className={cn(
-              "flex flex-col items-start border-b-[2px] px-6 py-3 transition-colors",
+              "flex shrink-0 flex-col items-start border-b-[2px] px-4 py-3 transition-colors md:px-6",
               isActive
                 ? "border-border-stronger text-text-primary mb-[-2px]" // mb-[-2px] ensures the active border overlaps the container's bottom border visually
                 : "text-text-muted hover:text-text-primary mb-[-2px] border-transparent"

--- a/src/features/member/components/Profile/Report/StatsContent.tsx
+++ b/src/features/member/components/Profile/Report/StatsContent.tsx
@@ -15,7 +15,7 @@ export default async function StatsContent() {
   const stats = data.result;
 
   return (
-    <div className="gap-lg grid grid-cols-2">
+    <div className="gap-lg grid grid-cols-1 md:grid-cols-2">
       <ActivitySummaryCard
         data={{
           focusedTime: stats.focusedTime,

--- a/src/features/member/components/Profile/Report/StatsSkeleton.tsx
+++ b/src/features/member/components/Profile/Report/StatsSkeleton.tsx
@@ -2,7 +2,7 @@ import ReportCard from "@/components/ReportCard/ReportCard";
 
 export default function StatsSkeleton() {
   return (
-    <div className="gap-lg grid grid-cols-2">
+    <div className="gap-lg grid grid-cols-1 md:grid-cols-2">
       <ActivitySummaryCardSkeleton />
       <CategoryParticipationCardSkeleton />
       <ReceivedEmojiCardSkeleton />


### PR DESCRIPTION
## 작업 내용

### 작업 내용
마이페이지(/profile) 전반을 3-tier 브레이크포인트(모바일 <768 / 태블릿 md 768–1279 / 데스크톱 xl ≥1280)에 맞춰 반응형으로 정리했습니다. 기존 데스크톱 기준 고정폭 레이아웃이 모바일에서 가로로 넘치던 문제를 해결했습니다.

### 프로필 요약 (ProfileSummary)

아바타+텍스트(프로필 그룹)와 통계 블록을 분리하고 flex-col xl:flex-row로 스택 → 가로 전환
통계 4블록: 모바일 2×2 그리드 → 태블릿 4열 → 데스크톱 가로 1줄 (grid-cols-2 md:grid-cols-4 xl:flex), 각 셀 w-full xl:w-22
닉네임+이메일 칩 flex-wrap 처리로 이메일이 길 때 줄바꿈되어 오버플로 방지
탭 (ProfileTabs)

좁은 화면 대비 overflow-x-auto scrollbar-hide + 각 탭 shrink-0, 패딩 px-4 md:px-6
계정 관리 (ProfileAccountContent)

고정폭 사이드바 → flex-col md:flex-row, w-full md:w-69 (모바일 풀폭 스택)
본문 좌우 패딩 md:px-3xl로 모바일에서 제거, 세로 여백 모바일 축소
기록 리포트 (StatsContent / StatsSkeleton)

통계 카드 그리드 grid-cols-1 md:grid-cols-2 (스켈레톤 동기화)
레이아웃 / 폼

profile/layout.tsx 패딩 램프 px-5 md:px-10 xl:px-[54px], 여백 모바일 축소
ProfileEditForm 세로 여백 gap-2xl md:gap-20

###참고 사항
브레이크포인트/토큰은 기존 컨벤션(md/xl만 사용, gap-*·px-* 토큰, 시맨틱 색상)을 그대로 따랐습니다. 신규 컴포넌트·유틸 추가 없이 클래스 조정만으로 처리했습니다.
기록 리포트 상세 카드(ActivitySummaryCard, ReceivedEmojiCard 등)는 이미 max-md: 반응형이 적용되어 있어 375/768/1280 타깃에서 오버플로가 없어 별도 변경하지 않았습니다.
검증: pnpm typecheck ✅ · 변경 파일 eslint ✅ · pnpm test src/test/member (6 suites / 19 tests) ✅
/profile/*는 로그인 보호 라우트라 실렌더 확인 시 로그인 세션이 필요합니다.
연관 이슈

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 프로필 페이지의 여백과 콘텐츠 배치를 반응형으로 조정해 다양한 화면 크기에서 더욱 자연스럽게 표시됩니다.
  * 프로필 요약 정보와 통계 영역의 레이아웃을 개선해 모바일·태블릿·데스크톱에서 가독성이 향상되었습니다.
  * 프로필 탭을 가로로 스크롤할 수 있어 작은 화면에서도 탭이 잘리지 않습니다.
  * 통계 및 로딩 화면이 모바일에서는 한 열, 중간 화면 이상에서는 두 열로 표시됩니다.
  * 프로필 편집 화면의 섹션 간 간격과 정렬이 반응형으로 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 참고 사항

> 코드 리뷰 시 참고할 만한 사항이나 주의할 점을 작성해주세요.

## 연관 이슈

> 이 PR과 연관된 이슈 번호를 작성하세요. 예) close #10

## CodeRabbit 운영 메모

- 증분 리뷰 재실행: `@coderabbitai review`
- 전체 PR 재검토: `@coderabbitai full review`
