### PR TITLE
fix: 달성도, 집중도를 내 달성도, 집중도 이상으로 설정하지 못하게 수정

### DIFF
--- a/src/components/StepperSlide/StepperSlide.tsx
+++ b/src/components/StepperSlide/StepperSlide.tsx
@@ -15,23 +15,36 @@ export function StepperSlide({
   onChange,
   myFocusValue,
   myFocusLabel = "내 집중도",
+  limit,
   min = 0,
   max = 100,
   disabled = false,
   className,
   ref,
 }: StepperSlideProps & { ref?: React.Ref<HTMLDivElement> }) {
-  const { isDragging, percentage, trackRef, handleMouseDown, handleTrackClick, handleKeyDown } =
-    useStepperSlide({
-      value,
-      onChange,
-      min,
-      max,
-      disabled,
-    });
+  const {
+    isDragging,
+    percentage,
+    selectableMax,
+    trackRef,
+    handleMouseDown,
+    handleTrackClick,
+    handleKeyDown,
+  } = useStepperSlide({
+    value,
+    onChange,
+    min,
+    max,
+    limit,
+    disabled,
+  });
 
   const myFocusPercentage =
     myFocusValue !== undefined ? ((myFocusValue - min) / (max - min)) * 100 : undefined;
+
+  // 선택할 수 없는 구간(상한 초과)을 트랙 위에 흐리게 표시한다.
+  const limitPercentage =
+    limit !== undefined ? ((selectableMax - min) / (max - min)) * 100 : undefined;
 
   return (
     <div
@@ -90,6 +103,14 @@ export function StepperSlide({
           style={{ width: `${percentage}%` }}
         />
 
+        {/* 선택 불가 구간 */}
+        {limitPercentage !== undefined && limitPercentage < 100 && (
+          <div
+            className="absolute top-0 h-full rounded-r-full bg-gray-800"
+            style={{ left: `${limitPercentage}%`, width: `${100 - limitPercentage}%` }}
+          />
+        )}
+
         {/* 내 집중도 마커 */}
         {myFocusPercentage !== undefined && (
           <div
@@ -114,7 +135,7 @@ export function StepperSlide({
           tabIndex={disabled ? -1 : 0}
           role="slider"
           aria-valuemin={min}
-          aria-valuemax={max}
+          aria-valuemax={selectableMax}
           aria-valuenow={value}
           aria-disabled={disabled}
         />

--- a/src/components/StepperSlide/StepperSlide.types.ts
+++ b/src/components/StepperSlide/StepperSlide.types.ts
@@ -7,6 +7,11 @@ export interface StepperSlideProps {
   myFocusValue?: number;
   /** 마커 말풍선 라벨 (기본값: "내 집중도") */
   myFocusLabel?: string;
+  /**
+   * 선택 가능한 상한값 (예: 내 달성률/집중률).
+   * 눈금 스케일(min~max)은 그대로 두고 이 값을 넘는 선택만 막는다.
+   */
+  limit?: number;
   /** 최소값 (기본값: 0) */
   min?: number;
   /** 최대값 (기본값: 100) */

--- a/src/components/StepperSlide/useStepperSlide.ts
+++ b/src/components/StepperSlide/useStepperSlide.ts
@@ -5,12 +5,15 @@ interface UseStepperSlideOptions {
   onChange: (value: number) => void;
   min?: number;
   max?: number;
+  limit?: number;
   disabled?: boolean;
 }
 
 interface UseStepperSlideReturn {
   isDragging: boolean;
   percentage: number;
+  /** 실제로 선택 가능한 최대값 (limit 반영) */
+  selectableMax: number;
   trackRef: React.RefObject<HTMLDivElement | null>;
   handleMouseDown: (e: React.MouseEvent) => void;
   handleTrackClick: (e: React.MouseEvent) => void;
@@ -22,6 +25,7 @@ export function useStepperSlide({
   onChange,
   min = 0,
   max = 100,
+  limit,
   disabled = false,
 }: UseStepperSlideOptions): UseStepperSlideReturn {
   const [isDragging, setIsDragging] = useState(false);
@@ -29,12 +33,16 @@ export function useStepperSlide({
 
   const percentage = ((value - min) / (max - min)) * 100;
 
+  // limit은 눈금 스케일(min~max)은 그대로 두고 선택 상한만 낮춘다.
+  // 소수점 비율(예: 63.5)이 들어와도 상한을 넘기지 않도록 내림한다.
+  const selectableMax = limit === undefined ? max : Math.min(max, Math.max(min, Math.floor(limit)));
+
   const getValueFromPosition = (clientX: number) => {
     if (!trackRef.current) return min;
     const rect = trackRef.current.getBoundingClientRect();
     const position = (clientX - rect.left) / rect.width;
     const rawValue = min + position * (max - min);
-    return Math.round(Math.min(max, Math.max(min, rawValue)));
+    return Math.round(Math.min(selectableMax, Math.max(min, rawValue)));
   };
 
   const handleMouseDown = (e: React.MouseEvent) => {
@@ -55,7 +63,7 @@ export function useStepperSlide({
     switch (e.key) {
       case "ArrowRight":
       case "ArrowUp":
-        newValue = Math.min(max, value + 1);
+        newValue = Math.min(selectableMax, value + 1);
         break;
       case "ArrowLeft":
       case "ArrowDown":
@@ -65,7 +73,7 @@ export function useStepperSlide({
         newValue = min;
         break;
       case "End":
-        newValue = max;
+        newValue = selectableMax;
         break;
       default:
         return;
@@ -100,6 +108,7 @@ export function useStepperSlide({
   return {
     isDragging,
     percentage,
+    selectableMax,
     trackRef,
     handleMouseDown,
     handleTrackClick,

--- a/src/components/StepperSlide/useStepperSlide.ts
+++ b/src/components/StepperSlide/useStepperSlide.ts
@@ -35,7 +35,10 @@ export function useStepperSlide({
 
   // limit은 눈금 스케일(min~max)은 그대로 두고 선택 상한만 낮춘다.
   // 소수점 비율(예: 63.5)이 들어와도 상한을 넘기지 않도록 내림한다.
-  const selectableMax = limit === undefined ? max : Math.min(max, Math.max(min, Math.floor(limit)));
+  // 상한을 넘는 value가 들어와도 상한이 value 아래로 내려가지는 않는다.
+  // (그러면 aria-valuenow > aria-valuemax가 되고, 증가 키가 값을 상한까지 낮춘다.)
+  const selectableMax =
+    limit === undefined ? max : Math.min(max, Math.max(min, Math.floor(limit), value));
 
   const getValueFromPosition = (clientX: number) => {
     if (!trackRef.current) return min;

--- a/src/features/session/components/SessionCreateForm.tsx
+++ b/src/features/session/components/SessionCreateForm.tsx
@@ -42,6 +42,7 @@ import {
   SESSION_RATE_DEFAULT,
 } from "../constants/sessionLimits";
 import { useCreateSession, useUpdateSession } from "../hooks/useSessionHooks";
+import { clampToRateLimit, resolveSessionRateRange } from "../utils/sessionRateLimits";
 import { validateSessionForm, type SessionFormErrors } from "../utils/validateSessionForm";
 
 import { SessionCreateConfirmDialog } from "./SessionCreateConfirmDialog";
@@ -93,20 +94,23 @@ export function SessionCreateForm({
   ); // 집중도 범위
 
   // 참여 조건은 내 달성률·집중률을 넘을 수 없다. (안내 문구와 동일한 규칙)
-  // 소수점 비율이 와도 상한을 넘기지 않도록 내림한다.
-  const achievementLimit = myProfile?.todoCompletionRate;
-  const focusLimit = myProfile?.focusRate;
-  const clampToLimit = (rate: number, limit: number | undefined) =>
-    limit === undefined ? rate : Math.min(rate, Math.max(0, Math.floor(limit)));
-
-  // 생성 모드: 프로필 로딩 전에 잡힌 기본값(50)이 상한을 넘으면 상한으로 낮춰 사용한다.
-  // 수정 모드: 이미 저장된 값은 상한을 넘더라도 임의로 낮추지 않고, 상향 조작만 슬라이더에서 막는다.
-  const achievementRange = isEdit
-    ? achievementRangeInput
-    : clampToLimit(achievementRangeInput, achievementLimit);
-  const focusRange = isEdit ? focusRangeInput : clampToLimit(focusRangeInput, focusLimit);
-  const defaultAchievementRange = clampToLimit(SESSION_RATE_DEFAULT, achievementLimit);
-  const defaultFocusRange = clampToLimit(SESSION_RATE_DEFAULT, focusLimit);
+  const { value: achievementRange, limit: achievementLimit } = resolveSessionRateRange({
+    isEdit,
+    input: achievementRangeInput,
+    savedRate: initialValues?.requiredAchievementRate ?? 0,
+    profileRate: myProfile?.todoCompletionRate,
+  });
+  const { value: focusRange, limit: focusLimit } = resolveSessionRateRange({
+    isEdit,
+    input: focusRangeInput,
+    savedRate: initialValues?.requiredFocusRate ?? 0,
+    profileRate: myProfile?.focusRate,
+  });
+  const defaultAchievementRange = clampToRateLimit(
+    SESSION_RATE_DEFAULT,
+    myProfile?.todoCompletionRate
+  );
+  const defaultFocusRange = clampToRateLimit(SESSION_RATE_DEFAULT, myProfile?.focusRate);
 
   // DatePicker 팝업 상태
   const [isDatePickerOpen, setIsDatePickerOpen] = useState(false);

--- a/src/features/session/components/SessionCreateForm.tsx
+++ b/src/features/session/components/SessionCreateForm.tsx
@@ -39,6 +39,7 @@ import {
   SESSION_PARTICIPANTS_DEFAULT,
   SESSION_PARTICIPANTS_MAX,
   SESSION_PARTICIPANTS_MIN,
+  SESSION_RATE_DEFAULT,
 } from "../constants/sessionLimits";
 import { useCreateSession, useUpdateSession } from "../hooks/useSessionHooks";
 import { validateSessionForm, type SessionFormErrors } from "../utils/validateSessionForm";
@@ -84,12 +85,28 @@ export function SessionCreateForm({
   const [participants, setParticipants] = useState(
     initialValues?.maxParticipants ?? SESSION_PARTICIPANTS_DEFAULT
   ); // 기본값 5명
-  const [achievementRange, setAchievementRange] = useState(
-    initialValues ? (initialValues.requiredAchievementRate ?? 0) : 50
+  const [achievementRangeInput, setAchievementRange] = useState(
+    initialValues ? (initialValues.requiredAchievementRate ?? 0) : SESSION_RATE_DEFAULT
   ); // To do 달성도 범위
-  const [focusRange, setFocusRange] = useState(
-    initialValues ? (initialValues.requiredFocusRate ?? 0) : 50
+  const [focusRangeInput, setFocusRange] = useState(
+    initialValues ? (initialValues.requiredFocusRate ?? 0) : SESSION_RATE_DEFAULT
   ); // 집중도 범위
+
+  // 참여 조건은 내 달성률·집중률을 넘을 수 없다. (안내 문구와 동일한 규칙)
+  // 소수점 비율이 와도 상한을 넘기지 않도록 내림한다.
+  const achievementLimit = myProfile?.todoCompletionRate;
+  const focusLimit = myProfile?.focusRate;
+  const clampToLimit = (rate: number, limit: number | undefined) =>
+    limit === undefined ? rate : Math.min(rate, Math.max(0, Math.floor(limit)));
+
+  // 생성 모드: 프로필 로딩 전에 잡힌 기본값(50)이 상한을 넘으면 상한으로 낮춰 사용한다.
+  // 수정 모드: 이미 저장된 값은 상한을 넘더라도 임의로 낮추지 않고, 상향 조작만 슬라이더에서 막는다.
+  const achievementRange = isEdit
+    ? achievementRangeInput
+    : clampToLimit(achievementRangeInput, achievementLimit);
+  const focusRange = isEdit ? focusRangeInput : clampToLimit(focusRangeInput, focusLimit);
+  const defaultAchievementRange = clampToLimit(SESSION_RATE_DEFAULT, achievementLimit);
+  const defaultFocusRange = clampToLimit(SESSION_RATE_DEFAULT, focusLimit);
 
   // DatePicker 팝업 상태
   const [isDatePickerOpen, setIsDatePickerOpen] = useState(false);
@@ -176,8 +193,8 @@ export function SessionCreateForm({
     startDateTime !== null ||
     duration !== SESSION_DURATION_MINUTES_DEFAULT ||
     participants !== SESSION_PARTICIPANTS_DEFAULT ||
-    achievementRange !== 50 ||
-    focusRange !== 50;
+    achievementRange !== defaultAchievementRange ||
+    focusRange !== defaultFocusRange;
 
   const hasUnsavedChanges = isEdit ? editDirty : createDirty;
 
@@ -532,6 +549,7 @@ export function SessionCreateForm({
               onChange={setAchievementRange}
               myFocusValue={myProfile?.todoCompletionRate}
               myFocusLabel="내 달성률"
+              limit={achievementLimit}
               className="w-[80%]"
             />
           </div>
@@ -555,6 +573,7 @@ export function SessionCreateForm({
               value={focusRange}
               onChange={setFocusRange}
               myFocusValue={myProfile?.focusRate}
+              limit={focusLimit}
               className="w-[80%]"
             />
           </div>

--- a/src/features/session/constants/sessionLimits.ts
+++ b/src/features/session/constants/sessionLimits.ts
@@ -6,3 +6,6 @@ export const SESSION_DURATION_MINUTES_DEFAULT = 90;
 export const SESSION_PARTICIPANTS_MIN = 1;
 export const SESSION_PARTICIPANTS_MAX = 10;
 export const SESSION_PARTICIPANTS_DEFAULT = 5;
+
+/** 참여 조건(달성률·집중률) 슬라이더 기본값 */
+export const SESSION_RATE_DEFAULT = 50;

--- a/src/features/session/utils/sessionRateLimits.ts
+++ b/src/features/session/utils/sessionRateLimits.ts
@@ -1,0 +1,51 @@
+interface ResolveSessionRateRangeOptions {
+  /** 수정 모드 여부 */
+  isEdit: boolean;
+  /** 슬라이더 state에 담긴 현재 입력값 */
+  input: number;
+  /** 수정 모드에서 이미 저장돼 있던 값 (생성 모드에서는 무시) */
+  savedRate: number;
+  /** 내 달성률·집중률. 프로필 로딩 전이면 undefined */
+  profileRate: number | undefined;
+}
+
+interface SessionRateRange {
+  /** 슬라이더에 전달할 값 */
+  value: number;
+  /** 슬라이더에 전달할 선택 상한 */
+  limit: number | undefined;
+}
+
+/** 비율을 상한 이하로 낮춘다. 소수점 상한(예: 63.5)은 넘기지 않도록 내림한다. */
+export function clampToRateLimit(rate: number, limit: number | undefined): number {
+  if (limit === undefined) return rate;
+  return Math.min(rate, Math.max(0, Math.floor(limit)));
+}
+
+/**
+ * 참여 조건(달성률·집중률) 슬라이더에 넘길 값과 선택 상한을 계산한다.
+ * 참여 조건은 내 달성률·집중률을 넘을 수 없다. (안내 문구와 동일한 규칙)
+ *
+ * value가 limit을 넘는 상태를 슬라이더에 넘기면 aria-valuenow > aria-valuemax가 되고,
+ * 증가 키(ArrowRight/ArrowUp)가 증가를 거부하는 대신 값을 상한까지 "낮춘다".
+ * 그래서 두 값은 항상 value <= limit을 만족하도록 함께 계산한다.
+ */
+export function resolveSessionRateRange({
+  isEdit,
+  input,
+  savedRate,
+  profileRate,
+}: ResolveSessionRateRangeOptions): SessionRateRange {
+  // 생성 모드: 프로필 로딩 전에 잡힌 기본값(50)이 상한을 넘으면 상한으로 낮춰 사용한다.
+  if (!isEdit) {
+    return { value: clampToRateLimit(input, profileRate), limit: profileRate };
+  }
+
+  // 수정 모드: 이미 저장된 값은 상한을 넘더라도 임의로 낮추지 않고, 상향 조작만 슬라이더에서 막는다.
+  // 저장된 값까지 상한을 올려 두면 그 값에서 증가 키는 무시되고 하향만 자유로워진다.
+  // 기준을 현재 입력값이 아니라 저장된 값으로 고정해야, 한 번 낮춘 뒤 되돌리지 못하는 문제가 없다.
+  return {
+    value: input,
+    limit: profileRate === undefined ? undefined : Math.max(Math.floor(profileRate), savedRate),
+  };
+}

--- a/src/test/components/StepperSlide.test.tsx
+++ b/src/test/components/StepperSlide.test.tsx
@@ -190,6 +190,64 @@ describe("StepperSlide", () => {
     });
   });
 
+  describe("limit(선택 상한)", () => {
+    it("상한을 넘는 값으로 증가시킬 수 없어야 합니다", () => {
+      const onChange = jest.fn();
+      render(<StepperSlide value={60} onChange={onChange} limit={60} />);
+
+      fireEvent.keyDown(screen.getByRole("slider"), { key: "ArrowRight" });
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("End 키를 눌러도 상한까지만 이동해야 합니다", () => {
+      const onChange = jest.fn();
+      render(<StepperSlide value={10} onChange={onChange} limit={60} />);
+
+      fireEvent.keyDown(screen.getByRole("slider"), { key: "End" });
+
+      expect(onChange).toHaveBeenCalledWith(60);
+    });
+
+    it("소수점 상한은 내림해 적용되어야 합니다", () => {
+      const onChange = jest.fn();
+      render(<StepperSlide value={10} onChange={onChange} limit={63.7} />);
+
+      fireEvent.keyDown(screen.getByRole("slider"), { key: "End" });
+
+      expect(onChange).toHaveBeenCalledWith(63);
+    });
+
+    it("상한 아래로는 자유롭게 감소할 수 있어야 합니다", () => {
+      const onChange = jest.fn();
+      render(<StepperSlide value={60} onChange={onChange} limit={60} />);
+
+      fireEvent.keyDown(screen.getByRole("slider"), { key: "ArrowLeft" });
+
+      expect(onChange).toHaveBeenCalledWith(59);
+    });
+
+    it("aria-valuemax가 상한을 반영해야 합니다", () => {
+      const onChange = jest.fn();
+      render(<StepperSlide value={30} onChange={onChange} limit={60} />);
+
+      expect(screen.getByRole("slider")).toHaveAttribute("aria-valuemax", "60");
+    });
+
+    it("트랙 클릭으로도 상한을 넘길 수 없어야 합니다", () => {
+      const onChange = jest.fn();
+      const { container } = render(<StepperSlide value={30} onChange={onChange} limit={60} />);
+
+      const track = container.querySelector(".cursor-pointer") as HTMLElement;
+      jest
+        .spyOn(track, "getBoundingClientRect")
+        .mockReturnValue({ left: 0, width: 100 } as DOMRect);
+      fireEvent.click(track, { clientX: 90 });
+
+      expect(onChange).toHaveBeenCalledWith(60);
+    });
+  });
+
   describe("커스텀 min/max", () => {
     it("커스텀 min/max 범위에서 올바르게 동작해야 합니다", () => {
       const onChange = jest.fn();

--- a/src/test/components/StepperSlide.test.tsx
+++ b/src/test/components/StepperSlide.test.tsx
@@ -248,6 +248,44 @@ describe("StepperSlide", () => {
     });
   });
 
+  describe("limit보다 큰 value (수정 모드의 기존 값)", () => {
+    it("aria-valuemax가 value보다 작아지지 않아야 합니다", () => {
+      const onChange = jest.fn();
+      render(<StepperSlide value={80} onChange={onChange} limit={60} />);
+
+      const slider = screen.getByRole("slider");
+      expect(slider).toHaveAttribute("aria-valuenow", "80");
+      expect(slider).toHaveAttribute("aria-valuemax", "80");
+    });
+
+    it("증가 키가 값을 상한까지 낮추지 않아야 합니다", () => {
+      const onChange = jest.fn();
+      render(<StepperSlide value={80} onChange={onChange} limit={60} />);
+
+      fireEvent.keyDown(screen.getByRole("slider"), { key: "ArrowRight" });
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("End 키가 값을 상한까지 낮추지 않아야 합니다", () => {
+      const onChange = jest.fn();
+      render(<StepperSlide value={80} onChange={onChange} limit={60} />);
+
+      fireEvent.keyDown(screen.getByRole("slider"), { key: "End" });
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("하향 조작은 그대로 열려 있어야 합니다", () => {
+      const onChange = jest.fn();
+      render(<StepperSlide value={80} onChange={onChange} limit={60} />);
+
+      fireEvent.keyDown(screen.getByRole("slider"), { key: "ArrowLeft" });
+
+      expect(onChange).toHaveBeenCalledWith(79);
+    });
+  });
+
   describe("커스텀 min/max", () => {
     it("커스텀 min/max 범위에서 올바르게 동작해야 합니다", () => {
       const onChange = jest.fn();

--- a/src/test/session/sessionRateLimits.test.ts
+++ b/src/test/session/sessionRateLimits.test.ts
@@ -1,0 +1,95 @@
+import {
+  clampToRateLimit,
+  resolveSessionRateRange,
+} from "../../features/session/utils/sessionRateLimits";
+
+describe("clampToRateLimit", () => {
+  it("상한이 없으면 값을 그대로 둡니다", () => {
+    expect(clampToRateLimit(50, undefined)).toBe(50);
+  });
+
+  it("상한을 넘는 값은 상한으로 낮춥니다", () => {
+    expect(clampToRateLimit(50, 30)).toBe(30);
+  });
+
+  it("소수점 상한은 내림해 적용합니다", () => {
+    expect(clampToRateLimit(70, 63.7)).toBe(63);
+  });
+
+  it("상한 아래 값은 그대로 둡니다", () => {
+    expect(clampToRateLimit(20, 60)).toBe(20);
+  });
+});
+
+describe("resolveSessionRateRange", () => {
+  describe("생성 모드", () => {
+    it("기본값이 상한을 넘으면 상한으로 낮춥니다", () => {
+      expect(
+        resolveSessionRateRange({ isEdit: false, input: 50, savedRate: 0, profileRate: 30 })
+      ).toEqual({ value: 30, limit: 30 });
+    });
+
+    it("프로필 로딩 전에는 값과 상한을 건드리지 않습니다", () => {
+      expect(
+        resolveSessionRateRange({ isEdit: false, input: 50, savedRate: 0, profileRate: undefined })
+      ).toEqual({ value: 50, limit: undefined });
+    });
+  });
+
+  describe("수정 모드", () => {
+    it("상한을 넘는 기존 값을 임의로 낮추지 않습니다", () => {
+      const { value } = resolveSessionRateRange({
+        isEdit: true,
+        input: 80,
+        savedRate: 80,
+        profileRate: 60,
+      });
+
+      expect(value).toBe(80);
+    });
+
+    it("상한을 넘는 기존 값이 있으면 상한을 그 값까지 올립니다", () => {
+      // value > limit을 슬라이더에 넘기면 aria-valuenow > aria-valuemax가 되고
+      // 증가 키가 값을 상한까지 낮춘다. 두 값은 항상 value <= limit이어야 한다.
+      const { value, limit } = resolveSessionRateRange({
+        isEdit: true,
+        input: 80,
+        savedRate: 80,
+        profileRate: 60,
+      });
+
+      expect(limit).toBe(80);
+      expect(value).toBeLessThanOrEqual(limit as number);
+    });
+
+    it("값을 낮춘 뒤에도 기존 값까지는 되돌릴 수 있어야 합니다", () => {
+      // 상한 기준은 현재 입력값이 아니라 저장된 값이므로 70으로 내려도 상한은 80을 유지한다.
+      const { limit } = resolveSessionRateRange({
+        isEdit: true,
+        input: 70,
+        savedRate: 80,
+        profileRate: 60,
+      });
+
+      expect(limit).toBe(80);
+    });
+
+    it("기존 값이 상한 이하면 프로필 상한을 그대로 씁니다", () => {
+      expect(
+        resolveSessionRateRange({ isEdit: true, input: 40, savedRate: 40, profileRate: 60 })
+      ).toEqual({ value: 40, limit: 60 });
+    });
+
+    it("소수점 프로필 상한은 내림해 적용합니다", () => {
+      expect(
+        resolveSessionRateRange({ isEdit: true, input: 40, savedRate: 40, profileRate: 63.7 })
+      ).toEqual({ value: 40, limit: 63 });
+    });
+
+    it("프로필 로딩 전에는 상한을 두지 않습니다", () => {
+      expect(
+        resolveSessionRateRange({ isEdit: true, input: 80, savedRate: 80, profileRate: undefined })
+      ).toEqual({ value: 80, limit: undefined });
+    });
+  });
+});


### PR DESCRIPTION
## 작업 내용

> 달성률·집중률 제한 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 세션 생성 시 달성률과 집중도 슬라이더에 사용자별 선택 상한이 적용됩니다.
  - 슬라이더 트랙에서 선택 가능한 범위와 제한된 범위를 구분해 확인할 수 있습니다.
  - 키보드 조작, 끝값 선택, 트랙 클릭에서도 설정된 상한을 초과하지 않습니다.
  - 소수점 상한은 자동으로 내림 처리됩니다.
  - 세션 참여 조건의 기본값이 50으로 적용됩니다.

- **버그 수정**
  - 세션 수정 시 기존 설정값은 유지하면서 슬라이더의 상향 선택만 제한됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 참고 사항


## 연관 이슈

> close #299 

## CodeRabbit 운영 메모

- 증분 리뷰 재실행: `@coderabbitai review`
- 전체 PR 재검토: `@coderabbitai full review`
