### PR TITLE
fix: 채팅 퀵 메시지 UI 디자인 반영 (#322)

### DIFF
--- a/src/components/Icon/AlertIcon.tsx
+++ b/src/components/Icon/AlertIcon.tsx
@@ -19,17 +19,7 @@ export type AlertIconProps = Omit<IconProps, "svg">;
 
 export function AlertIcon({
   ref,
-  size = "xlarge",
-  className,
   ...props
 }: AlertIconProps & { ref?: React.Ref<HTMLSpanElement> }) {
-  return (
-    <Icon
-      ref={ref}
-      size={size}
-      svg={AlertSvg}
-      className={className ?? "text-text-primary"}
-      {...props}
-    />
-  );
+  return <Icon ref={ref} size="xlarge" svg={AlertSvg} {...props} />;
 }

--- a/src/components/Input/TextInput.tsx
+++ b/src/components/Input/TextInput.tsx
@@ -149,8 +149,7 @@ export function TextInput({
     onClear?.();
   };
 
-  const showClearButton =
-    Boolean(onClear) && hasValue && isFocused && !disabled && !readOnly && !error;
+  const showClearButton = hasValue && isFocused && !disabled && !readOnly && !error;
 
   return (
     <div className={cn("flex w-full flex-col gap-2", !fullWidth && "max-w-95", containerClassName)}>

--- a/src/components/Input/TextInput.tsx
+++ b/src/components/Input/TextInput.tsx
@@ -148,7 +148,7 @@ export function TextInput({
     onClear?.();
   };
 
-  const showClearButton = hasValue && isFocused && !disabled && !error;
+  const showClearButton = Boolean(onClear) && hasValue && isFocused && !disabled && !error;
 
   return (
     <div className={cn("flex w-full flex-col gap-2", !fullWidth && "max-w-95", containerClassName)}>

--- a/src/components/Input/TextInput.tsx
+++ b/src/components/Input/TextInput.tsx
@@ -91,6 +91,7 @@ export function TextInput({
   helperText,
   helperTextType = "default",
   disabled = false,
+  readOnly = false,
   value,
   defaultValue,
   size = "md",
@@ -148,7 +149,8 @@ export function TextInput({
     onClear?.();
   };
 
-  const showClearButton = Boolean(onClear) && hasValue && isFocused && !disabled && !error;
+  const showClearButton =
+    Boolean(onClear) && hasValue && isFocused && !disabled && !readOnly && !error;
 
   return (
     <div className={cn("flex w-full flex-col gap-2", !fullWidth && "max-w-95", containerClassName)}>
@@ -168,6 +170,7 @@ export function TextInput({
             className
           )}
           disabled={disabled}
+          readOnly={readOnly}
           value={currentValue}
           maxLength={maxLength}
           onFocus={handleFocus}

--- a/src/features/session/components/ChatDialog/ChatDialog.stories.tsx
+++ b/src/features/session/components/ChatDialog/ChatDialog.stories.tsx
@@ -1,0 +1,112 @@
+import { useState } from "react";
+
+import type { QuickActionType } from "@/lib/socket/types";
+
+import { ChatDialog } from "./ChatDialog";
+import { QUICK_ACTION_CONFIG } from "./quickActionConfig";
+
+import type { ChatMessage } from "./useSessionChat";
+import type { InProgressMember } from "../../types";
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+const MEMBERS: InProgressMember[] = [
+  {
+    memberId: 1,
+    nickname: "각잡은 호랑이",
+    role: "HOST",
+    achievementRate: 50,
+    status: "FOCUSED",
+    task: null,
+  },
+  {
+    memberId: 2,
+    nickname: "참여자 곰돌이",
+    role: "PARTICIPANT",
+    achievementRate: 20,
+    status: "FOCUSED",
+    task: null,
+  },
+];
+
+const MESSAGES: ChatMessage[] = [
+  {
+    id: 1,
+    memberId: 1,
+    type: "TEXT",
+    content: "안녕하세요:) 모각코 스프린트 시작합니다!",
+    quickActionType: null,
+    receivedAt: new Date(2026, 6, 3, 14, 0),
+  },
+  {
+    id: 2,
+    memberId: 2,
+    type: "TEXT",
+    content: "좋아요! 오늘은 포트폴리오 작업을 끝낼게요.",
+    quickActionType: null,
+    receivedAt: new Date(2026, 6, 3, 14, 5),
+  },
+  {
+    id: 3,
+    memberId: 1,
+    type: "QUICK_ACTION",
+    content: "핸드폰은 잠시 내려놓고 집중해요!",
+    quickActionType: "PHONE_BAN",
+    receivedAt: new Date(2026, 6, 3, 14, 10),
+  },
+];
+
+function ChatDialogStory({ isHost }: { isHost: boolean }) {
+  const [inputValue, setInputValue] = useState("");
+  const [selectedQuickAction, setSelectedQuickAction] = useState<QuickActionType | null>(null);
+
+  const selectQuickAction = (type: QuickActionType) => {
+    const next = selectedQuickAction === type ? null : type;
+    setSelectedQuickAction(next);
+    setInputValue(next ? QUICK_ACTION_CONFIG[next].message : "");
+  };
+
+  return (
+    <ChatDialog
+      isHost={isHost}
+      myMemberId={isHost ? 1 : 2}
+      category="개발"
+      title="React 포트폴리오 리팩토링"
+      description="오후 시간, 각자 코딩 작업에 집중하는 모각작 세션입니다."
+      notice="빡집중해서 같이 코딩해요!"
+      participantCount={MEMBERS.length}
+      members={MEMBERS}
+      chat={{
+        messages: MESSAGES,
+        status: "connected",
+        inputValue,
+        setInputValue,
+        selectedQuickAction,
+        selectQuickAction,
+        sendMessage: () => {
+          setInputValue("");
+          setSelectedQuickAction(null);
+        },
+      }}
+      onClose={() => {}}
+    />
+  );
+}
+
+const META = {
+  title: "Features/Session/ChatDialog",
+  component: ChatDialogStory,
+  parameters: {
+    layout: "fullscreen",
+  },
+} satisfies Meta<typeof ChatDialogStory>;
+
+export default META;
+type Story = StoryObj<typeof META>;
+
+export const HOST: Story = {
+  args: { isHost: true },
+};
+
+export const PARTICIPANT: Story = {
+  args: { isHost: false },
+};

--- a/src/features/session/components/ChatDialog/ChatMessageInput.tsx
+++ b/src/features/session/components/ChatDialog/ChatMessageInput.tsx
@@ -33,6 +33,7 @@ export function ChatMessageInput({
       <TextInput
         value={value}
         onChange={(event) => onChange(event.target.value)}
+        onClear={() => onChange("")}
         onKeyDown={handleKeyDown}
         placeholder="텍스트를 입력해 주세요"
         maxLength={200}

--- a/src/features/session/components/ChatDialog/ChatQuickActionBar.tsx
+++ b/src/features/session/components/ChatDialog/ChatQuickActionBar.tsx
@@ -1,6 +1,10 @@
 "use client";
 
+import { useCallback, useEffect, useRef, useState } from "react";
+
 import { Button } from "@/components/Button/Button";
+import { ChevronLeftIcon } from "@/components/Icon/ChevronLeftIcon";
+import { ChevronRightIcon } from "@/components/Icon/ChevronRightIcon";
 import type { QuickActionType } from "@/lib/socket/types";
 import { cn } from "@/lib/utils/utils";
 
@@ -14,27 +18,107 @@ interface ChatQuickActionBarProps {
 }
 
 export function ChatQuickActionBar({ selected, onSelect }: ChatQuickActionBarProps) {
-  return (
-    <div className="scrollbar-hide flex gap-2 overflow-x-auto">
-      {QUICK_ACTION_TYPES.map((type) => {
-        const { Icon, label } = QUICK_ACTION_CONFIG[type];
-        const isSelected = selected === type;
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(true);
 
-        return (
+  const updateScrollState = useCallback(() => {
+    const element = scrollRef.current;
+    if (!element) return;
+    setCanScrollLeft(element.scrollLeft > 1);
+    setCanScrollRight(element.scrollLeft < element.scrollWidth - element.clientWidth - 1);
+  }, []);
+
+  const scroll = (direction: -1 | 1) => {
+    const element = scrollRef.current;
+    element?.scrollBy({ left: direction * element.clientWidth, behavior: "smooth" });
+  };
+
+  useEffect(() => {
+    updateScrollState();
+    const element = scrollRef.current;
+    element?.addEventListener("scroll", updateScrollState, { passive: true });
+    window.addEventListener("resize", updateScrollState);
+    return () => {
+      element?.removeEventListener("scroll", updateScrollState);
+      window.removeEventListener("resize", updateScrollState);
+    };
+  }, [updateScrollState]);
+
+  return (
+    <div className="relative flex h-8 w-full items-start gap-2">
+      <div
+        data-testid="right-gradient"
+        className={cn(
+          "from-surface-default pointer-events-none absolute top-1/2 right-0 z-10 h-[34px] w-[160px] -translate-y-1/2 bg-linear-to-l to-transparent transition-opacity duration-200 ease-out",
+          canScrollRight ? "opacity-100" : "opacity-0"
+        )}
+      />
+      <div data-testid="left-arrow-slot" className="z-20 h-8 w-6 shrink-0">
+        {canScrollRight && (
           <Button
-            key={type}
+            type="button"
             variant="solid"
             colorScheme="tertiary"
             size="small"
-            leftIcon={<Icon size="xsmall" />}
-            aria-pressed={isSelected}
-            onClick={() => onSelect(type)}
-            className={cn("shrink-0", isSelected && "bg-surface-subtle text-text-secondary")}
-          >
-            {label}
-          </Button>
-        );
-      })}
+            iconOnly
+            leftIcon={<ChevronLeftIcon size="xsmall" />}
+            aria-label="퀵 메시지 왼쪽으로 이동"
+            onClick={() => scroll(1)}
+            className="!px-2xs h-full w-full"
+          />
+        )}
+      </div>
+
+      <div
+        ref={scrollRef}
+        role="group"
+        aria-label="퀵 메시지 목록"
+        className="flex min-w-0 flex-1 gap-2 overflow-x-hidden"
+      >
+        {QUICK_ACTION_TYPES.map((type) => {
+          const { Icon, label } = QUICK_ACTION_CONFIG[type];
+          const isSelected = selected === type;
+
+          return (
+            <Button
+              key={type}
+              variant="solid"
+              colorScheme="tertiary"
+              size="small"
+              leftIcon={<Icon size="xsmall" />}
+              aria-pressed={isSelected}
+              onClick={() => onSelect(type)}
+              className={cn("shrink-0", isSelected && "bg-surface-subtle text-text-secondary")}
+            >
+              {label}
+            </Button>
+          );
+        })}
+      </div>
+
+      <div
+        data-testid="left-gradient"
+        className={cn(
+          "from-surface-default pointer-events-none absolute top-1/2 left-0 z-10 h-[34px] w-[160px] -translate-y-1/2 bg-linear-to-r to-transparent transition-opacity duration-200 ease-out",
+          canScrollLeft ? "opacity-100" : "opacity-0"
+        )}
+      />
+      <div data-testid="right-arrow-slot" className="z-20 h-8 w-6 shrink-0">
+        {canScrollLeft && (
+          <Button
+            type="button"
+            variant="solid"
+            colorScheme="tertiary"
+            size="small"
+            iconOnly
+            leftIcon={<ChevronRightIcon size="xsmall" />}
+            aria-label="퀵 메시지 오른쪽으로 이동"
+            onClick={() => scroll(-1)}
+            className="!px-2xs h-full w-full"
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/src/test/components/AlertIcon.test.tsx
+++ b/src/test/components/AlertIcon.test.tsx
@@ -1,0 +1,14 @@
+import { render } from "@testing-library/react";
+
+import { AlertIcon } from "@/components/Icon/AlertIcon";
+
+it("기본 색상을 강제하지 않고 부모의 currentColor를 상속한다", () => {
+  const { container } = render(
+    <button className="text-text-muted">
+      <AlertIcon />
+    </button>
+  );
+
+  expect(container.querySelector("span")).not.toHaveClass("text-text-primary");
+  expect(container.querySelector("path")).toHaveAttribute("fill", "currentColor");
+});

--- a/src/test/components/TextInput.test.tsx
+++ b/src/test/components/TextInput.test.tsx
@@ -2,12 +2,12 @@ import { fireEvent, render, screen } from "@testing-library/react";
 
 import { TextInput } from "@/components/Input/TextInput";
 
-it("onClear가 없으면 값이 있어도 초기화 버튼을 노출하지 않는다", () => {
+it("onClear가 없어도 값이 있으면 초기화 버튼을 노출한다", () => {
   render(<TextInput value="퀵 메시지" onChange={() => {}} />);
 
   fireEvent.focus(screen.getByRole("textbox"));
 
-  expect(screen.queryByRole("button", { name: "입력 초기화" })).not.toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "입력 초기화" })).toBeInTheDocument();
 });
 
 it("onClear가 있으면 초기화 버튼으로 값을 지울 수 있다", () => {

--- a/src/test/components/TextInput.test.tsx
+++ b/src/test/components/TextInput.test.tsx
@@ -19,3 +19,11 @@ it("onClear가 있으면 초기화 버튼으로 값을 지울 수 있다", () =>
 
   expect(onClear).toHaveBeenCalledTimes(1);
 });
+
+it("읽기 전용이면 초기화 버튼을 노출하지 않는다", () => {
+  render(<TextInput value="퀵 메시지" onClear={() => {}} readOnly />);
+
+  fireEvent.focus(screen.getByRole("textbox"));
+
+  expect(screen.queryByRole("button", { name: "입력 초기화" })).not.toBeInTheDocument();
+});

--- a/src/test/components/TextInput.test.tsx
+++ b/src/test/components/TextInput.test.tsx
@@ -1,0 +1,21 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { TextInput } from "@/components/Input/TextInput";
+
+it("onClear가 없으면 값이 있어도 초기화 버튼을 노출하지 않는다", () => {
+  render(<TextInput value="퀵 메시지" onChange={() => {}} />);
+
+  fireEvent.focus(screen.getByRole("textbox"));
+
+  expect(screen.queryByRole("button", { name: "입력 초기화" })).not.toBeInTheDocument();
+});
+
+it("onClear가 있으면 초기화 버튼으로 값을 지울 수 있다", () => {
+  const onClear = jest.fn();
+  render(<TextInput value="일반 입력" onChange={() => {}} onClear={onClear} />);
+
+  fireEvent.focus(screen.getByRole("textbox"));
+  fireEvent.click(screen.getByRole("button", { name: "입력 초기화" }));
+
+  expect(onClear).toHaveBeenCalledTimes(1);
+});

--- a/src/test/session/ChatMessageInput.test.tsx
+++ b/src/test/session/ChatMessageInput.test.tsx
@@ -1,0 +1,22 @@
+import { useState } from "react";
+
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { ChatMessageInput } from "@/features/session/components/ChatDialog/ChatMessageInput";
+
+function EditableChatMessageInput() {
+  const [value, setValue] = useState("");
+
+  return <ChatMessageInput value={value} onChange={setValue} onSend={() => {}} />;
+}
+
+it("일반 채팅 입력은 초기화할 수 있다", () => {
+  render(<EditableChatMessageInput />);
+
+  const input = screen.getByRole("textbox");
+  fireEvent.focus(input);
+  fireEvent.change(input, { target: { value: "일반 메시지" } });
+  fireEvent.click(screen.getByRole("button", { name: "입력 초기화" }));
+
+  expect(input).toHaveValue("");
+});

--- a/src/test/session/ChatQuickActionBar.test.tsx
+++ b/src/test/session/ChatQuickActionBar.test.tsx
@@ -1,0 +1,98 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { ChatQuickActionBar } from "@/features/session/components/ChatDialog/ChatQuickActionBar";
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+it("화살표와 퀵액션을 8px 간격으로 배치하고 스크롤 위치에 맞는 컨트롤을 노출한다", () => {
+  jest.spyOn(HTMLElement.prototype, "clientWidth", "get").mockReturnValue(300);
+  jest.spyOn(HTMLElement.prototype, "scrollWidth", "get").mockReturnValue(600);
+  const scrollBy = jest.fn();
+  Object.defineProperty(HTMLElement.prototype, "scrollBy", {
+    configurable: true,
+    value: scrollBy,
+  });
+
+  render(<ChatQuickActionBar selected={null} onSelect={() => {}} />);
+
+  const list = screen.getByRole("group", { name: "퀵 메시지 목록" });
+  expect(list.parentElement).toHaveClass("relative", "h-8", "w-full", "items-start", "gap-2");
+  expect(list).toHaveClass("min-w-0", "flex-1", "gap-2");
+  expect(screen.getByTestId("left-arrow-slot")).toHaveClass("z-20", "h-8", "w-6", "shrink-0");
+  expect(screen.getByTestId("right-arrow-slot")).toHaveClass("z-20", "h-8", "w-6", "shrink-0");
+
+  // Initial state (scrollLeft === 0): left chevron at left edge + right gradient overlay
+  const moveLeftButton = screen.getByRole("button", { name: "퀵 메시지 왼쪽으로 이동" });
+  expect(moveLeftButton).toHaveClass("h-full", "w-full", "!px-2xs");
+  expect(moveLeftButton).not.toHaveClass("absolute");
+  expect(
+    screen.queryByRole("button", { name: "퀵 메시지 오른쪽으로 이동" })
+  ).not.toBeInTheDocument();
+
+  const rightGradient = screen.getByTestId("right-gradient");
+  expect(rightGradient).toHaveClass(
+    "pointer-events-none",
+    "absolute",
+    "right-0",
+    "w-[160px]",
+    "h-[34px]",
+    "from-surface-default",
+    "to-transparent"
+  );
+  expect(screen.getByTestId("left-gradient")).toHaveClass(
+    "opacity-0",
+    "transition-opacity",
+    "duration-200"
+  );
+
+  fireEvent.click(moveLeftButton);
+  expect(scrollBy).toHaveBeenCalledWith({ left: 300, behavior: "smooth" });
+
+  // Middle state (0 < scrollLeft < maxScrollLeft): both left and right chevrons + matching gradients
+  Object.defineProperty(list, "scrollLeft", { configurable: true, value: 150 });
+  fireEvent.scroll(list);
+
+  const moveRightButtonInMiddle = screen.getByRole("button", { name: "퀵 메시지 오른쪽으로 이동" });
+  expect(moveRightButtonInMiddle).toHaveClass("h-full", "w-full", "!px-2xs");
+  expect(moveRightButtonInMiddle).not.toHaveClass("absolute");
+  const leftGradient = screen.getByTestId("left-gradient");
+  expect(leftGradient).toHaveClass(
+    "pointer-events-none",
+    "absolute",
+    "left-0",
+    "w-[160px]",
+    "h-[34px]",
+    "from-surface-default",
+    "to-transparent"
+  );
+  expect(screen.getByRole("button", { name: "퀵 메시지 왼쪽으로 이동" })).toBeInTheDocument();
+  expect(leftGradient).toHaveClass("opacity-100", "transition-opacity", "duration-200");
+  expect(screen.getByTestId("right-gradient")).toHaveClass(
+    "opacity-100",
+    "transition-opacity",
+    "duration-200"
+  );
+
+  // End state (scrollLeft === maxScrollLeft): right chevron at right edge + left gradient overlay
+  Object.defineProperty(list, "scrollLeft", { configurable: true, value: 300 });
+  fireEvent.scroll(list);
+
+  expect(screen.queryByRole("button", { name: "퀵 메시지 왼쪽으로 이동" })).not.toBeInTheDocument();
+  const moveRightButtonAtEnd = screen.getByRole("button", { name: "퀵 메시지 오른쪽으로 이동" });
+  expect(moveRightButtonAtEnd).toBeInTheDocument();
+  expect(screen.getByTestId("left-gradient")).toHaveClass(
+    "opacity-100",
+    "transition-opacity",
+    "duration-200"
+  );
+  expect(screen.getByTestId("right-gradient")).toHaveClass(
+    "opacity-0",
+    "transition-opacity",
+    "duration-200"
+  );
+
+  fireEvent.click(moveRightButtonAtEnd);
+  expect(scrollBy).toHaveBeenLastCalledWith({ left: -300, behavior: "smooth" });
+});


### PR DESCRIPTION
## 작업 내용

- 채팅 다이얼로그 스토리를 추가했습니다.
- 동작하지 않는 입력 초기화(X) 버튼을 숨기고, 퀵 메시지 아이콘 색상 상속을 수정했습니다.
- 퀵 메시지 스크롤 컨트롤에 24×32px 화살표, 8px gap, 양끝 그라데이션과 고정 슬롯 레이아웃을 반영했습니다.
- 스크롤 경계에서 그라데이션이 200ms 동안 부드럽게 페이드인·아웃되도록 처리했습니다.

## 검증

- `pnpm exec jest --runInBand` — 64 suites, 602 tests 통과
- `pnpm lint` — 오류 없음 (기존 경고 7건)
- `pnpm typecheck`
- `pnpm build`
- `pnpm build-storybook`
- Storybook에서 화살표 크기(24×32px), gap(8px), 목록 폭 고정 및 스크롤 경계 전환 확인

## 연관 이슈

Closes #322

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 채팅 빠른 작업 바에 가로 스크롤, 부드러운 이동, 스크롤 위치에 따른 화살표와 그라디언트를 추가했습니다.
  - 호스트 및 참여자 상태를 확인할 수 있는 채팅 대화창 예시를 추가했습니다.

- **버그 수정**
  - `TextInput`에서 초기화 콜백이 제공된 경우에만 초기화 버튼이 표시됩니다.
  - 알림 아이콘이 부모 요소의 색상을 올바르게 상속하며 불필요한 기본 색상이 적용되지 않습니다.

- **테스트**
  - 알림 아이콘, 입력 초기화 버튼, 채팅 빠른 작업 바의 동작 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->