### PR TITLE
fix: 진행시간 filter 변경

### DIFF
--- a/src/features/session/components/SessionList/sessionListFilter.types.ts
+++ b/src/features/session/components/SessionList/sessionListFilter.types.ts
@@ -18,10 +18,9 @@ export const SORT_OPTIONS: FilterOption<SessionSort>[] = [
 ];
 
 export const DURATION_OPTIONS: FilterOption<DurationRange>[] = [
-  { value: "HALF_TO_ONE_HOUR", label: "30분 ~1시간" },
-  { value: "TWO_TO_FOUR_HOURS", label: "2시간 ~ 4시간" },
-  { value: "FIVE_TO_EIGHT_HOURS", label: "5시간 ~ 8시간" },
-  { value: "TEN_PLUS_HOURS", label: "10시간 이상" },
+  { value: "ONE_HOUR_OR_LESS", label: "1시간 이하" },
+  { value: "ONE_TO_TWO_HOURS", label: "1시간 ~ 2시간" },
+  { value: "TWO_TO_THREE_HOURS", label: "2시간 ~ 3시간" },
 ];
 
 export const TIME_SLOT_OPTIONS: TimeSlotFilterOption[] = [

--- a/src/features/session/components/SessionList/sessionListFilter.utils.ts
+++ b/src/features/session/components/SessionList/sessionListFilter.utils.ts
@@ -50,10 +50,9 @@ export function getTimeSlotFilterLabel(selectedTimeSlots: TimeSlot[]) {
 }
 
 const DURATION_TRIGGER_LABEL_MAP: Record<DurationRange, string> = {
-  HALF_TO_ONE_HOUR: "30분-1시간",
-  TWO_TO_FOUR_HOURS: "2시간-4시간",
-  FIVE_TO_EIGHT_HOURS: "5시간-8시간",
-  TEN_PLUS_HOURS: "10시간 이상",
+  ONE_HOUR_OR_LESS: "1시간 이하",
+  ONE_TO_TWO_HOURS: "1시간-2시간",
+  TWO_TO_THREE_HOURS: "2시간-3시간",
 };
 
 export function getDurationFilterLabel(durationRange: DurationRange | null) {

--- a/src/features/session/types.ts
+++ b/src/features/session/types.ts
@@ -57,11 +57,7 @@ export type SessionSort = "POPULAR" | "LATEST" | "DEADLINE_APPROACHING";
 
 export type TimeSlot = "MORNING" | "AFTERNOON" | "EVENING";
 
-export type DurationRange =
-  | "HALF_TO_ONE_HOUR"
-  | "TWO_TO_FOUR_HOURS"
-  | "FIVE_TO_EIGHT_HOURS"
-  | "TEN_PLUS_HOURS";
+export type DurationRange = "ONE_HOUR_OR_LESS" | "ONE_TO_TWO_HOURS" | "TWO_TO_THREE_HOURS";
 
 export type SessionListStatus = "WAITING" | "IN_PROGRESS";
 

--- a/src/test/components/SessionList.test.tsx
+++ b/src/test/components/SessionList.test.tsx
@@ -167,13 +167,13 @@ describe("SessionList", () => {
   it("모바일 viewport에서는 세션 목록 요청 size를 5로 설정하고 기존 필터 값을 유지한다", async () => {
     setViewportLayout("mobile", true);
     setSearchParams(
-      "q=react&category=DEVELOPMENT&page=2&sort=LATEST&startDate=2026-02-01&endDate=2026-02-28&timeSlots=MORNING,EVENING&durationRange=TWO_TO_FOUR_HOURS&participants=6"
+      "q=react&category=DEVELOPMENT&page=2&sort=LATEST&startDate=2026-02-01&endDate=2026-02-28&timeSlots=MORNING,EVENING&durationRange=ONE_TO_TWO_HOURS&participants=6"
     );
     setupFilters({
       startDate: "2026-02-01",
       endDate: "2026-02-28",
       timeSlots: ["MORNING", "EVENING"],
-      durationRange: "TWO_TO_FOUR_HOURS",
+      durationRange: "ONE_TO_TWO_HOURS",
       participants: "6",
       sort: "LATEST",
     });
@@ -191,7 +191,7 @@ describe("SessionList", () => {
           startDate: "2026-02-01",
           endDate: "2026-02-28",
           timeSlots: ["MORNING", "EVENING"],
-          durationRange: "TWO_TO_FOUR_HOURS",
+          durationRange: "ONE_TO_TWO_HOURS",
           participants: 6,
         })
       );

--- a/src/test/components/SessionListFilterBar.test.tsx
+++ b/src/test/components/SessionListFilterBar.test.tsx
@@ -105,9 +105,9 @@ describe("SessionListFilterBar", () => {
     const { props } = renderFilterBar();
 
     fireEvent.click(screen.getByRole("button", { name: /진행시간/ }));
-    fireEvent.click(screen.getByRole("radio", { name: "30분 ~1시간" }));
+    fireEvent.click(screen.getByRole("radio", { name: "1시간 이하" }));
 
-    expect(props.onSetDurationRange).toHaveBeenCalledWith("HALF_TO_ONE_HOUR");
+    expect(props.onSetDurationRange).toHaveBeenCalledWith("ONE_HOUR_OR_LESS");
   });
 
   it("closes a non-sort panel on Escape and removes the reserved panel space", () => {


### PR DESCRIPTION
## 작업 내용

> 백엔드 진행시간 필터 명세 변경에 따라 DurationRange enum과 필터 UI를 교체했습니다.

enum 교체 (src/features/session/types.ts)
기존: HALF_TO_ONE_HOUR / TWO_TO_FOUR_HOURS / FIVE_TO_EIGHT_HOURS / TEN_PLUS_HOURS (4개)
변경: ONE_HOUR_OR_LESS / ONE_TO_TWO_HOURS / TWO_TO_THREE_HOURS (3개)
필터 패널 옵션 라벨 변경 (sessionListFilter.types.ts): 1시간 이하 / 1시간 ~ 2시간 / 2시간 ~ 3시간
필터 트리거 버튼 라벨 변경 (sessionListFilter.utils.ts): 기존 표기 스타일에 맞춰 1시간 이하 / 1시간-2시간 / 2시간-3시간
테스트 갱신: SessionList.test.tsx, SessionListFilterBar.test.tsx를 새 enum 값 기준으로 수정

@coderabbitai summary

## 참고 사항

> 코드 리뷰 시 참고할 만한 사항이나 주의할 점을 작성해주세요.

## 연관 이슈

> close #297 

## CodeRabbit 운영 메모

- 증분 리뷰 재실행: `@coderabbitai review`
- 전체 PR 재검토: `@coderabbitai full review`
