### PR TITLE
fix: 대기실 북마크 버튼 제거

### DIFF
--- a/src/features/lobby/components/LobbyHeader.tsx
+++ b/src/features/lobby/components/LobbyHeader.tsx
@@ -1,12 +1,10 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useRef } from "react";
 
 import { useRouter } from "next/navigation";
 
 import { Button } from "@/components/Button/Button";
-import { BookmarkFillIcon } from "@/components/Icon/BookmarkFillIcon";
-import { BookmarkIcon } from "@/components/Icon/BookmarkIcon";
 import { ChevronLeftIcon } from "@/components/Icon/ChevronLeftIcon";
 import { EditIcon } from "@/components/Icon/EditIcon";
 import { ExternalLinkIcon } from "@/components/Icon/ExternalLinkIcon";
@@ -43,7 +41,6 @@ export function LobbyHeader({
 }: LobbyHeaderProps) {
   const router = useRouter();
   const leaveButtonRef = useRef<HTMLButtonElement>(null);
-  const [isBookmarked, setIsBookmarked] = useState(false);
   const { shareSession } = useShareSession();
   const { handleLeave, isPending, serverError } = useLeaveSessionHandler({
     sessionId,
@@ -84,18 +81,6 @@ export function LobbyHeader({
             onClick={() => shareSession(Number(sessionId))}
             aria-label="세션 링크 공유"
             leftIcon={<ExternalLinkIcon size="xsmall" />}
-          />
-          <Button
-            iconOnly
-            variant="ghost"
-            colorScheme="secondary"
-            size="small"
-            onClick={() => setIsBookmarked((prev) => !prev)}
-            aria-pressed={isBookmarked}
-            aria-label={isBookmarked ? "북마크 해제" : "북마크"}
-            leftIcon={
-              isBookmarked ? <BookmarkFillIcon size="xsmall" /> : <BookmarkIcon size="xsmall" />
-            }
           />
         </div>
         {isHost && (


### PR DESCRIPTION
## 작업 내용

- 구현되지 않은 대기실 북마크 버튼을 제거했습니다.
- 버튼에서만 사용하던 로컬 상태와 아이콘 import를 함께 정리했습니다.
- 공유·수정하기·나가기 동작은 유지했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **변경 사항**
  * 로비 헤더에서 북마크 버튼과 관련 아이콘을 제거했습니다.
  * 세션 공유, 호스트 수정, 세션 나가기 기능은 계속 사용할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 참고 사항

- ESLint 오류 0건, 타입 검사, 전체 Jest 59개 스위트/579개 테스트, 프로덕션 빌드를 통과했습니다.
- MSW 대기실에서 데스크톱·모바일 비노출과 공유·수정·나가기 회귀를 확인했습니다.
- Coverage 모드는 기존 Edge Runtime–Istanbul 동적 코드 생성 제한으로 일부 스위트가 중단되며, 이번 변경과 무관함을 분리 재현했습니다.

## 연관 이슈

close #298

## CodeRabbit 운영 메모

- 증분 리뷰 재실행: `@coderabbitai review`
- 전체 PR 재검토: `@coderabbitai full review`
