### PR TITLE
feat: Figma 공통 Toast 디자인 반영 (#319)

### DIFF
--- a/src/components/Icon/AlertCircleIcon.tsx
+++ b/src/components/Icon/AlertCircleIcon.tsx
@@ -1,0 +1,30 @@
+import { Icon, type IconProps } from "./Icon";
+
+const AlertCircleSvg = (
+  <svg
+    width="100%"
+    height="100%"
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <g transform="translate(2 2)">
+      <path
+        d="M10 10V5.5M10 13.3354V13.375M19 10C19 14.9706 14.9706 19 10 19C5.02944 19 1 14.9706 1 10C1 5.02944 5.02944 1 10 1C14.9706 1 19 5.02944 19 10Z"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </g>
+  </svg>
+);
+
+export type AlertCircleIconProps = Omit<IconProps, "svg">;
+
+export function AlertCircleIcon({
+  ref,
+  ...props
+}: AlertCircleIconProps & { ref?: React.Ref<HTMLSpanElement> }) {
+  return <Icon ref={ref} svg={AlertCircleSvg} {...props} />;
+}

--- a/src/components/Icon/AlertTriangleIcon.tsx
+++ b/src/components/Icon/AlertTriangleIcon.tsx
@@ -1,0 +1,30 @@
+import { Icon, type IconProps } from "./Icon";
+
+const AlertTriangleSvg = (
+  <svg
+    width="100%"
+    height="100%"
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <g transform="translate(2 3)">
+      <path
+        d="M10.0006 9.90003V5.41447M10.0006 13.2248V13.2642M15.6706 17H4.3307C2.78173 17 1.47455 15.9763 1.06328 14.5757C0.88772 13.9778 1.10344 13.3551 1.43339 12.8249L7.10332 2.60102C8.43173 0.466323 11.5695 0.466326 12.8979 2.60103L18.5679 12.8249C18.8978 13.3551 19.1135 13.9778 18.938 14.5757C18.5267 15.9763 17.2195 17 15.6706 17Z"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </g>
+  </svg>
+);
+
+export type AlertTriangleIconProps = Omit<IconProps, "svg">;
+
+export function AlertTriangleIcon({
+  ref,
+  ...props
+}: AlertTriangleIconProps & { ref?: React.Ref<HTMLSpanElement> }) {
+  return <Icon ref={ref} svg={AlertTriangleSvg} {...props} />;
+}

--- a/src/components/Icon/CheckContainedIcon.tsx
+++ b/src/components/Icon/CheckContainedIcon.tsx
@@ -1,0 +1,30 @@
+import { Icon, type IconProps } from "./Icon";
+
+const CheckContainedSvg = (
+  <svg
+    width="100%"
+    height="100%"
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <g transform="translate(2 2)">
+      <path
+        d="M13.142 7.98299L8.875 12.25L7.42049 10.7955M10 1C5.02944 1 1 5.02944 1 10C1 14.9706 5.02944 19 10 19C14.9706 19 19 14.9706 19 10C19 5.02944 14.9706 1 10 1Z"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </g>
+  </svg>
+);
+
+export type CheckContainedIconProps = Omit<IconProps, "svg">;
+
+export function CheckContainedIcon({
+  ref,
+  ...props
+}: CheckContainedIconProps & { ref?: React.Ref<HTMLSpanElement> }) {
+  return <Icon ref={ref} svg={CheckContainedSvg} {...props} />;
+}

--- a/src/components/Icon/InformationCircleContainedIcon.tsx
+++ b/src/components/Icon/InformationCircleContainedIcon.tsx
@@ -1,0 +1,30 @@
+import { Icon, type IconProps } from "./Icon";
+
+const InformationCircleContainedSvg = (
+  <svg
+    width="100%"
+    height="100%"
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <g transform="translate(2 2)">
+      <path
+        d="M10 10L10 14.5M10 6.66455V6.625M1 10C1 5.02944 5.02944 1 10 1C14.9706 1 19 5.02944 19 10C19 14.9706 14.9706 19 10 19C5.02944 19 1 14.9706 1 10Z"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </g>
+  </svg>
+);
+
+export type InformationCircleContainedIconProps = Omit<IconProps, "svg">;
+
+export function InformationCircleContainedIcon({
+  ref,
+  ...props
+}: InformationCircleContainedIconProps & { ref?: React.Ref<HTMLSpanElement> }) {
+  return <Icon ref={ref} svg={InformationCircleContainedSvg} {...props} />;
+}

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -28,10 +28,10 @@ const TOAST_ICONS: Record<ToastType, React.ReactNode> = {
 };
 
 const TOAST_STYLES: Record<ToastType, string> = {
-  info: "bg-[#1a2332] border-[#2a4a6b]",
-  success: "bg-[#1a2e1a] border-[#2b5a2b]",
-  warning: "bg-[#2e2a1a] border-[#5a4a2b]",
-  error: "bg-[#2e1a1a] border-[#5a2b2b]",
+  info: "bg-[#1a2332] ring-[#2a4a6b]",
+  success: "bg-[#1a2e1a] ring-[#2b5a2b]",
+  warning: "bg-[#2e2a1a] ring-[#5a4a2b]",
+  error: "bg-[#2e1a1a] ring-[#5a2b2b]",
 };
 
 export function Toast({
@@ -63,7 +63,7 @@ export function Toast({
   return (
     <div
       className={cn(
-        "pointer-events-auto flex w-full max-w-[400px] items-center gap-3 overflow-hidden rounded-lg border p-4 shadow-[0px_0px_2px_0px_#00000014,0px_16px_24px_0px_#0000001f] transition-[opacity,transform]",
+        "pointer-events-auto flex w-[400px] max-w-full items-center gap-3 overflow-hidden rounded-lg p-4 shadow-[0px_0px_2px_0px_#00000014,0px_16px_24px_0px_#0000001f] ring-1 transition-[opacity,transform] ring-inset",
         isClosing
           ? "animate-out fade-out slide-out-to-top-2 duration-200"
           : "animate-in slide-in-from-top-2 fade-in duration-300",
@@ -71,9 +71,9 @@ export function Toast({
       )}
       role="alert"
     >
-      <div className="flex-shrink-0">{TOAST_ICONS[type]}</div>
+      <div className="flex size-5 flex-shrink-0">{TOAST_ICONS[type]}</div>
       <div className="flex min-w-0 flex-1 flex-col gap-1">
-        <p className="w-full text-sm leading-normal font-semibold break-words text-white">
+        <p className="w-full text-sm leading-[17px] font-semibold break-words text-white">
           {title}
         </p>
         {description ? (
@@ -86,7 +86,7 @@ export function Toast({
         <button
           type="button"
           onClick={handleClose}
-          className="flex-shrink-0 transition-colors"
+          className="flex size-4 flex-shrink-0 transition-colors"
           aria-label="닫기"
         >
           <XIcon size="xsmall" className="text-[#999999]" />

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -1,39 +1,56 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
-import { CloseIcon } from "@/components/Icon/CloseIcon";
-import { InfoIcon } from "@/components/Icon/InfoIcon";
+import { AlertCircleIcon } from "@/components/Icon/AlertCircleIcon";
+import { AlertTriangleIcon } from "@/components/Icon/AlertTriangleIcon";
+import { CheckContainedIcon } from "@/components/Icon/CheckContainedIcon";
+import { InformationCircleContainedIcon } from "@/components/Icon/InformationCircleContainedIcon";
+import { XIcon } from "@/components/Icon/XIcon";
 import type { ToastType } from "@/lib/toast";
 import { cn } from "@/lib/utils/utils";
 
 export interface ToastProps {
   id: string;
   type: ToastType;
-  message: string;
+  title: string;
+  description?: string;
+  showClose?: boolean;
   duration?: number;
   onClose: (id: string) => void;
 }
 
 const TOAST_ICONS: Record<ToastType, React.ReactNode> = {
-  success: <InfoIcon size="small" className="text-green-500" />,
-  error: <InfoIcon size="small" className="text-red-500" />,
-  info: <InfoIcon size="small" className="text-blue-500" />,
+  info: (
+    <InformationCircleContainedIcon size="small" className="text-[#6699ff]" aria-hidden="true" />
+  ),
+  success: <CheckContainedIcon size="small" className="text-[#4dcc66]" aria-hidden="true" />,
+  warning: <AlertTriangleIcon size="small" className="text-[#ffcc4d]" aria-hidden="true" />,
+  error: <AlertCircleIcon size="small" className="text-[#ff5959]" aria-hidden="true" />,
 };
 
 const TOAST_STYLES: Record<ToastType, string> = {
-  success: "bg-green-500/10 border-green-500/20",
-  error: "bg-red-500/10 border-red-500/20",
-  info: "bg-blue-500/10 border-blue-500/20",
+  info: "bg-[#1a2332] border-[#2a4a6b]",
+  success: "bg-[#1a2e1a] border-[#2b5a2b]",
+  warning: "bg-[#2e2a1a] border-[#5a4a2b]",
+  error: "bg-[#2e1a1a] border-[#5a2b2b]",
 };
 
-export function Toast({ id, type, message, duration = 3000, onClose }: ToastProps) {
+export function Toast({
+  id,
+  type,
+  title,
+  description,
+  showClose = true,
+  duration = 3000,
+  onClose,
+}: ToastProps) {
   const [isClosing, setIsClosing] = useState(false);
 
-  const handleClose = () => {
+  const handleClose = useCallback(() => {
     setIsClosing(true);
     setTimeout(() => {
       onClose(id);
     }, 200); // 200ms duration for exit animation to complete
-  };
+  }, [id, onClose]);
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -41,13 +58,12 @@ export function Toast({ id, type, message, duration = 3000, onClose }: ToastProp
     }, duration);
 
     return () => clearTimeout(timer);
-  }, [duration]);
+  }, [duration, handleClose]);
 
   return (
     <div
       className={cn(
-        "pointer-events-auto flex max-w-md min-w-[320px] items-center gap-3 rounded-lg border p-4 shadow-lg transition-[opacity,transform]",
-        "bg-surface-default border-border-subtle",
+        "pointer-events-auto flex w-full max-w-[400px] items-center gap-3 overflow-hidden rounded-lg border p-4 shadow-[0px_0px_2px_0px_#00000014,0px_16px_24px_0px_#0000001f] transition-[opacity,transform]",
         isClosing
           ? "animate-out fade-out slide-out-to-top-2 duration-200"
           : "animate-in slide-in-from-top-2 fade-in duration-300",
@@ -56,15 +72,26 @@ export function Toast({ id, type, message, duration = 3000, onClose }: ToastProp
       role="alert"
     >
       <div className="flex-shrink-0">{TOAST_ICONS[type]}</div>
-      <p className="text-text-primary flex-1 text-sm font-medium">{message}</p>
-      <button
-        type="button"
-        onClick={handleClose}
-        className="text-text-muted hover:text-text-secondary flex-shrink-0 transition-colors"
-        aria-label="닫기"
-      >
-        <CloseIcon size="xsmall" />
-      </button>
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <p className="w-full text-sm leading-normal font-semibold break-words text-white">
+          {title}
+        </p>
+        {description ? (
+          <p className="w-full text-[13px] leading-[1.4] break-words text-[#b0b0b0]">
+            {description}
+          </p>
+        ) : null}
+      </div>
+      {showClose ? (
+        <button
+          type="button"
+          onClick={handleClose}
+          className="flex-shrink-0 transition-colors"
+          aria-label="닫기"
+        >
+          <XIcon size="xsmall" className="text-[#999999]" />
+        </button>
+      ) : null}
     </div>
   );
 }

--- a/src/components/Toast/ToastViewport.tsx
+++ b/src/components/Toast/ToastViewport.tsx
@@ -21,13 +21,15 @@ export function ToastViewport() {
   }, []);
 
   return (
-    <div className="pointer-events-none fixed top-24 right-4 z-[60] flex flex-col gap-2">
+    <div className="pointer-events-none fixed top-24 right-4 left-4 z-[60] flex flex-col gap-2 sm:left-auto sm:w-[400px]">
       {toasts.map((toastItem) => (
         <Toast
           key={toastItem.id}
           id={toastItem.id}
           type={toastItem.type}
-          message={toastItem.message}
+          title={toastItem.title}
+          description={toastItem.description}
+          showClose={toastItem.showClose}
           duration={toastItem.duration}
           onClose={toast.hideToast}
         />

--- a/src/lib/toast.ts
+++ b/src/lib/toast.ts
@@ -1,10 +1,20 @@
-export type ToastType = "success" | "error" | "info";
+export type ToastType = "success" | "error" | "info" | "warning";
+
+export interface ToastOptions {
+  title: string;
+  description?: string;
+  showClose?: boolean;
+}
+
+export type ToastContent = string | ToastOptions;
 
 // 화면에 실제로 그려질 토스트 한 개의 데이터 형태
 export interface ToastItem {
   id: string;
   type: ToastType;
-  message: string;
+  title: string;
+  description?: string;
+  showClose: boolean;
   duration: number;
 }
 
@@ -35,13 +45,21 @@ const emit = (event: ToastEvent) => {
 };
 
 // 토스트 표시 이벤트 발행
-const showToast = (type: ToastType, message: string, duration = 3000) => {
+const normalizeToastContent = (content: ToastContent) => {
+  if (typeof content === "string") {
+    return { title: content, showClose: true };
+  }
+
+  return { ...content, showClose: content.showClose ?? true };
+};
+
+const showToast = (type: ToastType, content: ToastContent, duration = 3000) => {
   emit({
     type: "show",
     toast: {
       id: createToastId(),
       type,
-      message,
+      ...normalizeToastContent(content),
       duration,
     },
   });
@@ -66,7 +84,8 @@ export const toast = {
   subscribe,
   showToast,
   hideToast,
-  success: (message: string, duration?: number) => showToast("success", message, duration),
-  error: (message: string, duration?: number) => showToast("error", message, duration),
-  info: (message: string, duration?: number) => showToast("info", message, duration),
+  success: (content: ToastContent, duration?: number) => showToast("success", content, duration),
+  error: (content: ToastContent, duration?: number) => showToast("error", content, duration),
+  info: (content: ToastContent, duration?: number) => showToast("info", content, duration),
+  warning: (content: ToastContent, duration?: number) => showToast("warning", content, duration),
 };

--- a/src/stories/components/Toast/Toast.stories.tsx
+++ b/src/stories/components/Toast/Toast.stories.tsx
@@ -1,0 +1,73 @@
+import { Toast } from "@/components/Toast/Toast";
+
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+const onClose = () => undefined;
+
+const meta = {
+  title: "Components/Toast",
+  component: Toast,
+  tags: ["autodocs"],
+  parameters: {
+    layout: "centered",
+    backgrounds: {
+      default: "dark",
+    },
+  },
+} satisfies Meta<typeof Toast>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const baseArgs = {
+  id: "toast-story",
+  duration: 60_000,
+  onClose,
+  title: "저장되었습니다.",
+  description: "변경 사항이 반영되었습니다.",
+};
+
+export const Info: Story = {
+  args: { ...baseArgs, type: "info" },
+};
+
+export const Success: Story = {
+  args: { ...baseArgs, type: "success" },
+};
+
+export const Warning: Story = {
+  args: { ...baseArgs, type: "warning" },
+};
+
+export const Error: Story = {
+  args: { ...baseArgs, type: "error" },
+};
+
+export const AllStates: Story = {
+  args: { ...baseArgs, type: "info" },
+  render: () => (
+    <div className="flex w-[400px] max-w-full flex-col gap-4">
+      <Toast {...baseArgs} id="toast-info" type="info" />
+      <Toast {...baseArgs} id="toast-success" type="success" />
+      <Toast {...baseArgs} id="toast-warning" type="warning" />
+      <Toast {...baseArgs} id="toast-error" type="error" />
+    </div>
+  ),
+};
+
+export const TitleOnly: Story = {
+  args: { ...baseArgs, type: "success", description: undefined },
+};
+
+export const WithoutClose: Story = {
+  args: { ...baseArgs, type: "info", showClose: false },
+};
+
+export const Mobile: Story = {
+  args: { ...baseArgs, type: "warning" },
+  render: (args) => (
+    <div className="w-[320px] max-w-full">
+      <Toast {...args} />
+    </div>
+  ),
+};

--- a/src/test/components/Toast.test.tsx
+++ b/src/test/components/Toast.test.tsx
@@ -1,0 +1,144 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+
+import { Toast, type ToastProps } from "@/components/Toast/Toast";
+import { ToastViewport } from "@/components/Toast/ToastViewport";
+import { toast } from "@/lib/toast";
+
+const TOAST_CONTENT = {
+  title: "저장되었습니다.",
+  description: "변경 사항이 반영되었습니다.",
+};
+
+function renderToast(
+  props: Partial<Omit<ToastProps, "id" | "onClose">> & Pick<ToastProps, "type"> = {
+    type: "success",
+  }
+) {
+  const onClose = jest.fn();
+
+  render(
+    <Toast id="toast-test" duration={60_000} onClose={onClose} {...TOAST_CONTENT} {...props} />
+  );
+
+  return onClose;
+}
+
+describe("Toast", () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("normalizes an object payload before notifying subscribers", () => {
+    let receivedToast: unknown;
+    const unsubscribe = toast.subscribe((event) => {
+      if (event.type === "show") {
+        receivedToast = event.toast;
+      }
+    });
+
+    toast.success({ ...TOAST_CONTENT, showClose: false });
+    unsubscribe();
+
+    expect(receivedToast).toMatchObject({
+      ...TOAST_CONTENT,
+      showClose: false,
+      type: "success",
+      duration: 3000,
+    });
+  });
+
+  it("renders title and description while hiding the close button when requested", () => {
+    renderToast({ type: "success", showClose: false });
+
+    expect(screen.getByText(TOAST_CONTENT.title)).toBeInTheDocument();
+    expect(screen.getByText(TOAST_CONTENT.description)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "닫기" })).not.toBeInTheDocument();
+  });
+
+  it("renders only the title and shows the close button by default", () => {
+    renderToast({ type: "info", title: "제목만 표시합니다.", description: undefined });
+
+    expect(screen.getByText("제목만 표시합니다.")).toBeInTheDocument();
+    expect(screen.queryByText(TOAST_CONTENT.description)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "닫기" })).toBeInTheDocument();
+  });
+
+  it.each([
+    [
+      "info",
+      "bg-[#1a2332]",
+      "border-[#2a4a6b]",
+      "text-[#6699ff]",
+      "M10 10L10 14.5M10 6.66455V6.625",
+    ],
+    [
+      "success",
+      "bg-[#1a2e1a]",
+      "border-[#2b5a2b]",
+      "text-[#4dcc66]",
+      "M13.142 7.98299L8.875 12.25L7.42049 10.7955",
+    ],
+    [
+      "warning",
+      "bg-[#2e2a1a]",
+      "border-[#5a4a2b]",
+      "text-[#ffcc4d]",
+      "M10.0006 9.90003V5.41447M10.0006 13.2248V13.2642",
+    ],
+    ["error", "bg-[#2e1a1a]", "border-[#5a2b2b]", "text-[#ff5959]", "M10 10V5.5M10 13.3354V13.375"],
+  ] as const)(
+    "applies the Figma %s visual state",
+    (type, backgroundClass, borderClass, iconColorClass, iconPath) => {
+      renderToast({ type });
+
+      const alert = screen.getByRole("alert");
+      const icon = alert.querySelector('[aria-hidden="true"]');
+
+      expect(alert).toHaveClass(backgroundClass, borderClass);
+      expect(icon).toHaveClass(iconColorClass);
+      expect(icon?.querySelector("path")).toHaveAttribute("d", expect.stringContaining(iconPath));
+    }
+  );
+
+  it("keeps a legacy string call visible as a title through the viewport", () => {
+    render(<ToastViewport />);
+
+    act(() => {
+      toast.info("기존 호출도 유지됩니다.");
+    });
+
+    expect(screen.getByText("기존 호출도 유지됩니다.")).toBeInTheDocument();
+  });
+
+  it("closes after the existing exit-animation delay", () => {
+    jest.useFakeTimers();
+    const onClose = renderToast({ type: "error" });
+
+    fireEvent.click(screen.getByRole("button", { name: "닫기" }));
+
+    act(() => {
+      jest.advanceTimersByTime(199);
+    });
+    expect(onClose).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(onClose).toHaveBeenCalledWith("toast-test");
+  });
+
+  it("automatically closes after the existing duration and exit-animation delay", () => {
+    jest.useFakeTimers();
+    const onClose = renderToast({ type: "error", duration: 3000 });
+
+    act(() => {
+      jest.advanceTimersByTime(3199);
+    });
+    expect(onClose).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(onClose).toHaveBeenCalledWith("toast-test");
+  });
+});

--- a/src/test/components/Toast.test.tsx
+++ b/src/test/components/Toast.test.tsx
@@ -55,6 +55,19 @@ describe("Toast", () => {
     expect(screen.queryByRole("button", { name: "닫기" })).not.toBeInTheDocument();
   });
 
+  it("matches the Figma toast dimensions and alignment", () => {
+    renderToast({ type: "info" });
+
+    const alert = screen.getByRole("alert");
+    const icon = alert.querySelector('[aria-hidden="true"]');
+    const closeButton = screen.getByRole("button", { name: "닫기" });
+
+    expect(alert).toHaveClass("w-[400px]", "max-w-full", "ring-1", "ring-inset");
+    expect(icon?.parentElement).toHaveClass("flex", "size-5");
+    expect(screen.getByText(TOAST_CONTENT.title)).toHaveClass("leading-[17px]");
+    expect(closeButton).toHaveClass("flex", "size-4");
+  });
+
   it("renders only the title and shows the close button by default", () => {
     renderToast({ type: "info", title: "제목만 표시합니다.", description: undefined });
 
@@ -64,37 +77,31 @@ describe("Toast", () => {
   });
 
   it.each([
-    [
-      "info",
-      "bg-[#1a2332]",
-      "border-[#2a4a6b]",
-      "text-[#6699ff]",
-      "M10 10L10 14.5M10 6.66455V6.625",
-    ],
+    ["info", "bg-[#1a2332]", "ring-[#2a4a6b]", "text-[#6699ff]", "M10 10L10 14.5M10 6.66455V6.625"],
     [
       "success",
       "bg-[#1a2e1a]",
-      "border-[#2b5a2b]",
+      "ring-[#2b5a2b]",
       "text-[#4dcc66]",
       "M13.142 7.98299L8.875 12.25L7.42049 10.7955",
     ],
     [
       "warning",
       "bg-[#2e2a1a]",
-      "border-[#5a4a2b]",
+      "ring-[#5a4a2b]",
       "text-[#ffcc4d]",
       "M10.0006 9.90003V5.41447M10.0006 13.2248V13.2642",
     ],
-    ["error", "bg-[#2e1a1a]", "border-[#5a2b2b]", "text-[#ff5959]", "M10 10V5.5M10 13.3354V13.375"],
+    ["error", "bg-[#2e1a1a]", "ring-[#5a2b2b]", "text-[#ff5959]", "M10 10V5.5M10 13.3354V13.375"],
   ] as const)(
     "applies the Figma %s visual state",
-    (type, backgroundClass, borderClass, iconColorClass, iconPath) => {
+    (type, backgroundClass, ringClass, iconColorClass, iconPath) => {
       renderToast({ type });
 
       const alert = screen.getByRole("alert");
       const icon = alert.querySelector('[aria-hidden="true"]');
 
-      expect(alert).toHaveClass(backgroundClass, borderClass);
+      expect(alert).toHaveClass(backgroundClass, ringClass);
       expect(icon).toHaveClass(iconColorClass);
       expect(icon?.querySelector("path")).toHaveAttribute("d", expect.stringContaining(iconPath));
     }


### PR DESCRIPTION
## 작업 내용

- 기존 이벤트 기반 Toast API와 3,000ms 노출·적재·애니메이션을 유지하면서 객체 payload(`title`, `description`, `showClose`)와 `warning` 상태를 추가했습니다.
- 공통 Figma vector 기반의 Info·Success·Warning·Error 아이콘 4종을 `src/components/Icon`에 추가하고, 닫기에는 기존 `XIcon`을 재사용했습니다.
- 상태별 배경·테두리·아이콘 색상, 400px 상한, 모바일 좌우 16px, title/description 타이포그래피와 그림자를 Toast Figma에 반영했습니다.
- 이벤트 버스·뷰포트를 포함한 Toast 테스트와 4상태·title-only·닫기 없음·모바일 Storybook 사례를 추가했습니다.

| Toast 상태 | Figma 공통 아이콘 | 컴포넌트 |
| --- | --- | --- |
| Info | `information-circle-contained` (`370:10387`) | `InformationCircleContainedIcon` |
| Success | `check-contained` (`370:10253`) | `CheckContainedIcon` |
| Warning | `alert-triangle` (`370:10818`) | `AlertTriangleIcon` |
| Error | `alert-circle` (`370:10812`) | `AlertCircleIcon` |
| Close | Toast `x` | 기존 `XIcon` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 경고 원형·삼각형, 완료, 정보 표시 아이콘을 추가했습니다.
  * 토스트에 제목, 설명, 닫기 버튼 표시 설정을 지원합니다.
  * 성공·오류·정보에 더해 경고 유형을 제공합니다.
  * 문자열 또는 옵션 객체로 토스트를 표시할 수 있습니다.
* **개선 사항**
  * 모바일과 큰 화면에 맞게 토스트 배치를 개선했습니다.
  * 토스트의 상태별 스타일과 레이아웃을 다양화했습니다.
* **테스트**
  * 토스트의 콘텐츠 표시와 수동·자동 닫힘 동작을 검증했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 참고 사항

- Toast Figma: https://www.figma.com/design/R8rybDxGFAUVdTIqIi5RgT/Untitled?node-id=358-31122&m=dev
- 공통 아이콘 Figma: https://www.figma.com/design/R8rybDxGFAUVdTIqIi5RgT/Untitled?node-id=370-9976&m=dev
- 데스크톱 Storybook에서 네 상태의 glyph·색상·여백을 Figma와 대조했습니다. 모바일은 `left-4 right-4 sm:left-auto sm:w-[400px]`로 320/375px에서 화면 이탈 없이 축소됩니다.

### 검증

- `pnpm test src/test/components/Toast.test.tsx --runInBand`
- `pnpm test --runInBand` — 60 suites, 589 tests passed
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm build-storybook`
- `git diff --check`

`pnpm build-storybook`의 기존 Vite `use client`/sourcemap 경고와 전체 테스트의 기존 proxy `console.warn` 출력은 실패 없이 완료됐습니다.

## 연관 이슈

close #319

## CodeRabbit 운영 메모

- 증분 리뷰 재실행: `@coderabbitai review`
- 전체 PR 재검토: `@coderabbitai full review`