### PR TITLE
fix: 관심 카테고리 선택 제한 안내 추가

### DIFF
--- a/src/features/member/components/Profile/ProfileEditForm.tsx
+++ b/src/features/member/components/Profile/ProfileEditForm.tsx
@@ -176,11 +176,15 @@ export function ProfileEditForm() {
                     onClick={() => {
                       if (isSelected) {
                         field.onChange(field.value.filter((k) => k !== catKey));
-                      } else {
-                        if (field.value.length < 3) {
-                          field.onChange([...field.value, catKey]);
-                        }
+                        return;
                       }
+
+                      if (field.value.length >= 3) {
+                        toast.info("관심 카테고리는 최대 3개까지 선택 가능합니다.");
+                        return;
+                      }
+
+                      field.onChange([...field.value, catKey]);
                     }}
                     className="w-[136px]"
                   >

--- a/src/test/member/profile-edit-form.test.tsx
+++ b/src/test/member/profile-edit-form.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { ProfileEditForm } from "@/features/member/components/Profile/ProfileEditForm";
+import { useMeForEdit, useUpdateMe } from "@/features/member/hooks/useMemberHooks";
+import { toast } from "@/lib/toast";
+
+jest.mock("@/features/member/hooks/useMemberHooks", () => ({
+  useMeForEdit: jest.fn(),
+  useUpdateMe: jest.fn(),
+}));
+
+jest.mock("@/lib/toast", () => ({
+  toast: {
+    subscribe: jest.fn(),
+    showToast: jest.fn(),
+    hideToast: jest.fn(),
+    success: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+  },
+}));
+
+const mockedUseMeForEdit = jest.mocked(useMeForEdit);
+const mockedUseUpdateMe = jest.mocked(useUpdateMe);
+const mockedToast = jest.mocked(toast);
+
+describe("ProfileEditForm interest categories", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseMeForEdit.mockReturnValue({
+      data: {
+        isSuccess: true,
+        code: "COMMON200",
+        message: "성공적으로 요청을 처리했습니다.",
+        result: {
+          id: 1,
+          nickname: "테스터",
+          profileImageUrl: "",
+          email: "tester@example.com",
+          bio: "소개",
+          firstInterestCategory: "DEVELOPMENT",
+          secondInterestCategory: "DESIGN",
+          thirdInterestCategory: "PLANNING_PM",
+        },
+      },
+    } as unknown as ReturnType<typeof useMeForEdit>);
+    mockedUseUpdateMe.mockReturnValue({
+      mutate: jest.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof useUpdateMe>);
+  });
+
+  it("3개 선택 후 다른 카테고리를 누르면 안내하고 선택을 유지한다", async () => {
+    const user = userEvent.setup();
+    render(<ProfileEditForm />);
+
+    const development = screen.getByRole("button", { name: "개발" });
+    const fourthCategory = screen.getByRole("button", { name: "커리어 · 자기계발" });
+
+    await waitFor(() => expect(development).toHaveAttribute("aria-pressed", "true"));
+    await user.click(fourthCategory);
+
+    expect(mockedToast.info).toHaveBeenCalledWith("관심 카테고리는 최대 3개까지 선택 가능합니다.");
+    expect(mockedToast.info).toHaveBeenCalledTimes(1);
+    expect(fourthCategory).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("기존 선택을 해제하면 다른 카테고리를 선택할 수 있다", async () => {
+    const user = userEvent.setup();
+    render(<ProfileEditForm />);
+
+    const development = screen.getByRole("button", { name: "개발" });
+    const fourthCategory = screen.getByRole("button", { name: "커리어 · 자기계발" });
+
+    await waitFor(() => expect(development).toHaveAttribute("aria-pressed", "true"));
+    await user.click(development);
+    await user.click(fourthCategory);
+
+    expect(fourthCategory).toHaveAttribute("aria-pressed", "true");
+    expect(mockedToast.info).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 작업 내용

- 관심 카테고리를 이미 3개 선택한 상태에서 다른 카테고리를 누르면 제한 안내 토스트를 표시합니다.
- 선택값은 유지하고, 기존 카테고리를 해제한 후에는 다른 카테고리를 정상 선택할 수 있습니다.
- 제한 도달과 제한 해제 후 재선택 흐름을 컴포넌트 테스트로 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 관심 카테고리를 최대 3개까지 선택할 수 있도록 동작을 개선했습니다.
  * 이미 3개를 선택한 상태에서 추가 선택하면 안내 메시지가 표시되고 선택되지 않습니다.
  * 기존 선택을 해제한 후 새 카테고리를 정상적으로 추가할 수 있습니다.

* **테스트**
  * 관심 카테고리 추가·해제 및 선택 제한 동작에 대한 검증을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 참고 사항

- 마이페이지 프로필 설정만 수정하며 온보딩, API, 스키마에는 변경이 없습니다.
- 대상 테스트, 전체 Jest(60개 스위트·581개 테스트), 변경 파일 ESLint, 타입 검사, 프로덕션 빌드와 MSW 브라우저 QA를 통과했습니다.
- 전체 lint는 오류 없이 통과했으며, 변경과 무관한 기존 경고 8건이 남아 있습니다.

## 연관 이슈

close #306

## CodeRabbit 운영 메모

- 증분 리뷰 재실행: `@coderabbitai review`
- 전체 PR 재검토: `@coderabbitai full review`
