### PR TITLE
Fix/#292 서비스 문구 오탈자 및 달성률 표기 통일

### DIFF
--- a/src/app/(with-header)/privacy/page.tsx
+++ b/src/app/(with-header)/privacy/page.tsx
@@ -17,8 +17,8 @@ export default function PrivacyPage() {
 
       <p className="text-text-secondary mt-6 leading-7">
         GAK (DND 9팀, 이하 &quot;운영팀&quot;)은 이용자의 개인정보를 중요시하며, 「개인정보 보호법」
-        등 등 관련 법령을 준수합니다. 이 방침은 운영팀이 수집한 개인정보가 어떻게 이용되고
-        보호되는지 설명합니다.
+        등 관련 법령을 준수합니다. 이 방침은 운영팀이 수집한 개인정보가 어떻게 이용되고 보호되는지
+        설명합니다.
       </p>
 
       <div className="mt-10 flex flex-col gap-10">

--- a/src/features/member/components/Profile/Report/ActivitySummaryCard.tsx
+++ b/src/features/member/components/Profile/Report/ActivitySummaryCard.tsx
@@ -19,7 +19,7 @@ export default function ActivitySummaryCard({
   focusedTimeLabel = "총 집중 시간",
   participationTimeLabel = "전체 참여 시간",
   achievementRate,
-  achievementRateLabel = "목표 달성율",
+  achievementRateLabel = "목표 달성률",
 }: ActivitySummaryCardProps) {
   return (
     <ReportCard>

--- a/src/features/session/components/SessionResult/ParticipantsReportContent.tsx
+++ b/src/features/session/components/SessionResult/ParticipantsReportContent.tsx
@@ -62,7 +62,7 @@ export async function ParticipantsReportContent({ sessionId }: ParticipantsRepor
           focusedTimeLabel="평균 집중 시간"
           participationTimeLabel="평균 참여 시간"
           achievementRate={sessionReport?.averageAchievementRate ?? 0}
-          achievementRateLabel="평균 목표 달성율"
+          achievementRateLabel="평균 목표 달성률"
         />
         <RealtimeSessionEmojiCard sessionId={sessionId} initialEmojis={initialEmojis} />
       </div>

--- a/src/features/session/components/SessionResult/SessionResultContent.tsx
+++ b/src/features/session/components/SessionResult/SessionResultContent.tsx
@@ -56,7 +56,6 @@ export async function SessionResultContent({ sessionId }: SessionResultContentPr
           title="나의 활동 요약"
           participationTimeLabel="전체 참여 시간"
           achievementRate={memberResult.achievementRate}
-          achievementRateLabel="목표 달성율"
         />
         <RealtimeMemberEmojiCard
           sessionId={sessionId}


### PR DESCRIPTION
## 작업 내용

- 개인정보 처리방침의 `등 등` 중복 표현을 수정했습니다.
- 세션 결과와 참여자 리포트의 `달성율` 표기를 `달성률`로 통일했습니다.
- 결과 화면의 중복 `achievementRateLabel` prop을 제거하고 공용 기본값을 사용하도록 정리했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 개인정보 처리방침 문장의 중복 표현과 줄바꿈을 정리했습니다.
  * 목표 달성률 관련 문구의 맞춤법을 수정했습니다.
  * 활동 요약 및 세션 결과 화면에서 일관된 표현이 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 검증

- `rg -n '달성율|등 등' src`: 검색 결과 없음
- `git diff --check`: 통과
- `pnpm lint`: 0 errors, 기존 warnings 8건
- `pnpm typecheck`: 통과
- `pnpm test --passWithNoTests`: 57 suites, 564 tests 통과

## 참고 사항

- 정적 문구 수정만 포함하며 신규 테스트 파일은 추가하지 않았습니다.

## 연관 이슈

Closes #292
Close #307 