### PR TITLE
fix: 권한 없을 시 권한없음 페이지 출력되도록 수정

### DIFF
--- a/src/features/session/components/SessionEditContent.tsx
+++ b/src/features/session/components/SessionEditContent.tsx
@@ -8,7 +8,6 @@ import { Button } from "@/components/Button/Button";
 import { ErrorFallbackUI } from "@/components/Error/ErrorFallbackUI";
 import { TrashIcon } from "@/components/Icon/TrashIcon";
 import { useAuthState } from "@/features/auth/hooks/useAuthState";
-import { useMe } from "@/features/member/hooks/useMemberHooks";
 import { ApiError } from "@/lib/api/api-client";
 import { DEFAULT_API_ERROR_MESSAGE } from "@/lib/error/error-codes";
 import { LOGIN_ROUTE } from "@/lib/routes/route-paths";
@@ -29,8 +28,12 @@ export function SessionEditContent({ sessionId }: SessionEditContentProps) {
   const authState = useAuthState();
   const isAuthenticated = authState.status === "authenticated";
   const { data, isLoading, error, refetch } = useSessionDetail(sessionId);
-  const { data: meData, isLoading: isMeLoading } = useMe({ enabled: isAuthenticated });
-  const { data: waitingRoomData, isLoading: isWaitingRoomLoading } = useWaitingRoom(sessionId, {
+  const {
+    data: waitingRoomData,
+    isLoading: isWaitingRoomLoading,
+    error: waitingRoomError,
+    refetch: refetchWaitingRoom,
+  } = useWaitingRoom(sessionId, {
     enabled: isAuthenticated,
   });
 
@@ -39,17 +42,19 @@ export function SessionEditContent({ sessionId }: SessionEditContentProps) {
   const { mutate: deleteSession, isPending: isDeleting } = useDeleteSession();
 
   const isAuthDataLoading =
-    authState.status === "recovering" || (isAuthenticated && (isMeLoading || isWaitingRoomLoading));
+    authState.status === "recovering" || (isAuthenticated && isWaitingRoomLoading);
 
   const session = data?.result;
   // 대기 중인 세션만 수정/삭제 가능 (백엔드 SESSION400_12/14 사전 차단)
   const isEditable = !!session && isWaitingStatus(session.status);
 
   // 호스트만 수정/삭제 가능 — 세션 상세 API에는 호스트 식별자가 없어 대기방 멤버의 role로 판별한다.
-  // 대기방 조회 실패·미참여 시에는 isHost=false로 남아 폼이 열리지 않는다(fail-closed).
-  const myMemberId = meData?.result?.id;
+  // 대기방 조회 실패는 "권한 없음"과 구분해야 한다. 실패를 그대로 fail-closed 처리하면
+  // 실제 호스트에게도 권한 안내가 뜨므로, 재시도 가능한 오류 화면으로 분기한다.
+  const myMemberId = isAuthenticated ? authState.profile.id : undefined;
   const isHost =
-    !!myMemberId &&
+    !waitingRoomError &&
+    myMemberId !== undefined &&
     (waitingRoomData?.result?.members?.some(
       (member) => member.memberId === myMemberId && member.role === "HOST"
     ) ??
@@ -127,6 +132,14 @@ export function SessionEditContent({ sessionId }: SessionEditContentProps) {
           description="세션을 수정하려면 로그인이 필요합니다."
           buttonLabel="로그인하기"
           href={LOGIN_ROUTE}
+        />
+      ) : waitingRoomError ? (
+        <ErrorFallbackUI
+          className="py-20"
+          title="수정 권한을 확인할 수 없어요"
+          description="권한 정보를 불러오는데 실패했습니다. 잠시 후 다시 시도해주세요."
+          buttonLabel="다시 시도하기"
+          onRetry={() => void refetchWaitingRoom()}
         />
       ) : !isHost ? (
         <ErrorFallbackUI

--- a/src/features/session/components/SessionEditContent.tsx
+++ b/src/features/session/components/SessionEditContent.tsx
@@ -28,6 +28,9 @@ export function SessionEditContent({ sessionId }: SessionEditContentProps) {
   const authState = useAuthState();
   const isAuthenticated = authState.status === "authenticated";
   const { data, isLoading, error, refetch } = useSessionDetail(sessionId);
+
+  // 세션 상세와 병렬로 조회한다. isEditable에 연동해 지연시키면 정상 경로(호스트의 수정 진입)에
+  // 왕복이 하나 늘어난다. 조회 지연이 세션 오류 화면을 가리는 문제는 아래 렌더 분기 순서로 처리한다.
   const {
     data: waitingRoomData,
     isLoading: isWaitingRoomLoading,
@@ -41,8 +44,14 @@ export function SessionEditContent({ sessionId }: SessionEditContentProps) {
   const [deleteServerError, setDeleteServerError] = useState<string | null>(null);
   const { mutate: deleteSession, isPending: isDeleting } = useDeleteSession();
 
+  // isLoading(= isPending && isFetching)만으로는 부족하다. SSR(서버에서 fetch 미실행)이나
+  // 오프라인(fetchStatus "paused")에서는 데이터가 없어도 isLoading이 false라 로딩 분기를 통과하고,
+  // isHost가 false로 떨어져 호스트에게 "수정 권한이 없어요"가 표시된다.
+  // 응답이 도착했는지(데이터 유무)를 기준으로 판정한다.
+  const isWaitingRoomUnresolved = !waitingRoomError && waitingRoomData === undefined;
   const isAuthDataLoading =
-    authState.status === "recovering" || (isAuthenticated && isWaitingRoomLoading);
+    authState.status === "recovering" ||
+    (isAuthenticated && (isWaitingRoomLoading || isWaitingRoomUnresolved));
 
   const session = data?.result;
   // 대기 중인 세션만 수정/삭제 가능 (백엔드 SESSION400_12/14 사전 차단)
@@ -82,6 +91,18 @@ export function SessionEditContent({ sessionId }: SessionEditContentProps) {
     });
   };
 
+  // 세션 상세 조회 실패는 로딩보다 먼저 처리한다. 대기방 조회나 인증 복구가 지연되는 동안
+  // 로딩 화면이 먼저 걸리면 사용자가 재시도 버튼에 도달하지 못한다.
+  const sessionErrorFallback = (
+    <ErrorFallbackUI
+      className="py-20"
+      title="세션 정보를 불러올 수 없어요"
+      description="데이터를 불러오는데 실패했습니다. 잠시 후 다시 시도해주세요."
+      buttonLabel="다시 시도하기"
+      onRetry={() => void refetch()}
+    />
+  );
+
   return (
     <>
       <header className="mb-xl md:mb-2xl flex items-start justify-between gap-4">
@@ -111,16 +132,12 @@ export function SessionEditContent({ sessionId }: SessionEditContentProps) {
         )}
       </header>
 
-      {isLoading || isAuthDataLoading ? (
+      {error ? (
+        sessionErrorFallback
+      ) : isLoading || isAuthDataLoading ? (
         <p className="text-text-secondary py-20 text-center text-sm">불러오는 중...</p>
-      ) : error || !session ? (
-        <ErrorFallbackUI
-          className="py-20"
-          title="세션 정보를 불러올 수 없어요"
-          description="데이터를 불러오는데 실패했습니다. 잠시 후 다시 시도해주세요."
-          buttonLabel="다시 시도하기"
-          onRetry={() => void refetch()}
-        />
+      ) : !session ? (
+        sessionErrorFallback
       ) : !isEditable ? (
         <ErrorFallbackUI
           className="py-20"

--- a/src/features/session/components/SessionEditContent.tsx
+++ b/src/features/session/components/SessionEditContent.tsx
@@ -7,11 +7,14 @@ import { useRouter } from "next/navigation";
 import { Button } from "@/components/Button/Button";
 import { ErrorFallbackUI } from "@/components/Error/ErrorFallbackUI";
 import { TrashIcon } from "@/components/Icon/TrashIcon";
+import { useAuthState } from "@/features/auth/hooks/useAuthState";
+import { useMe } from "@/features/member/hooks/useMemberHooks";
 import { ApiError } from "@/lib/api/api-client";
 import { DEFAULT_API_ERROR_MESSAGE } from "@/lib/error/error-codes";
+import { LOGIN_ROUTE } from "@/lib/routes/route-paths";
 import { toast } from "@/lib/toast";
 
-import { useDeleteSession, useSessionDetail } from "../hooks/useSessionHooks";
+import { useDeleteSession, useSessionDetail, useWaitingRoom } from "../hooks/useSessionHooks";
 import { isWaitingStatus } from "../types";
 
 import { SessionCreateForm } from "./SessionCreateForm";
@@ -23,15 +26,35 @@ interface SessionEditContentProps {
 
 export function SessionEditContent({ sessionId }: SessionEditContentProps) {
   const router = useRouter();
+  const authState = useAuthState();
+  const isAuthenticated = authState.status === "authenticated";
   const { data, isLoading, error, refetch } = useSessionDetail(sessionId);
+  const { data: meData, isLoading: isMeLoading } = useMe({ enabled: isAuthenticated });
+  const { data: waitingRoomData, isLoading: isWaitingRoomLoading } = useWaitingRoom(sessionId, {
+    enabled: isAuthenticated,
+  });
 
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [deleteServerError, setDeleteServerError] = useState<string | null>(null);
   const { mutate: deleteSession, isPending: isDeleting } = useDeleteSession();
 
+  const isAuthDataLoading =
+    authState.status === "recovering" || (isAuthenticated && (isMeLoading || isWaitingRoomLoading));
+
   const session = data?.result;
   // 대기 중인 세션만 수정/삭제 가능 (백엔드 SESSION400_12/14 사전 차단)
   const isEditable = !!session && isWaitingStatus(session.status);
+
+  // 호스트만 수정/삭제 가능 — 세션 상세 API에는 호스트 식별자가 없어 대기방 멤버의 role로 판별한다.
+  // 대기방 조회 실패·미참여 시에는 isHost=false로 남아 폼이 열리지 않는다(fail-closed).
+  const myMemberId = meData?.result?.id;
+  const isHost =
+    !!myMemberId &&
+    (waitingRoomData?.result?.members?.some(
+      (member) => member.memberId === myMemberId && member.role === "HOST"
+    ) ??
+      false);
+  const canManage = isEditable && isHost;
 
   const handleDelete = () => {
     setDeleteServerError(null);
@@ -60,7 +83,7 @@ export function SessionEditContent({ sessionId }: SessionEditContentProps) {
           <p className="mt-2xs text-[13px] text-gray-500 md:text-base">세션 정보를 수정해보세요</p>
         </div>
 
-        {isEditable && (
+        {canManage && (
           <Button
             type="button"
             variant="outlined"
@@ -79,7 +102,7 @@ export function SessionEditContent({ sessionId }: SessionEditContentProps) {
         )}
       </header>
 
-      {isLoading ? (
+      {isLoading || isAuthDataLoading ? (
         <p className="text-text-secondary py-20 text-center text-sm">불러오는 중...</p>
       ) : error || !session ? (
         <ErrorFallbackUI
@@ -94,6 +117,22 @@ export function SessionEditContent({ sessionId }: SessionEditContentProps) {
           className="py-20"
           title="수정할 수 없는 세션이에요"
           description="대기 중인 세션만 수정할 수 있어요."
+          buttonLabel="세션으로 돌아가기"
+          href={`/session/${sessionId}/waiting`}
+        />
+      ) : !isAuthenticated ? (
+        <ErrorFallbackUI
+          className="py-20"
+          title="로그인이 필요해요"
+          description="세션을 수정하려면 로그인이 필요합니다."
+          buttonLabel="로그인하기"
+          href={LOGIN_ROUTE}
+        />
+      ) : !isHost ? (
+        <ErrorFallbackUI
+          className="py-20"
+          title="수정 권한이 없어요"
+          description="세션을 만든 호스트만 수정할 수 있어요."
           buttonLabel="세션으로 돌아가기"
           href={`/session/${sessionId}/waiting`}
         />

--- a/src/lib/api/api-client.ts
+++ b/src/lib/api/api-client.ts
@@ -104,8 +104,10 @@ function isApiErrorResponse(value: unknown): value is ApiErrorResponse {
 
 function getApiErrorMessage(value: unknown, status: number): string {
   // 백엔드가 같은 에러 코드를 여러 의미로 재사용하는 경우가 있어(예: SESSION400_15가
-  // 세션 생성 제한/수정 불가 양쪽에 쓰임) 서버 메시지를 우선 노출하고, 없을 때만 코드 매핑으로 폴백
-  if (isApiErrorResponse(value) && value.message.trim() !== "") {
+  // 세션 생성 제한/수정 불가 양쪽에 쓰임) 서버 메시지를 우선 노출하고, 없을 때만 코드 매핑으로 폴백.
+  // isApiErrorResponse는 isSuccess까지 요구하므로 게이트웨이 등에서 필드가 빠지면 코드 매핑으로
+  // 떨어져 엉뚱한 문구가 나온다. 판정 대신 message 유무만 본다.
+  if (isRecord(value) && typeof value.message === "string" && value.message.trim() !== "") {
     return value.message;
   }
 

--- a/src/test/api-error-message.test.ts
+++ b/src/test/api-error-message.test.ts
@@ -1,0 +1,61 @@
+import { ApiError, executeFetch } from "@/lib/api/api-client";
+
+function mockErrorResponse(body: unknown, status = 400) {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: false,
+    status,
+    statusText: "Bad Request",
+    headers: new Headers({ "content-type": "application/json" }),
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  }) as unknown as typeof fetch;
+}
+
+describe("API 에러 메시지 해석", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.restoreAllMocks();
+  });
+
+  // 백엔드가 SESSION400_15를 "세션 생성 제한"과 "수정 불가" 양쪽에 재사용한다.
+  // 코드 매핑을 고정 적용하면 생성 화면에서 "수정" 문구가 나온다.
+  it("재사용되는 코드라도 서버 메시지를 그대로 노출해야 한다", async () => {
+    mockErrorResponse({
+      httpStatus: "BAD_REQUEST",
+      isSuccess: false,
+      code: "SESSION400_15",
+      message: "한 번에 하나의 세션만 생성할 수 있습니다",
+    });
+
+    await expect(
+      executeFetch("POST", "https://example.test/api/sessions/create", {})
+    ).rejects.toThrow(new ApiError("한 번에 하나의 세션만 생성할 수 있습니다", 400));
+  });
+
+  it("isSuccess 필드가 없는 응답에서도 서버 메시지를 노출해야 한다", async () => {
+    mockErrorResponse({
+      httpStatus: "BAD_REQUEST",
+      code: "SESSION400_15",
+      message: "한 번에 하나의 세션만 생성할 수 있습니다",
+    });
+
+    await expect(
+      executeFetch("POST", "https://example.test/api/sessions/create", {})
+    ).rejects.toThrow("한 번에 하나의 세션만 생성할 수 있습니다");
+  });
+
+  it("서버 메시지가 비어 있으면 코드 매핑으로 폴백해야 한다", async () => {
+    mockErrorResponse({
+      httpStatus: "BAD_REQUEST",
+      isSuccess: false,
+      code: "SESSION400_15",
+      message: "   ",
+    });
+
+    await expect(
+      executeFetch("POST", "https://example.test/api/sessions/create", {})
+    ).rejects.toThrow("세션에 참여자가 있어 수정할 수 없어요.");
+  });
+});

--- a/src/test/session/session-edit-content.test.tsx
+++ b/src/test/session/session-edit-content.test.tsx
@@ -1,11 +1,11 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import { SessionEditContent } from "@/features/session/components/SessionEditContent";
 
 const mockUseAuthState = jest.fn();
 const mockUseSessionDetail = jest.fn();
 const mockUseWaitingRoom = jest.fn();
-const mockUseMe = jest.fn();
 
 jest.mock("next/navigation", () => ({
   useRouter: () => ({ push: jest.fn() }),
@@ -13,10 +13,6 @@ jest.mock("next/navigation", () => ({
 
 jest.mock("@/features/auth/hooks/useAuthState", () => ({
   useAuthState: () => mockUseAuthState(),
-}));
-
-jest.mock("@/features/member/hooks/useMemberHooks", () => ({
-  useMe: () => mockUseMe(),
 }));
 
 jest.mock("@/features/session/hooks/useSessionHooks", () => ({
@@ -55,11 +51,6 @@ describe("SessionEditContent", () => {
       refetch: jest.fn(),
     });
 
-    mockUseMe.mockReturnValue({
-      data: { result: { id: 7 } },
-      isLoading: false,
-    });
-
     mockUseWaitingRoom.mockReturnValue({
       data: {
         result: {
@@ -70,6 +61,8 @@ describe("SessionEditContent", () => {
         },
       },
       isLoading: false,
+      error: null,
+      refetch: jest.fn(),
     });
   });
 
@@ -81,9 +74,9 @@ describe("SessionEditContent", () => {
   });
 
   it("로그인한 비호스트(참여자)면 수정 폼 대신 권한 안내를 표시해야 한다", () => {
-    mockUseMe.mockReturnValue({
-      data: { result: { id: 8 } },
-      isLoading: false,
+    mockUseAuthState.mockReturnValue({
+      status: "authenticated",
+      profile: { id: 8 },
     });
 
     render(<SessionEditContent sessionId="1" />);
@@ -94,9 +87,9 @@ describe("SessionEditContent", () => {
   });
 
   it("로그인한 미참여자면 수정 폼 대신 권한 안내를 표시해야 한다", () => {
-    mockUseMe.mockReturnValue({
-      data: { result: { id: 99 } },
-      isLoading: false,
+    mockUseAuthState.mockReturnValue({
+      status: "authenticated",
+      profile: { id: 99 },
     });
 
     render(<SessionEditContent sessionId="1" />);
@@ -105,21 +98,42 @@ describe("SessionEditContent", () => {
     expect(screen.getByText("수정 권한이 없어요")).toBeInTheDocument();
   });
 
-  it("대기방 조회에 실패하면 수정 폼을 열지 않아야 한다 (fail-closed)", () => {
+  it("대기방 응답에 데이터가 없으면 수정 폼을 열지 않아야 한다 (fail-closed)", () => {
     mockUseWaitingRoom.mockReturnValue({
       data: undefined,
       isLoading: false,
+      error: null,
+      refetch: jest.fn(),
     });
 
     render(<SessionEditContent sessionId="1" />);
 
     expect(screen.queryByTestId("session-edit-form")).not.toBeInTheDocument();
     expect(screen.getByText("수정 권한이 없어요")).toBeInTheDocument();
+  });
+
+  it("대기방 조회가 실패하면 권한 안내 대신 재시도 가능한 오류 화면을 표시해야 한다", async () => {
+    const refetchWaitingRoom = jest.fn();
+    mockUseWaitingRoom.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error("waiting room failed"),
+      refetch: refetchWaitingRoom,
+    });
+
+    render(<SessionEditContent sessionId="1" />);
+
+    expect(screen.queryByTestId("session-edit-form")).not.toBeInTheDocument();
+    expect(screen.queryByText("수정 권한이 없어요")).not.toBeInTheDocument();
+    expect(screen.getByText("수정 권한을 확인할 수 없어요")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /삭제하기/ })).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "다시 시도하기" }));
+    expect(refetchWaitingRoom).toHaveBeenCalledTimes(1);
   });
 
   it("비로그인 사용자면 로그인 안내를 표시해야 한다", () => {
     mockUseAuthState.mockReturnValue({ status: "guest" });
-    mockUseMe.mockReturnValue({ data: undefined, isLoading: false });
     mockUseWaitingRoom.mockReturnValue({ data: undefined, isLoading: false });
 
     render(<SessionEditContent sessionId="1" />);
@@ -130,7 +144,6 @@ describe("SessionEditContent", () => {
 
   it("인증 정보 복구 중이면 수정 폼을 렌더링하지 않아야 한다", () => {
     mockUseAuthState.mockReturnValue({ status: "recovering" });
-    mockUseMe.mockReturnValue({ data: undefined, isLoading: true });
     mockUseWaitingRoom.mockReturnValue({ data: undefined, isLoading: true });
 
     render(<SessionEditContent sessionId="1" />);

--- a/src/test/session/session-edit-content.test.tsx
+++ b/src/test/session/session-edit-content.test.tsx
@@ -98,9 +98,26 @@ describe("SessionEditContent", () => {
     expect(screen.getByText("수정 권한이 없어요")).toBeInTheDocument();
   });
 
-  it("대기방 응답에 데이터가 없으면 수정 폼을 열지 않아야 한다 (fail-closed)", () => {
+  // SSR과 오프라인(fetchStatus "paused")에서는 응답 전에도 isLoading이 false다.
+  // 이때 권한 안내로 떨어지면 호스트에게 "수정 권한이 없어요"가 표시된다.
+  it("대기방 응답 전이면 isLoading이 false여도 권한 안내 대신 로딩을 표시해야 한다", () => {
     mockUseWaitingRoom.mockReturnValue({
       data: undefined,
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    render(<SessionEditContent sessionId="1" />);
+
+    expect(screen.queryByTestId("session-edit-form")).not.toBeInTheDocument();
+    expect(screen.queryByText("수정 권한이 없어요")).not.toBeInTheDocument();
+    expect(screen.getByText("불러오는 중...")).toBeInTheDocument();
+  });
+
+  it("대기방 응답에 참여자 정보가 없으면 수정 폼을 열지 않아야 한다 (fail-closed)", () => {
+    mockUseWaitingRoom.mockReturnValue({
+      data: { result: { members: [] } },
       isLoading: false,
       error: null,
       refetch: jest.fn(),
@@ -130,6 +147,67 @@ describe("SessionEditContent", () => {
 
     await userEvent.click(screen.getByRole("button", { name: "다시 시도하기" }));
     expect(refetchWaitingRoom).toHaveBeenCalledTimes(1);
+  });
+
+  it("세션 상세 조회 실패와 대기방 조회 지연이 겹쳐도 세션 오류 화면을 표시해야 한다", async () => {
+    const refetchSession = jest.fn();
+    mockUseSessionDetail.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error("session detail failed"),
+      refetch: refetchSession,
+    });
+    // 대기방 조회가 아직 응답하지 않은 상태
+    mockUseWaitingRoom.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    render(<SessionEditContent sessionId="1" />);
+
+    expect(screen.queryByText("불러오는 중...")).not.toBeInTheDocument();
+    expect(screen.getByText("세션 정보를 불러올 수 없어요")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "다시 시도하기" }));
+    expect(refetchSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("세션 상세 조회 실패와 인증 복구 지연이 겹쳐도 세션 오류 화면을 표시해야 한다", () => {
+    mockUseAuthState.mockReturnValue({ status: "recovering" });
+    mockUseSessionDetail.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error("session detail failed"),
+      refetch: jest.fn(),
+    });
+    mockUseWaitingRoom.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    render(<SessionEditContent sessionId="1" />);
+
+    expect(screen.queryByText("불러오는 중...")).not.toBeInTheDocument();
+    expect(screen.getByText("세션 정보를 불러올 수 없어요")).toBeInTheDocument();
+  });
+
+  // 대기방 조회를 isEditable에 연동하면 정상 경로에 왕복이 하나 늘어나므로,
+  // 세션 상태와 무관하게 병렬로 조회하는 것이 의도된 동작이다.
+  it("세션 상태와 무관하게 대기방 조회를 세션 상세와 병렬로 시작해야 한다", () => {
+    mockUseSessionDetail.mockReturnValue({
+      data: { result: { sessionId: 1, title: "테스트 세션", status: "진행중" } },
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    render(<SessionEditContent sessionId="1" />);
+
+    expect(mockUseWaitingRoom).toHaveBeenCalledWith("1", { enabled: true });
   });
 
   it("비로그인 사용자면 로그인 안내를 표시해야 한다", () => {

--- a/src/test/session/session-edit-content.test.tsx
+++ b/src/test/session/session-edit-content.test.tsx
@@ -1,0 +1,161 @@
+import { render, screen } from "@testing-library/react";
+
+import { SessionEditContent } from "@/features/session/components/SessionEditContent";
+
+const mockUseAuthState = jest.fn();
+const mockUseSessionDetail = jest.fn();
+const mockUseWaitingRoom = jest.fn();
+const mockUseMe = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock("@/features/auth/hooks/useAuthState", () => ({
+  useAuthState: () => mockUseAuthState(),
+}));
+
+jest.mock("@/features/member/hooks/useMemberHooks", () => ({
+  useMe: () => mockUseMe(),
+}));
+
+jest.mock("@/features/session/hooks/useSessionHooks", () => ({
+  useSessionDetail: (...args: unknown[]) => mockUseSessionDetail(...args),
+  useWaitingRoom: (...args: unknown[]) => mockUseWaitingRoom(...args),
+  useDeleteSession: () => ({ mutate: jest.fn(), isPending: false }),
+}));
+
+jest.mock("@/features/session/components/SessionCreateForm", () => ({
+  SessionCreateForm: () => <div data-testid="session-edit-form" />,
+}));
+
+jest.mock("@/features/session/components/SessionDeleteConfirmDialog", () => ({
+  SessionDeleteConfirmDialog: () => <div data-testid="session-delete-dialog" />,
+}));
+
+describe("SessionEditContent", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseAuthState.mockReturnValue({
+      status: "authenticated",
+      profile: { id: 7 },
+    });
+
+    mockUseSessionDetail.mockReturnValue({
+      data: {
+        result: {
+          sessionId: 1,
+          title: "테스트 세션",
+          status: "대기",
+        },
+      },
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    mockUseMe.mockReturnValue({
+      data: { result: { id: 7 } },
+      isLoading: false,
+    });
+
+    mockUseWaitingRoom.mockReturnValue({
+      data: {
+        result: {
+          members: [
+            { memberId: 7, role: "HOST", task: null },
+            { memberId: 8, role: "PARTICIPANT", task: null },
+          ],
+        },
+      },
+      isLoading: false,
+    });
+  });
+
+  it("호스트면 수정 폼과 삭제 버튼을 렌더링해야 한다", () => {
+    render(<SessionEditContent sessionId="1" />);
+
+    expect(screen.getByTestId("session-edit-form")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /삭제하기/ })).toBeInTheDocument();
+  });
+
+  it("로그인한 비호스트(참여자)면 수정 폼 대신 권한 안내를 표시해야 한다", () => {
+    mockUseMe.mockReturnValue({
+      data: { result: { id: 8 } },
+      isLoading: false,
+    });
+
+    render(<SessionEditContent sessionId="1" />);
+
+    expect(screen.queryByTestId("session-edit-form")).not.toBeInTheDocument();
+    expect(screen.getByText("수정 권한이 없어요")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /삭제하기/ })).not.toBeInTheDocument();
+  });
+
+  it("로그인한 미참여자면 수정 폼 대신 권한 안내를 표시해야 한다", () => {
+    mockUseMe.mockReturnValue({
+      data: { result: { id: 99 } },
+      isLoading: false,
+    });
+
+    render(<SessionEditContent sessionId="1" />);
+
+    expect(screen.queryByTestId("session-edit-form")).not.toBeInTheDocument();
+    expect(screen.getByText("수정 권한이 없어요")).toBeInTheDocument();
+  });
+
+  it("대기방 조회에 실패하면 수정 폼을 열지 않아야 한다 (fail-closed)", () => {
+    mockUseWaitingRoom.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    });
+
+    render(<SessionEditContent sessionId="1" />);
+
+    expect(screen.queryByTestId("session-edit-form")).not.toBeInTheDocument();
+    expect(screen.getByText("수정 권한이 없어요")).toBeInTheDocument();
+  });
+
+  it("비로그인 사용자면 로그인 안내를 표시해야 한다", () => {
+    mockUseAuthState.mockReturnValue({ status: "guest" });
+    mockUseMe.mockReturnValue({ data: undefined, isLoading: false });
+    mockUseWaitingRoom.mockReturnValue({ data: undefined, isLoading: false });
+
+    render(<SessionEditContent sessionId="1" />);
+
+    expect(screen.queryByTestId("session-edit-form")).not.toBeInTheDocument();
+    expect(screen.getByText("로그인이 필요해요")).toBeInTheDocument();
+  });
+
+  it("인증 정보 복구 중이면 수정 폼을 렌더링하지 않아야 한다", () => {
+    mockUseAuthState.mockReturnValue({ status: "recovering" });
+    mockUseMe.mockReturnValue({ data: undefined, isLoading: true });
+    mockUseWaitingRoom.mockReturnValue({ data: undefined, isLoading: true });
+
+    render(<SessionEditContent sessionId="1" />);
+
+    expect(screen.queryByTestId("session-edit-form")).not.toBeInTheDocument();
+    expect(screen.getByText("불러오는 중...")).toBeInTheDocument();
+  });
+
+  it("대기 중이 아닌 세션이면 호스트여도 수정 불가 안내를 표시해야 한다", () => {
+    mockUseSessionDetail.mockReturnValue({
+      data: {
+        result: {
+          sessionId: 1,
+          title: "테스트 세션",
+          status: "진행중",
+        },
+      },
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    render(<SessionEditContent sessionId="1" />);
+
+    expect(screen.queryByTestId("session-edit-form")).not.toBeInTheDocument();
+    expect(screen.getByText("수정할 수 없는 세션이에요")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 작업 내용

> 권한없는 사용자가 edit 페이지에 직접 접속 시, 접속 권한 차단 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **변경 사항**
  * 세션 수정 및 삭제 권한을 대기방 상태와 호스트 여부에 따라 제한합니다.
  * 인증 및 대기방 정보를 불러오는 동안 로딩 상태를 표시합니다.
  * 비로그인, 권한 부족, 정보 조회 실패 시 상황별 안내와 재시도·로그인·돌아가기 기능을 제공합니다.
  * 호스트에게만 세션 삭제 버튼이 표시됩니다.

* **테스트**
  * 호스트·참여자 권한, 진행 중 세션 제한, 조회 실패 및 재시도 동작을 검증했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 참고 사항

## 연관 이슈

> close #295 

## CodeRabbit 운영 메모

- 증분 리뷰 재실행: `@coderabbitai review`
- 전체 PR 재검토: `@coderabbitai full review`
