### PR TITLE
fix: 투두 공백 입력으로 세션 참여 방지

### DIFF
--- a/src/features/lobby/components/SessionJoinModal.tsx
+++ b/src/features/lobby/components/SessionJoinModal.tsx
@@ -10,6 +10,7 @@ import { PlusIcon } from "@/components/Icon/PlusIcon";
 import { TextInput } from "@/components/Input/TextInput";
 import { Portal } from "@/components/Portal/Portal";
 import { useJoinSession } from "@/features/session/hooks/useSessionHooks";
+import { joinSessionFormSchema } from "@/features/session/schemas";
 import type { ReportTodoItem } from "@/features/session/types";
 import { useBodyScrollLock } from "@/hooks/useBodyScrollLock";
 import { ApiError } from "@/lib/api/api-client";
@@ -37,6 +38,11 @@ export function SessionJoinModal({ sessionId, onClose, onJoinSuccess }: SessionJ
   const [serverError, setServerError] = useState<string | null>(null);
 
   const joinSessionMutation = useJoinSession();
+  const formValidation = joinSessionFormSchema.safeParse({
+    goal,
+    todos: todos.map((todo) => todo.content),
+  });
+  const isFormValid = formValidation.success;
 
   const setDialogRef = useCallback((node: HTMLDialogElement | null) => {
     if (node) {
@@ -47,7 +53,10 @@ export function SessionJoinModal({ sessionId, onClose, onJoinSuccess }: SessionJ
   }, []);
 
   const handleTodoChange = (index: number, content: string) => {
-    setTodos((prev) => prev.map((todo, i) => (i === index ? { ...todo, content } : todo)));
+    const normalizedContent = content.trim() === "" ? "" : content;
+    setTodos((prev) =>
+      prev.map((todo, i) => (i === index ? { ...todo, content: normalizedContent } : todo))
+    );
   };
 
   const handleRemoveTodo = (index: number) => {
@@ -60,25 +69,22 @@ export function SessionJoinModal({ sessionId, onClose, onJoinSuccess }: SessionJ
   };
 
   const handleJoin = async () => {
-    const isGoalEmpty = goal.trim() === "";
-    const hasValidTodo = todos.some((todo) => todo.content.trim() !== "");
-
-    setGoalError(isGoalEmpty);
-    setTodoError(!hasValidTodo);
     setServerError(null);
 
-    if (isGoalEmpty || !hasValidTodo) {
+    if (!formValidation.success) {
+      const invalidFields = new Set(formValidation.error.issues.map((issue) => issue.path[0]));
+      setGoalError(invalidFields.has("goal"));
+      setTodoError(invalidFields.has("todos"));
       return;
     }
 
-    const validTodos = todos
-      .filter((todo) => todo.content.trim() !== "")
-      .map((todo) => todo.content.trim());
+    setGoalError(false);
+    setTodoError(false);
 
     try {
       await joinSessionMutation.mutateAsync({
         sessionRoomId: sessionId,
-        body: { goal: goal.trim(), todos: validTodos },
+        body: formValidation.data,
       });
 
       // 성공 시: 모달 닫고 세션 페이지로 이동
@@ -223,7 +229,7 @@ export function SessionJoinModal({ sessionId, onClose, onJoinSuccess }: SessionJ
             size="medium"
             className="text-sm"
             onClick={handleJoin}
-            disabled={joinSessionMutation.isPending}
+            disabled={joinSessionMutation.isPending || !isFormValid}
           >
             {joinSessionMutation.isPending ? "참여 중..." : "작성 완료"}
           </Button>

--- a/src/features/session/schemas.ts
+++ b/src/features/session/schemas.ts
@@ -69,3 +69,21 @@ export const editSessionFormSchema = z.object({
 
 // 두 스키마는 동일한 형태를 추론한다 (startTime 검증 여부만 차이).
 export type CreateSessionFormData = z.infer<typeof createSessionFormSchema>;
+
+const joinTodoSchema = z.string().trim().max(50, "할 일은 최대 50자까지 입력 가능합니다.");
+
+export const joinSessionFormSchema = z.object({
+  goal: z
+    .string()
+    .trim()
+    .min(1, "목표를 입력해주세요")
+    .max(50, "목표는 최대 50자까지 입력 가능합니다."),
+  todos: z
+    .array(joinTodoSchema)
+    .refine((todos) => todos.some((todo) => todo !== ""), {
+      message: "할 일을 1개 이상 입력해주세요",
+    })
+    .transform((todos) => todos.filter((todo) => todo !== "")),
+});
+
+export type JoinSessionFormData = z.infer<typeof joinSessionFormSchema>;

--- a/src/test/lobby/session-join-modal.test.tsx
+++ b/src/test/lobby/session-join-modal.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { SessionJoinModal } from "@/features/lobby/components/SessionJoinModal";
+import { useJoinSession } from "@/features/session/hooks/useSessionHooks";
+
+jest.mock("@/features/session/hooks/useSessionHooks", () => ({
+  useJoinSession: jest.fn(),
+}));
+
+const mockedUseJoinSession = jest.mocked(useJoinSession);
+const mockMutateAsync = jest.fn();
+
+beforeAll(() => {
+  HTMLDialogElement.prototype.showModal = jest.fn(function (this: HTMLDialogElement) {
+    this.open = true;
+  });
+  HTMLDialogElement.prototype.close = jest.fn(function (this: HTMLDialogElement) {
+    this.open = false;
+  });
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockMutateAsync.mockReturnValue(new Promise(() => undefined));
+  mockedUseJoinSession.mockReturnValue({
+    mutateAsync: mockMutateAsync,
+    isPending: false,
+  } as unknown as ReturnType<typeof useJoinSession>);
+});
+
+describe("SessionJoinModal", () => {
+  it("공백만 입력한 투두를 빈 값으로 유지하고 작성 완료 버튼을 비활성화한다", async () => {
+    const user = userEvent.setup();
+    render(<SessionJoinModal sessionId="123" onClose={jest.fn()} />);
+
+    await user.type(await screen.findByPlaceholderText("목표를 입력하세요"), "테스트 목표");
+    const todoInput = screen.getByPlaceholderText("할 일을 입력하세요");
+    const submitButton = screen.getByRole("button", { name: "작성 완료" });
+
+    await user.type(todoInput, "   ");
+
+    expect(todoInput).toHaveValue("");
+    expect(screen.getByText("0/50")).toBeInTheDocument();
+    expect(submitButton).toBeDisabled();
+  });
+
+  it("Zod가 정규화한 목표와 투두로 참여 요청을 보낸다", async () => {
+    const user = userEvent.setup();
+    render(<SessionJoinModal sessionId="123" onClose={jest.fn()} />);
+
+    await user.type(await screen.findByPlaceholderText("목표를 입력하세요"), "  테스트 목표  ");
+    await user.type(screen.getByPlaceholderText("할 일을 입력하세요"), "  테스트 투두  ");
+
+    const submitButton = screen.getByRole("button", { name: "작성 완료" });
+    expect(submitButton).toBeEnabled();
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith({
+        sessionRoomId: "123",
+        body: { goal: "테스트 목표", todos: ["테스트 투두"] },
+      });
+    });
+  });
+});

--- a/src/test/session/session-join-schema.test.ts
+++ b/src/test/session/session-join-schema.test.ts
@@ -1,0 +1,29 @@
+import { joinSessionFormSchema } from "@/features/session/schemas";
+
+describe("joinSessionFormSchema", () => {
+  it("공백만 있는 목표 또는 투두를 거부한다", () => {
+    expect(joinSessionFormSchema.safeParse({ goal: "   ", todos: ["할 일"] }).success).toBe(false);
+    expect(joinSessionFormSchema.safeParse({ goal: "목표", todos: ["   ", "\t"] }).success).toBe(
+      false
+    );
+  });
+
+  it("앞뒤 공백을 제거하고 빈 투두를 제외한다", () => {
+    expect(
+      joinSessionFormSchema.parse({
+        goal: "  테스트 목표  ",
+        todos: ["  첫 번째 투두  ", "   ", "두 번째 투두\t"],
+      })
+    ).toEqual({
+      goal: "테스트 목표",
+      todos: ["첫 번째 투두", "두 번째 투두"],
+    });
+  });
+
+  it.each([
+    ["목표", { goal: "a".repeat(51), todos: ["할 일"] }],
+    ["투두", { goal: "목표", todos: ["a".repeat(51)] }],
+  ])("50자를 초과한 %s를 거부한다", (_field, data) => {
+    expect(joinSessionFormSchema.safeParse(data).success).toBe(false);
+  });
+});


### PR DESCRIPTION
## 작업 내용

- 세션 참여 폼의 목표·투두리스트를 Zod로 trim 후 검증합니다.
- 공백만 입력한 투두리스트는 빈 값으로 정규화해 글자 수 `0/50`으로 표시하고, 유효한 목표·투두가 없으면 작성 완료 버튼을 비활성화합니다.
- 파싱된 값을 API 요청 payload에 그대로 사용하도록 회귀 테스트를 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 세션 참여 폼에 목표와 할 일 입력값 검증을 추가했습니다.
  * 앞뒤 공백을 자동으로 정리하고, 비어 있는 할 일 항목은 제출에서 제외합니다.
  * 목표와 할 일은 최대 50자까지 입력할 수 있습니다.
  * 필수 입력이 유효한 경우에만 참여 버튼이 활성화됩니다.
  * 입력 오류를 항목별로 안내합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 참고 사항

- 검증: focused Jest 2 suites/6 tests, full Jest 64 suites/626 tests, lint(기존 경고 7건·오류 없음), typecheck, build, git diff --check 통과.
- 브라우저 mock QA는 로컬 mock 런타임의 기존 데이터 로드 오류로 완료하지 못했습니다. 컴포넌트 회귀 테스트가 버튼 비활성화·`0/50` 표시·정규화된 요청값을 검증합니다.

## 연관 이슈

close #324

## CodeRabbit 운영 메모

- 증분 리뷰 재실행: `@coderabbitai review`
- 전체 PR 재검토: `@coderabbitai full review`