### PR TITLE
fix: 정책 페이지 시행일 정정 (#327)

### DIFF
--- a/src/app/(with-header)/cookie-policy/page.tsx
+++ b/src/app/(with-header)/cookie-policy/page.tsx
@@ -13,7 +13,7 @@ export default function CookiePolicyPage() {
   return (
     <div className="p-3xl flex flex-col">
       <h1 className="text-text-primary text-3xl font-bold">쿠키 정책</h1>
-      <p className="text-text-disabled mt-2 text-sm">시행일: 2025년 7월 1일</p>
+      <p className="text-text-disabled mt-2 text-sm">시행일: 2026년 2월 28일</p>
 
       <p className="text-text-secondary mt-6 leading-7">
         GAK (DND 9팀, 이하 &quot;운영팀&quot;)은 서비스 제공 및 이용자 편의를 위해 쿠키(Cookie)와

--- a/src/app/(with-header)/privacy/page.tsx
+++ b/src/app/(with-header)/privacy/page.tsx
@@ -13,7 +13,7 @@ export default function PrivacyPage() {
   return (
     <div className="p-3xl flex flex-col">
       <h1 className="text-text-primary text-3xl font-bold">개인정보 처리방침</h1>
-      <p className="text-text-disabled mt-2 text-sm">시행일: 2025년 7월 1일</p>
+      <p className="text-text-disabled mt-2 text-sm">시행일: 2026년 2월 28일</p>
 
       <p className="text-text-secondary mt-6 leading-7">
         GAK (DND 9팀, 이하 &quot;운영팀&quot;)은 이용자의 개인정보를 중요시하며, 「개인정보 보호법」

--- a/src/app/(with-header)/terms/page.tsx
+++ b/src/app/(with-header)/terms/page.tsx
@@ -13,7 +13,7 @@ export default function TermsPage() {
   return (
     <div className="p-3xl flex flex-col">
       <h1 className="text-text-primary text-3xl font-bold">이용약관</h1>
-      <p className="text-text-disabled mt-2 text-sm">시행일: 2025년 7월 1일</p>
+      <p className="text-text-disabled mt-2 text-sm">시행일: 2026년 2월 28일</p>
 
       <div className="mt-10 flex flex-col gap-10">
         <section>

--- a/src/test/legal-policy-effective-date.test.tsx
+++ b/src/test/legal-policy-effective-date.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+
+import CookiePolicyPage from "@/app/(with-header)/cookie-policy/page";
+import PrivacyPage from "@/app/(with-header)/privacy/page";
+import TermsPage from "@/app/(with-header)/terms/page";
+
+const effectiveDate = "시행일: 2026년 2월 28일";
+
+describe("legal policy effective dates", () => {
+  it.each([
+    ["이용약관", TermsPage],
+    ["개인정보 처리방침", PrivacyPage],
+    ["쿠키 정책", CookiePolicyPage],
+  ])("%s renders the corrected effective date", (_name, Page) => {
+    render(<Page />);
+
+    expect(screen.getByText(effectiveDate)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 작업 내용

- `/terms`, `/privacy`, `/cookie-policy` 시행일 문구를 `시행일: 2026년 2월 28일`로 정정
- 정책 페이지 시행일 검증을 위한 회귀 테스트 추가 (`src/test/legal-policy-effective-date.test.tsx`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **문서**
  - 쿠키 정책, 개인정보 처리방침, 이용약관의 시행일이 **2026년 2월 28일**로 변경되었습니다.
  - 세 법률 정책 페이지에서 최신 시행일을 확인할 수 있습니다.

- **테스트**
  - 세 정책 페이지에 변경된 시행일이 올바르게 표시되는지 검증하는 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 참고 사항

- 푸터의 2026년 저작권 연도 동적 표시 기능(`Footer.tsx`)은 수정하지 않았습니다.
- `pnpm test`, `pnpm lint`, `pnpm typecheck`, `pnpm build` 검사를 모두 통과했습니다. (기존 7개 린트 경고 제외)

## 연관 이슈

close #327

## CodeRabbit 운영 메모

- 증분 리뷰 재실행: `@coderabbitai review`
- 전체 PR 재검토: `@coderabbitai full review`