### PR TITLE
fix: 백엔드 서버 메시지 우선 노출 수정

### DIFF
--- a/src/lib/api/api-client.ts
+++ b/src/lib/api/api-client.ts
@@ -103,8 +103,10 @@ function isApiErrorResponse(value: unknown): value is ApiErrorResponse {
 }
 
 function getApiErrorMessage(value: unknown, status: number): string {
-  if (isApiErrorResponse(value)) {
-    return getApiErrorMessageByCode(value.code) ?? value.message;
+  // 백엔드가 같은 에러 코드를 여러 의미로 재사용하는 경우가 있어(예: SESSION400_15가
+  // 세션 생성 제한/수정 불가 양쪽에 쓰임) 서버 메시지를 우선 노출하고, 없을 때만 코드 매핑으로 폴백
+  if (isApiErrorResponse(value) && value.message.trim() !== "") {
+    return value.message;
   }
 
   if (isRecord(value) && typeof value.code === "string") {


### PR DESCRIPTION
## 작업 내용

> 진행 중 세션이 있을 때 다시 생성할 경우 노출되는 에러 메시지 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * API 오류 응답에 서버 메시지가 포함된 경우, 사용자에게 더 구체적인 오류 안내를 표시합니다.
  * 서버 메시지가 없으면 기존 오류 코드와 기본 오류 메시지를 사용합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 참고 사항

## 연관 이슈

> close #296 

## CodeRabbit 운영 메모

- 증분 리뷰 재실행: `@coderabbitai review`
- 전체 PR 재검토: `@coderabbitai full review`
