### PR TITLE
fix: Refresh Token 중복 갱신 병합 (#332)

### DIFF
--- a/src/lib/auth/refresh-token-single-flight.ts
+++ b/src/lib/auth/refresh-token-single-flight.ts
@@ -11,6 +11,7 @@ const REFRESH_SUCCESS_REUSE_MS = 2_000;
 
 type RefreshFailureReason = "http_error" | "invalid_response" | "timeout" | "network_error";
 
+/** 백엔드 갱신 결과에서 요청별 응답 정보를 제외하고 모든 caller가 함께 사용할 값만 나타낸다. */
 export type RefreshOutcome =
   | {
       readonly kind: "success";
@@ -24,88 +25,17 @@ export type RefreshOutcome =
       readonly errorCode: string | null;
     };
 
-type HardRefreshDisposition = "created" | "joined" | "reused" | "bypass";
-
-export type HardRefreshResult = {
-  readonly disposition: HardRefreshDisposition;
-  readonly outcome: RefreshOutcome;
-};
-
-export type SoftRefreshResult =
-  | { readonly kind: "miss" }
-  | { readonly kind: "caller_timeout" }
-  | {
-      readonly kind: "outcome";
-      readonly disposition: "joined" | "reused";
-      readonly outcome: RefreshOutcome;
-    };
-
-interface InFlightEntry {
-  readonly kind: "in_flight";
-  readonly promise: Promise<RefreshOutcome>;
-}
-
-interface SuccessEntry {
-  readonly kind: "success";
-  readonly outcome: Extract<RefreshOutcome, { kind: "success" }>;
-  readonly expiresAt: number;
-  cleanupTimer?: ReturnType<typeof setTimeout>;
-}
-
-type RefreshFlightEntry = InFlightEntry | SuccessEntry;
-
-// 이 Map은 같은 warm instance의 중복만 줄이며, 인스턴스 간 멱등성은 백엔드가 보장한다.
-const refreshFlights = new Map<string, RefreshFlightEntry>();
-
-/** 전달받은 entry가 현재 Map 값일 때만 삭제해 늦은 cleanup이 새 작업을 지우지 않게 한다. */
-function deleteEntryIfCurrent(fingerprint: string, entry: RefreshFlightEntry) {
-  if (refreshFlights.get(fingerprint) === entry) {
-    refreshFlights.delete(fingerprint);
-  }
-}
-
-/** 성공 entry의 논리적 TTL을 확인하고 만료된 현재 entry를 정리한다. */
-function deleteExpiredSuccessEntry(fingerprint: string, entry: SuccessEntry) {
-  if (Date.now() < entry.expiresAt) {
-    return false;
-  }
-
-  if (entry.cleanupTimer !== undefined) {
-    clearTimeout(entry.cleanupTimer);
-  }
-  deleteEntryIfCurrent(fingerprint, entry);
-  return true;
-}
-
-/** Map 전체에서 논리적 TTL이 지난 성공 entry를 기회적으로 정리한다. */
-function sweepExpiredSuccessEntries() {
-  for (const [fingerprint, entry] of refreshFlights) {
-    if (entry.kind === "success") {
-      deleteExpiredSuccessEntry(fingerprint, entry);
-    }
-  }
-}
-
-/** fingerprint의 현재 entry를 조회하되 만료된 성공 결과는 miss로 처리한다. */
-function getCurrentEntry(fingerprint: string): RefreshFlightEntry | null {
-  const entry = refreshFlights.get(fingerprint);
-  if (!entry) {
-    return null;
-  }
-
-  if (entry.kind === "success" && deleteExpiredSuccessEntry(fingerprint, entry)) {
-    return null;
-  }
-
-  return entry;
-}
-
-/** 원본 Refresh Token 대신 Map key로 사용할 SHA-256 fingerprint를 생성한다. */
-async function createRefreshTokenFingerprint(refreshToken: string): Promise<string> {
-  const bytes = new TextEncoder().encode(refreshToken);
-  const digest = await crypto.subtle.digest("SHA-256", bytes);
-  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
-}
+/**
+ * 같은 Refresh Token으로 들어온 요청들이 하나의 갱신 작업을 공유하도록 보관한다.
+ *
+ * key는 요청에 포함된 Refresh Token이고, value는 백엔드 갱신 결과를 기다리는 Promise다.
+ * 성공한 Promise는 바로 뒤따라오는 중복 요청도 재사용할 수 있도록 잠시 남겨두고,
+ * 실패한 Promise는 다음 요청이 다시 시도할 수 있도록 즉시 제거한다.
+ *
+ * 이 Map은 현재 서버 인스턴스의 메모리에만 존재한다. 따라서 같은 인스턴스 안의 중복만
+ * 줄일 수 있으며, 서로 다른 서버 인스턴스에서 발생한 중복 처리는 백엔드가 담당해야 한다.
+ */
+const refreshFlights = new Map<string, Promise<RefreshOutcome>>();
 
 /** 브라우저와 Node 런타임에서 발생한 AbortError를 공통 판별한다. */
 function isAbortError(error: unknown): boolean {
@@ -234,136 +164,73 @@ async function performRefreshExchange(
   }
 }
 
-/** 새 hard exchange를 Map에 등록하고 성공만 2초 동안 재사용 가능한 entry로 교체한다. */
-function startHardRefreshFlight(
-  fingerprint: string,
+/**
+ * 새 Access Token이 없으면 요청을 계속할 수 없는 hard 요청의 Refresh 갱신을 처리한다.
+ *
+ * 같은 Refresh Token의 Promise가 Map에 있으면 새 백엔드 요청을 만들지 않고 그 Promise를
+ * 그대로 반환한다. Promise가 없을 때만 백엔드 Refresh API를 한 번 호출하고 Map에 저장한다.
+ * 성공 결과는 짧은 시간 동안 재사용한 뒤 timer로 삭제하며, 실패 결과는 바로 삭제한다.
+ *
+ * @param refreshToken 브라우저가 보낸 Refresh Token. Map의 key와 백엔드 Cookie에만 사용한다.
+ * @param backendUrl Refresh API를 제공하는 백엔드 서버 주소.
+ * @returns 성공 또는 실패로 정리된 하나의 Refresh 결과 Promise.
+ */
+export function runHardRefreshSingleFlight(
   refreshToken: string,
   backendUrl: string
-): InFlightEntry {
-  const entry: InFlightEntry = {
-    kind: "in_flight",
-    promise: performRefreshExchange(backendUrl, refreshToken).then((outcome) => {
-      if (outcome.kind === "failure") {
-        deleteEntryIfCurrent(fingerprint, entry);
-        return outcome;
-      }
+): Promise<RefreshOutcome> {
+  const existingFlight = refreshFlights.get(refreshToken);
+  if (existingFlight) {
+    return existingFlight;
+  }
 
-      if (refreshFlights.get(fingerprint) !== entry) {
-        return outcome;
-      }
-
-      const successEntry: SuccessEntry = {
-        kind: "success",
-        outcome,
-        expiresAt: Date.now() + REFRESH_SUCCESS_REUSE_MS,
-      };
-      successEntry.cleanupTimer = setTimeout(() => {
-        deleteEntryIfCurrent(fingerprint, successEntry);
-      }, REFRESH_SUCCESS_REUSE_MS);
-      (
-        successEntry.cleanupTimer as ReturnType<typeof setTimeout> & { unref?: () => void }
-      ).unref?.();
-      refreshFlights.set(fingerprint, successEntry);
+  const promise = performRefreshExchange(backendUrl, refreshToken).then((outcome) => {
+    if (outcome.kind === "failure") {
+      refreshFlights.delete(refreshToken);
       return outcome;
-    }),
-  };
-  refreshFlights.set(fingerprint, entry);
-  return entry;
+    }
+
+    // 재사용 시간은 대략적이며 정확한 TTL이 필요할 때 expiresAt 검사를 추가한다
+    const timer = setTimeout(() => {
+      refreshFlights.delete(refreshToken);
+    }, REFRESH_SUCCESS_REUSE_MS);
+    (timer as ReturnType<typeof setTimeout> & { unref?: () => void }).unref?.();
+
+    return outcome;
+  });
+
+  refreshFlights.set(refreshToken, promise);
+  return promise;
 }
 
-/** hard caller가 기존 작업·성공 결과를 공유하거나, 없으면 새 Refresh exchange를 시작한다. */
-export async function runHardRefreshSingleFlight(
-  refreshToken: string,
-  backendUrl: string
-): Promise<HardRefreshResult> {
-  sweepExpiredSuccessEntries();
-
-  let fingerprint: string;
-  try {
-    fingerprint = await createRefreshTokenFingerprint(refreshToken);
-  } catch {
-    return {
-      disposition: "bypass",
-      outcome: await performRefreshExchange(backendUrl, refreshToken),
-    };
-  }
-
-  const existingEntry = getCurrentEntry(fingerprint);
-  if (existingEntry?.kind === "success") {
-    return { disposition: "reused", outcome: existingEntry.outcome };
-  }
-  if (existingEntry?.kind === "in_flight") {
-    return { disposition: "joined", outcome: await existingEntry.promise };
-  }
-
-  const createdEntry = startHardRefreshFlight(fingerprint, refreshToken, backendUrl);
-  return { disposition: "created", outcome: await createdEntry.promise };
-}
-
-/** soft caller가 새 작업을 만들지 않고 1.5초 예산 안에서 기존 작업이나 성공 결과에만 합류한다. */
+/**
+ * 현재 Access Token으로 요청을 계속할 수 있는 soft 요청이 기존 Refresh 작업에만 합류한다.
+ *
+ * 이 함수는 백엔드 갱신을 새로 시작하지 않는다. 같은 Refresh Token의 진행 중인 Promise나
+ * 잠시 보관 중인 성공 Promise가 없으면 즉시 null을 반환한다. Promise가 있으면 약 1.5초만
+ * 기다리며, 그 안에 결과가 나오지 않아도 원래 hard 작업은 취소하지 않고 이 caller만 null을
+ * 반환해 기존 Access Token으로 요청을 계속하게 한다.
+ *
+ * @param refreshToken 브라우저가 보낸 Refresh Token. 기존 Promise를 찾는 key로만 사용한다.
+ * @returns 시간 안에 받은 Refresh 결과. 작업이 없거나 대기 시간이 지나면 null.
+ */
 export async function joinSoftRefreshSingleFlight(
   refreshToken: string
-): Promise<SoftRefreshResult> {
-  const deadlineAt = Date.now() + SOFT_REFRESH_TOTAL_TIMEOUT_MS;
-  let callerTimedOut = false;
-  /** timer callback과 절대 시각을 함께 확인해 정확한 deadline 경계를 판별한다. */
-  const hasCallerTimedOut = () => callerTimedOut || Date.now() >= deadlineAt;
+): Promise<RefreshOutcome | null> {
+  const flight = refreshFlights.get(refreshToken);
+  if (!flight) {
+    return null;
+  }
+
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
-  const timeoutPromise = new Promise<SoftRefreshResult>((resolve) => {
+  const timeoutPromise = new Promise<null>((resolve) => {
     timeoutId = setTimeout(() => {
-      callerTimedOut = true;
-      resolve({ kind: "caller_timeout" });
+      resolve(null);
     }, SOFT_REFRESH_TOTAL_TIMEOUT_MS);
   });
 
-  const lookupPromise = (async (): Promise<SoftRefreshResult> => {
-    sweepExpiredSuccessEntries();
-
-    let fingerprint: string;
-    try {
-      fingerprint = await createRefreshTokenFingerprint(refreshToken);
-    } catch {
-      return hasCallerTimedOut() ? { kind: "caller_timeout" } : { kind: "miss" };
-    }
-
-    if (hasCallerTimedOut()) {
-      return { kind: "caller_timeout" };
-    }
-
-    const entry = getCurrentEntry(fingerprint);
-    if (!entry) {
-      return { kind: "miss" };
-    }
-    if (entry.kind === "success") {
-      if (hasCallerTimedOut()) {
-        return { kind: "caller_timeout" };
-      }
-
-      return {
-        kind: "outcome",
-        disposition: "reused",
-        outcome: entry.outcome,
-      };
-    }
-
-    if (hasCallerTimedOut()) {
-      return { kind: "caller_timeout" };
-    }
-
-    const outcome = await entry.promise;
-    if (hasCallerTimedOut()) {
-      return { kind: "caller_timeout" };
-    }
-
-    return {
-      kind: "outcome",
-      disposition: "joined",
-      outcome,
-    };
-  })();
-
   try {
-    return await Promise.race([lookupPromise, timeoutPromise]);
+    return await Promise.race([flight, timeoutPromise]);
   } finally {
     if (timeoutId !== undefined) {
       clearTimeout(timeoutId);

--- a/src/lib/auth/refresh-token-single-flight.ts
+++ b/src/lib/auth/refresh-token-single-flight.ts
@@ -25,6 +25,23 @@ export type RefreshOutcome =
       readonly errorCode: string | null;
     };
 
+/** RefreshOutcome 중 실패일 때 항상 함께 전달하는 필드를 나타낸다. */
+type RefreshFailure = Extract<RefreshOutcome, { kind: "failure" }>;
+
+/**
+ * HTTP 오류, 잘못된 응답, timeout, 네트워크 오류를 같은 실패 결과 형태로 만든다.
+ *
+ * 호출자는 reason으로 실패 종류를 구분하고, status와 errorCode로 현재 요청에 맞는 응답을 만든다.
+ * 실패 결과의 필드를 매번 직접 작성하지 않아도 되어 각 분기의 반환 형태가 달라지는 일을 막는다.
+ */
+function createRefreshFailure(
+  reason: RefreshFailureReason,
+  status: number,
+  errorCode: string | null = null
+): RefreshFailure {
+  return { kind: "failure", reason, status, errorCode };
+}
+
 /**
  * 같은 Refresh Token으로 들어온 요청들이 하나의 갱신 작업을 공유하도록 보관한다.
  *
@@ -42,7 +59,13 @@ function isAbortError(error: unknown): boolean {
   return error instanceof Error && error.name === "AbortError";
 }
 
-/** Refresh 응답 body를 읽고 성공 응답의 파싱 실패만 명시적인 invalid response로 변환한다. */
+/**
+ * Refresh 응답의 JSON body를 읽는다.
+ *
+ * 요청이 중단되어 발생한 AbortError는 timeout 처리로 이어져야 하므로 다시 던진다. 그 외 JSON
+ * 파싱 실패는 body가 없는 것처럼 undefined로 돌려보낸다. 호출한 함수가 이미 가진 HTTP status를
+ * 사용해 오류 응답은 http_error로, 성공 응답의 잘못된 body는 invalid_response로 구분한다.
+ */
 async function readResponseBody(response: Response, signal: AbortSignal): Promise<unknown> {
   try {
     return await response.json();
@@ -51,23 +74,17 @@ async function readResponseBody(response: Response, signal: AbortSignal): Promis
       throw error;
     }
 
-    if (response.ok) {
-      throw new InvalidRefreshResponseError(response.status);
-    }
-
     return undefined;
   }
 }
 
-/** 성공 상태의 body가 유효한 JSON이 아닐 때 HTTP status를 보존해 전달한다. */
-class InvalidRefreshResponseError extends Error {
-  constructor(readonly status: number) {
-    super("Invalid refresh response");
-    this.name = "InvalidRefreshResponseError";
-  }
-}
-
-/** backend Refresh API를 호출하고 HTTP/body 결과를 요청 비종속 RefreshOutcome으로 변환한다. */
+/**
+ * backend Refresh API를 호출하고 HTTP/body 결과를 요청 비종속 RefreshOutcome으로 바꾼다.
+ *
+ * response.ok가 false인 것은 네트워크 예외가 아니라 백엔드가 반환한 정상적인 HTTP 응답이다.
+ * 그래서 if 분기에서 http_error로 반환한다. 성공 응답은 access/refresh token 쌍이 모두 있어야
+ * 성공이며, JSON이 깨졌거나 필요한 값이 없으면 원래 HTTP status를 보존한 invalid_response가 된다.
+ */
 async function executeRefreshExchange(
   backendUrl: string,
   refreshToken: string,
@@ -85,22 +102,12 @@ async function executeRefreshExchange(
   const body = await readResponseBody(response, signal);
 
   if (!response.ok) {
-    return {
-      kind: "failure",
-      reason: "http_error",
-      status: response.status,
-      errorCode: parseRefreshErrorCode(body),
-    };
+    return createRefreshFailure("http_error", response.status, parseRefreshErrorCode(body));
   }
 
   const tokens = parseRefreshTokenPair(body);
   if (!tokens) {
-    return {
-      kind: "failure",
-      reason: "invalid_response",
-      status: response.status,
-      errorCode: null,
-    };
+    return createRefreshFailure("invalid_response", response.status);
   }
 
   return {
@@ -113,54 +120,31 @@ async function executeRefreshExchange(
   };
 }
 
-/** Refresh exchange 전체에 10초 deadline을 적용하고 예외를 정규화된 실패 outcome으로 바꾼다. */
+/**
+ * Refresh exchange 전체에 10초 제한을 적용하고 예외를 정규화된 실패 outcome으로 바꾼다.
+ *
+ * timer가 끝나면 AbortController가 fetch와 body 읽기에 전달한 signal을 중단한다. Next.js의 기본
+ * fetch처럼 AbortSignal을 따르는 구현에서는 현재 작업이 AbortError로 끝나고 timeout 결과가 된다.
+ * signal을 무시하는 별도 fetch 구현은 이 deadline을 보장할 수 없으므로 사용하지 않는다. 요청이
+ * 먼저 끝나면 finally에서 timer를 지워 남은 timer가 다음 작업에 영향을 주지 않게 한다.
+ */
 async function performRefreshExchange(
   backendUrl: string,
   refreshToken: string
 ): Promise<RefreshOutcome> {
   const controller = new AbortController();
-  let timeoutId: ReturnType<typeof setTimeout> | undefined;
-  const timeoutPromise = new Promise<never>((_resolve, reject) => {
-    timeoutId = setTimeout(() => {
-      controller.abort();
-      reject(new DOMException("Refresh request timed out", "AbortError"));
-    }, REFRESH_EXCHANGE_TIMEOUT_MS);
-  });
+  const timeoutId = setTimeout(() => controller.abort(), REFRESH_EXCHANGE_TIMEOUT_MS);
 
   try {
-    return await Promise.race([
-      executeRefreshExchange(backendUrl, refreshToken, controller.signal),
-      timeoutPromise,
-    ]);
+    return await executeRefreshExchange(backendUrl, refreshToken, controller.signal);
   } catch (error) {
     if (controller.signal.aborted || isAbortError(error)) {
-      return {
-        kind: "failure",
-        reason: "timeout",
-        status: 504,
-        errorCode: null,
-      };
+      return createRefreshFailure("timeout", 504);
     }
 
-    if (error instanceof InvalidRefreshResponseError) {
-      return {
-        kind: "failure",
-        reason: "invalid_response",
-        status: error.status,
-        errorCode: null,
-      };
-    }
-
-    return {
-      kind: "failure",
-      reason: "network_error",
-      status: 500,
-      errorCode: null,
-    };
+    return createRefreshFailure("network_error", 500);
   } finally {
-    if (timeoutId !== undefined) {
-      clearTimeout(timeoutId);
-    }
+    clearTimeout(timeoutId);
   }
 }
 
@@ -190,11 +174,14 @@ export function runHardRefreshSingleFlight(
       return outcome;
     }
 
-    // 재사용 시간은 대략적이며 정확한 TTL이 필요할 때 expiresAt 검사를 추가한다
-    const timer = setTimeout(() => {
+    // 성공 결과를 잠시 재사용한 뒤 cleanupTimer가 Map에서 정리한다.
+    // ponytail: 정리 시점은 대략적이다. 정확한 TTL이 실제 요구사항이 될 때만 expiresAt 검사를 추가한다.
+    const cleanupTimer = setTimeout(() => {
       refreshFlights.delete(refreshToken);
     }, REFRESH_SUCCESS_REUSE_MS);
-    (timer as ReturnType<typeof setTimeout> & { unref?: () => void }).unref?.();
+    // `as ... & { unref?: ... }`는 기본 timer 타입에 Node 전용 unref가 있을 수 있음을 TypeScript에 알린다.
+    // `?.`는 unref가 있는 Node에서만 호출한다. unref는 timer를 취소하지 않고 이 timer가 서버 종료를 막지 않게 한다.
+    (cleanupTimer as ReturnType<typeof setTimeout> & { unref?: () => void }).unref?.();
 
     return outcome;
   });

--- a/src/lib/auth/refresh-token-single-flight.ts
+++ b/src/lib/auth/refresh-token-single-flight.ts
@@ -57,12 +57,14 @@ type RefreshFlightEntry = InFlightEntry | SuccessEntry;
 // 이 Map은 같은 warm instance의 중복만 줄이며, 인스턴스 간 멱등성은 백엔드가 보장한다.
 const refreshFlights = new Map<string, RefreshFlightEntry>();
 
+/** 전달받은 entry가 현재 Map 값일 때만 삭제해 늦은 cleanup이 새 작업을 지우지 않게 한다. */
 function deleteEntryIfCurrent(fingerprint: string, entry: RefreshFlightEntry) {
   if (refreshFlights.get(fingerprint) === entry) {
     refreshFlights.delete(fingerprint);
   }
 }
 
+/** 성공 entry의 논리적 TTL을 확인하고 만료된 현재 entry를 정리한다. */
 function deleteExpiredSuccessEntry(fingerprint: string, entry: SuccessEntry) {
   if (Date.now() < entry.expiresAt) {
     return false;
@@ -75,6 +77,7 @@ function deleteExpiredSuccessEntry(fingerprint: string, entry: SuccessEntry) {
   return true;
 }
 
+/** Map 전체에서 논리적 TTL이 지난 성공 entry를 기회적으로 정리한다. */
 function sweepExpiredSuccessEntries() {
   for (const [fingerprint, entry] of refreshFlights) {
     if (entry.kind === "success") {
@@ -83,6 +86,7 @@ function sweepExpiredSuccessEntries() {
   }
 }
 
+/** fingerprint의 현재 entry를 조회하되 만료된 성공 결과는 miss로 처리한다. */
 function getCurrentEntry(fingerprint: string): RefreshFlightEntry | null {
   const entry = refreshFlights.get(fingerprint);
   if (!entry) {
@@ -96,16 +100,19 @@ function getCurrentEntry(fingerprint: string): RefreshFlightEntry | null {
   return entry;
 }
 
+/** 원본 Refresh Token 대신 Map key로 사용할 SHA-256 fingerprint를 생성한다. */
 async function createRefreshTokenFingerprint(refreshToken: string): Promise<string> {
   const bytes = new TextEncoder().encode(refreshToken);
   const digest = await crypto.subtle.digest("SHA-256", bytes);
   return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
 }
 
+/** 브라우저와 Node 런타임에서 발생한 AbortError를 공통 판별한다. */
 function isAbortError(error: unknown): boolean {
   return error instanceof Error && error.name === "AbortError";
 }
 
+/** Refresh 응답 body를 읽고 성공 응답의 파싱 실패만 명시적인 invalid response로 변환한다. */
 async function readResponseBody(response: Response, signal: AbortSignal): Promise<unknown> {
   try {
     return await response.json();
@@ -122,6 +129,7 @@ async function readResponseBody(response: Response, signal: AbortSignal): Promis
   }
 }
 
+/** 성공 상태의 body가 유효한 JSON이 아닐 때 HTTP status를 보존해 전달한다. */
 class InvalidRefreshResponseError extends Error {
   constructor(readonly status: number) {
     super("Invalid refresh response");
@@ -129,6 +137,7 @@ class InvalidRefreshResponseError extends Error {
   }
 }
 
+/** backend Refresh API를 호출하고 HTTP/body 결과를 요청 비종속 RefreshOutcome으로 변환한다. */
 async function executeRefreshExchange(
   backendUrl: string,
   refreshToken: string,
@@ -174,6 +183,7 @@ async function executeRefreshExchange(
   };
 }
 
+/** Refresh exchange 전체에 10초 deadline을 적용하고 예외를 정규화된 실패 outcome으로 바꾼다. */
 async function performRefreshExchange(
   backendUrl: string,
   refreshToken: string
@@ -224,6 +234,7 @@ async function performRefreshExchange(
   }
 }
 
+/** 새 hard exchange를 Map에 등록하고 성공만 2초 동안 재사용 가능한 entry로 교체한다. */
 function startHardRefreshFlight(
   fingerprint: string,
   refreshToken: string,
@@ -260,6 +271,7 @@ function startHardRefreshFlight(
   return entry;
 }
 
+/** hard caller가 기존 작업·성공 결과를 공유하거나, 없으면 새 Refresh exchange를 시작한다. */
 export async function runHardRefreshSingleFlight(
   refreshToken: string,
   backendUrl: string
@@ -288,11 +300,13 @@ export async function runHardRefreshSingleFlight(
   return { disposition: "created", outcome: await createdEntry.promise };
 }
 
+/** soft caller가 새 작업을 만들지 않고 1.5초 예산 안에서 기존 작업이나 성공 결과에만 합류한다. */
 export async function joinSoftRefreshSingleFlight(
   refreshToken: string
 ): Promise<SoftRefreshResult> {
   const deadlineAt = Date.now() + SOFT_REFRESH_TOTAL_TIMEOUT_MS;
   let callerTimedOut = false;
+  /** timer callback과 절대 시각을 함께 확인해 정확한 deadline 경계를 판별한다. */
   const hasCallerTimedOut = () => callerTimedOut || Date.now() >= deadlineAt;
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<SoftRefreshResult>((resolve) => {

--- a/src/lib/auth/refresh-token-single-flight.ts
+++ b/src/lib/auth/refresh-token-single-flight.ts
@@ -1,0 +1,355 @@
+import { buildRefreshCookieHeader } from "./cookie-header-utils";
+import {
+  parseRefreshErrorCode,
+  parseRefreshTokenPair,
+  type RefreshTokenPair,
+} from "./token-refresh-utils";
+
+const REFRESH_EXCHANGE_TIMEOUT_MS = 10_000;
+const SOFT_REFRESH_TOTAL_TIMEOUT_MS = 1_500;
+const REFRESH_SUCCESS_REUSE_MS = 2_000;
+
+type RefreshFailureReason = "http_error" | "invalid_response" | "timeout" | "network_error";
+
+export type RefreshOutcome =
+  | {
+      readonly kind: "success";
+      readonly status: number;
+      readonly tokens: Readonly<RefreshTokenPair>;
+    }
+  | {
+      readonly kind: "failure";
+      readonly reason: RefreshFailureReason;
+      readonly status: number;
+      readonly errorCode: string | null;
+    };
+
+type HardRefreshDisposition = "created" | "joined" | "reused" | "bypass";
+
+export type HardRefreshResult = {
+  readonly disposition: HardRefreshDisposition;
+  readonly outcome: RefreshOutcome;
+};
+
+export type SoftRefreshResult =
+  | { readonly kind: "miss" }
+  | { readonly kind: "caller_timeout" }
+  | {
+      readonly kind: "outcome";
+      readonly disposition: "joined" | "reused";
+      readonly outcome: RefreshOutcome;
+    };
+
+interface InFlightEntry {
+  readonly kind: "in_flight";
+  readonly promise: Promise<RefreshOutcome>;
+}
+
+interface SuccessEntry {
+  readonly kind: "success";
+  readonly outcome: Extract<RefreshOutcome, { kind: "success" }>;
+  readonly expiresAt: number;
+  cleanupTimer?: ReturnType<typeof setTimeout>;
+}
+
+type RefreshFlightEntry = InFlightEntry | SuccessEntry;
+
+const refreshFlights = new Map<string, RefreshFlightEntry>();
+
+function deleteEntryIfCurrent(fingerprint: string, entry: RefreshFlightEntry) {
+  if (refreshFlights.get(fingerprint) === entry) {
+    refreshFlights.delete(fingerprint);
+  }
+}
+
+function deleteExpiredSuccessEntry(fingerprint: string, entry: SuccessEntry) {
+  if (Date.now() < entry.expiresAt) {
+    return false;
+  }
+
+  if (entry.cleanupTimer !== undefined) {
+    clearTimeout(entry.cleanupTimer);
+  }
+  deleteEntryIfCurrent(fingerprint, entry);
+  return true;
+}
+
+function sweepExpiredSuccessEntries() {
+  for (const [fingerprint, entry] of refreshFlights) {
+    if (entry.kind === "success") {
+      deleteExpiredSuccessEntry(fingerprint, entry);
+    }
+  }
+}
+
+function getCurrentEntry(fingerprint: string): RefreshFlightEntry | null {
+  const entry = refreshFlights.get(fingerprint);
+  if (!entry) {
+    return null;
+  }
+
+  if (entry.kind === "success" && deleteExpiredSuccessEntry(fingerprint, entry)) {
+    return null;
+  }
+
+  return entry;
+}
+
+async function createRefreshTokenFingerprint(refreshToken: string): Promise<string> {
+  const bytes = new TextEncoder().encode(refreshToken);
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+async function readResponseBody(response: Response, signal: AbortSignal): Promise<unknown> {
+  try {
+    return await response.json();
+  } catch (error) {
+    if (signal.aborted || isAbortError(error)) {
+      throw error;
+    }
+
+    if (response.ok) {
+      throw new InvalidRefreshResponseError(response.status);
+    }
+
+    return undefined;
+  }
+}
+
+class InvalidRefreshResponseError extends Error {
+  constructor(readonly status: number) {
+    super("Invalid refresh response");
+    this.name = "InvalidRefreshResponseError";
+  }
+}
+
+async function executeRefreshExchange(
+  backendUrl: string,
+  refreshToken: string,
+  signal: AbortSignal
+): Promise<RefreshOutcome> {
+  const response = await fetch(`${backendUrl}/auth/refresh`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Cookie: buildRefreshCookieHeader(refreshToken),
+    },
+    credentials: "include",
+    signal,
+  });
+  const body = await readResponseBody(response, signal);
+
+  if (!response.ok) {
+    return {
+      kind: "failure",
+      reason: "http_error",
+      status: response.status,
+      errorCode: parseRefreshErrorCode(body),
+    };
+  }
+
+  const tokens = parseRefreshTokenPair(body);
+  if (!tokens) {
+    return {
+      kind: "failure",
+      reason: "invalid_response",
+      status: response.status,
+      errorCode: null,
+    };
+  }
+
+  return {
+    kind: "success",
+    status: response.status,
+    tokens: {
+      accessToken: tokens.accessToken,
+      refreshToken: tokens.refreshToken,
+    },
+  };
+}
+
+async function performRefreshExchange(
+  backendUrl: string,
+  refreshToken: string
+): Promise<RefreshOutcome> {
+  const controller = new AbortController();
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_resolve, reject) => {
+    timeoutId = setTimeout(() => {
+      controller.abort();
+      reject(new DOMException("Refresh request timed out", "AbortError"));
+    }, REFRESH_EXCHANGE_TIMEOUT_MS);
+  });
+
+  try {
+    return await Promise.race([
+      executeRefreshExchange(backendUrl, refreshToken, controller.signal),
+      timeoutPromise,
+    ]);
+  } catch (error) {
+    if (controller.signal.aborted || isAbortError(error)) {
+      return {
+        kind: "failure",
+        reason: "timeout",
+        status: 504,
+        errorCode: null,
+      };
+    }
+
+    if (error instanceof InvalidRefreshResponseError) {
+      return {
+        kind: "failure",
+        reason: "invalid_response",
+        status: error.status,
+        errorCode: null,
+      };
+    }
+
+    return {
+      kind: "failure",
+      reason: "network_error",
+      status: 500,
+      errorCode: null,
+    };
+  } finally {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
+function startHardRefreshFlight(
+  fingerprint: string,
+  refreshToken: string,
+  backendUrl: string
+): InFlightEntry {
+  const entry: InFlightEntry = {
+    kind: "in_flight",
+    promise: performRefreshExchange(backendUrl, refreshToken).then((outcome) => {
+      if (outcome.kind === "failure") {
+        deleteEntryIfCurrent(fingerprint, entry);
+        return outcome;
+      }
+
+      if (refreshFlights.get(fingerprint) !== entry) {
+        return outcome;
+      }
+
+      const successEntry: SuccessEntry = {
+        kind: "success",
+        outcome,
+        expiresAt: Date.now() + REFRESH_SUCCESS_REUSE_MS,
+      };
+      successEntry.cleanupTimer = setTimeout(() => {
+        deleteEntryIfCurrent(fingerprint, successEntry);
+      }, REFRESH_SUCCESS_REUSE_MS);
+      (
+        successEntry.cleanupTimer as ReturnType<typeof setTimeout> & { unref?: () => void }
+      ).unref?.();
+      refreshFlights.set(fingerprint, successEntry);
+      return outcome;
+    }),
+  };
+  refreshFlights.set(fingerprint, entry);
+  return entry;
+}
+
+export async function runHardRefreshSingleFlight(
+  refreshToken: string,
+  backendUrl: string
+): Promise<HardRefreshResult> {
+  sweepExpiredSuccessEntries();
+
+  let fingerprint: string;
+  try {
+    fingerprint = await createRefreshTokenFingerprint(refreshToken);
+  } catch {
+    return {
+      disposition: "bypass",
+      outcome: await performRefreshExchange(backendUrl, refreshToken),
+    };
+  }
+
+  const existingEntry = getCurrentEntry(fingerprint);
+  if (existingEntry?.kind === "success") {
+    return { disposition: "reused", outcome: existingEntry.outcome };
+  }
+  if (existingEntry?.kind === "in_flight") {
+    return { disposition: "joined", outcome: await existingEntry.promise };
+  }
+
+  const createdEntry = startHardRefreshFlight(fingerprint, refreshToken, backendUrl);
+  return { disposition: "created", outcome: await createdEntry.promise };
+}
+
+export async function joinSoftRefreshSingleFlight(
+  refreshToken: string
+): Promise<SoftRefreshResult> {
+  const deadlineAt = Date.now() + SOFT_REFRESH_TOTAL_TIMEOUT_MS;
+  let callerTimedOut = false;
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<SoftRefreshResult>((resolve) => {
+    timeoutId = setTimeout(() => {
+      callerTimedOut = true;
+      resolve({ kind: "caller_timeout" });
+    }, SOFT_REFRESH_TOTAL_TIMEOUT_MS);
+  });
+
+  const lookupPromise = (async (): Promise<SoftRefreshResult> => {
+    sweepExpiredSuccessEntries();
+
+    let fingerprint: string;
+    try {
+      fingerprint = await createRefreshTokenFingerprint(refreshToken);
+    } catch {
+      return callerTimedOut || Date.now() >= deadlineAt
+        ? { kind: "caller_timeout" }
+        : { kind: "miss" };
+    }
+
+    if (callerTimedOut || Date.now() >= deadlineAt) {
+      return { kind: "caller_timeout" };
+    }
+
+    const entry = getCurrentEntry(fingerprint);
+    if (!entry) {
+      return { kind: "miss" };
+    }
+    if (entry.kind === "success") {
+      return {
+        kind: "outcome",
+        disposition: "reused",
+        outcome: entry.outcome,
+      };
+    }
+
+    const remainingMs = deadlineAt - Date.now();
+    if (remainingMs <= 0) {
+      return { kind: "caller_timeout" };
+    }
+
+    const outcome = await entry.promise;
+    if (callerTimedOut || Date.now() >= deadlineAt) {
+      return { kind: "caller_timeout" };
+    }
+
+    return {
+      kind: "outcome",
+      disposition: "joined",
+      outcome,
+    };
+  })();
+
+  try {
+    return await Promise.race([lookupPromise, timeoutPromise]);
+  } finally {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+    }
+  }
+}

--- a/src/lib/auth/refresh-token-single-flight.ts
+++ b/src/lib/auth/refresh-token-single-flight.ts
@@ -54,6 +54,7 @@ interface SuccessEntry {
 
 type RefreshFlightEntry = InFlightEntry | SuccessEntry;
 
+// 이 Map은 같은 warm instance의 중복만 줄이며, 인스턴스 간 멱등성은 백엔드가 보장한다.
 const refreshFlights = new Map<string, RefreshFlightEntry>();
 
 function deleteEntryIfCurrent(fingerprint: string, entry: RefreshFlightEntry) {
@@ -292,6 +293,7 @@ export async function joinSoftRefreshSingleFlight(
 ): Promise<SoftRefreshResult> {
   const deadlineAt = Date.now() + SOFT_REFRESH_TOTAL_TIMEOUT_MS;
   let callerTimedOut = false;
+  const hasCallerTimedOut = () => callerTimedOut || Date.now() >= deadlineAt;
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<SoftRefreshResult>((resolve) => {
     timeoutId = setTimeout(() => {
@@ -307,12 +309,10 @@ export async function joinSoftRefreshSingleFlight(
     try {
       fingerprint = await createRefreshTokenFingerprint(refreshToken);
     } catch {
-      return callerTimedOut || Date.now() >= deadlineAt
-        ? { kind: "caller_timeout" }
-        : { kind: "miss" };
+      return hasCallerTimedOut() ? { kind: "caller_timeout" } : { kind: "miss" };
     }
 
-    if (callerTimedOut || Date.now() >= deadlineAt) {
+    if (hasCallerTimedOut()) {
       return { kind: "caller_timeout" };
     }
 
@@ -321,6 +321,10 @@ export async function joinSoftRefreshSingleFlight(
       return { kind: "miss" };
     }
     if (entry.kind === "success") {
+      if (hasCallerTimedOut()) {
+        return { kind: "caller_timeout" };
+      }
+
       return {
         kind: "outcome",
         disposition: "reused",
@@ -328,13 +332,12 @@ export async function joinSoftRefreshSingleFlight(
       };
     }
 
-    const remainingMs = deadlineAt - Date.now();
-    if (remainingMs <= 0) {
+    if (hasCallerTimedOut()) {
       return { kind: "caller_timeout" };
     }
 
     const outcome = await entry.promise;
-    if (callerTimedOut || Date.now() >= deadlineAt) {
+    if (hasCallerTimedOut()) {
       return { kind: "caller_timeout" };
     }
 

--- a/src/lib/auth/token-refresh-utils.ts
+++ b/src/lib/auth/token-refresh-utils.ts
@@ -41,14 +41,10 @@ export function parseRefreshTokenPair(data: unknown): RefreshTokenPair | null {
   return data.result;
 }
 
-export async function getErrorCodeFromResponse(response: Response): Promise<string | null> {
-  try {
-    const data: unknown = await response.json();
-    if (!isErrorCodeResponseBody(data)) {
-      return null;
-    }
-    return data.code;
-  } catch {
+export function parseRefreshErrorCode(data: unknown): string | null {
+  if (!isErrorCodeResponseBody(data)) {
     return null;
   }
+
+  return data.code;
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -34,7 +34,7 @@ interface AuthFailureResponseOptions {
 }
 
 type RouteType = "public" | "protected" | "api";
-type AccessTokenState = "valid" | "expiring" | "expired_or_invalid";
+type AccessTokenRefreshState = "usable" | "expiring" | "expired_or_invalid";
 type RefreshMode = "soft" | "hard";
 type RefreshFailureReason = Extract<RefreshOutcome, { kind: "failure" }>["reason"];
 
@@ -82,14 +82,14 @@ export async function proxy(request: NextRequest) {
       return NextResponse.next();
     }
 
-    if (!accessToken || getAccessTokenState(accessToken) !== "valid") {
+    if (!accessToken || getAccessTokenRefreshState(accessToken) !== "usable") {
       return await trySoftRefreshToken(request, refreshToken);
     }
 
     return NextResponse.next();
   }
 
-  // 토큰 없으면 로그인 라우트로 리다이렉트
+  // Access Token이 없으면 Refresh Token으로 복구를 시도하거나 인증 실패 응답을 만든다.
   if (!accessToken) {
     if (!refreshToken) {
       return buildAuthFailureResponse(request, {
@@ -101,10 +101,10 @@ export async function proxy(request: NextRequest) {
     return await tryHardRefreshToken(request, refreshToken);
   }
 
-  // 토큰 만료 상태 체크
-  const accessTokenState = getAccessTokenState(accessToken);
+  // 서명 검증이 아닌 만료 시간 기반 Refresh 필요 상태를 확인한다.
+  const accessTokenRefreshState = getAccessTokenRefreshState(accessToken);
 
-  if (accessTokenState === "expiring") {
+  if (accessTokenRefreshState === "expiring") {
     if (!refreshToken) {
       return NextResponse.next();
     }
@@ -112,7 +112,7 @@ export async function proxy(request: NextRequest) {
     return await trySoftRefreshToken(request, refreshToken);
   }
 
-  if (accessTokenState === "expired_or_invalid") {
+  if (accessTokenRefreshState === "expired_or_invalid") {
     if (refreshToken) {
       return await tryHardRefreshToken(request, refreshToken);
     }
@@ -245,10 +245,10 @@ function decodeBase64Url(value: string): string {
 }
 
 /**
- * JWT 토큰 만료 상태 확인
- * 주의: Base64 디코딩만 수행하며 서명 검증은 백엔드에서 수행됨
+ * JWT payload의 exp만 base64url decode해 Refresh 필요 상태를 판단한다.
+ * 서명 검증은 수행하지 않으므로 이 결과만으로 토큰의 진위나 인증·인가를 보장하지 않는다.
  */
-function getAccessTokenState(token: string): AccessTokenState {
+function getAccessTokenRefreshState(token: string): AccessTokenRefreshState {
   try {
     const parts = token.split(".");
     if (parts.length !== 3 || !parts[1]) {
@@ -265,7 +265,7 @@ function getAccessTokenState(token: string): AccessTokenState {
       return "expired_or_invalid";
     }
 
-    return remainingMs < REFRESH_THRESHOLD_MS ? "expiring" : "valid";
+    return remainingMs < REFRESH_THRESHOLD_MS ? "expiring" : "usable";
   } catch {
     return "expired_or_invalid";
   }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -214,6 +214,11 @@ function logRefreshFailure(
     disposition: details.disposition,
   };
 
+  if (details.mode === "soft") {
+    console.warn("Proxy: Token refresh failed", context);
+    return;
+  }
+
   console.error("Proxy: Token refresh failed", context);
 }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -9,7 +9,6 @@ import { setRedirectAfterLoginCookie } from "@/lib/auth/redirect-after-login-coo
 import {
   joinSoftRefreshSingleFlight,
   runHardRefreshSingleFlight,
-  type HardRefreshResult,
   type RefreshOutcome,
 } from "@/lib/auth/refresh-token-single-flight";
 import { isKnownPublicPageRoute, isProtectedPageRoute } from "@/lib/auth/route-access-policy";
@@ -38,10 +37,17 @@ type RouteType = "public" | "protected" | "api";
 type AccessTokenState = "valid" | "expiring" | "expired_or_invalid";
 type RefreshMode = "soft" | "hard";
 type RefreshFailureReason = Extract<RefreshOutcome, { kind: "failure" }>["reason"];
-type RefreshDisposition = HardRefreshResult["disposition"];
 
-let fingerprintBypassLogged = false;
-
+/**
+ * 실제 페이지나 API가 실행되기 전에 인증 상태를 확인하는 공통 진입점이다.
+ *
+ * 공개 경로인지 보호 경로인지 구분하고 Access Token 상태에 따라 요청을 그대로 통과시키거나,
+ * 기존 Refresh 작업에만 합류하는 soft 갱신 또는 새 작업을 만들 수 있는 hard 갱신을 선택한다.
+ * 각 갱신 결과는 현재 요청만을 위한 응답과 Cookie로 변환한다.
+ *
+ * @param request 브라우저 또는 API client가 보낸 현재 Next.js 요청.
+ * @returns 인증 상태에 따라 통과, 새 Cookie, redirect 또는 API 오류가 적용된 응답.
+ */
 export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const isPublicPageRoute = isKnownPublicPageRoute(pathname);
@@ -195,6 +201,14 @@ function getRouteType(pathname: string): RouteType {
   return matched?.type ?? "public";
 }
 
+/**
+ * Refresh 실패 원인을 토큰 같은 민감정보 없이 정해진 필드만 사용해 기록한다.
+ * soft 실패는 현재 Access Token으로 계속 진행할 수 있어 warn으로 남기고,
+ * hard 실패는 인증이 필요한 요청을 완료하지 못한 상황이므로 error로 남긴다.
+ *
+ * @param request 실패가 발생한 현재 요청. 경로 종류를 구하는 데만 사용한다.
+ * @param details 실패 종류, 상태 코드, Cookie 삭제 여부와 갱신 모드.
+ */
 function logRefreshFailure(
   request: NextRequest,
   details: {
@@ -202,7 +216,6 @@ function logRefreshFailure(
     status: number;
     cookieClear: boolean;
     mode: RefreshMode;
-    disposition: RefreshDisposition;
   }
 ) {
   const context = {
@@ -211,7 +224,6 @@ function logRefreshFailure(
     routeType: getRouteType(request.nextUrl.pathname),
     cookieClear: details.cookieClear,
     mode: details.mode,
-    disposition: details.disposition,
   };
 
   if (details.mode === "soft") {
@@ -220,17 +232,6 @@ function logRefreshFailure(
   }
 
   console.error("Proxy: Token refresh failed", context);
-}
-
-function logFingerprintBypassOnce() {
-  if (fingerprintBypassLogged) {
-    return;
-  }
-
-  fingerprintBypassLogged = true;
-  console.warn("Proxy: Token refresh fingerprint bypass", {
-    mode: "hard",
-  });
 }
 
 /**
@@ -270,11 +271,22 @@ function getAccessTokenState(token: string): AccessTokenState {
   }
 }
 
+/**
+ * 공유된 Refresh 성공 결과를 현재 caller만의 NextResponse로 변환한다.
+ *
+ * 갱신된 토큰을 현재 요청의 Cookie header에 넣어 뒤의 route handler가 바로 사용할 수 있게 하고,
+ * 응답 Cookie에도 넣어 브라우저가 다음 요청부터 새 토큰을 보내도록 한다. Refresh 결과만 공유하고
+ * 응답 객체는 요청마다 새로 만들기 때문에 동시에 들어온 caller들의 응답이 서로 섞이지 않는다.
+ *
+ * @param request 새 토큰을 전달받아야 하는 현재 요청.
+ * @param outcome 백엔드가 반환한 새 Access Token과 Refresh Token.
+ * @param mode 결과를 받은 경로가 soft인지 hard인지 나타내는 값.
+ * @returns 새 토큰이 요청 header와 응답 Cookie에 적용된 응답.
+ */
 function buildRefreshSuccessResponse(
   request: NextRequest,
   outcome: Extract<RefreshOutcome, { kind: "success" }>,
-  mode: RefreshMode,
-  disposition: RefreshDisposition
+  mode: RefreshMode
 ): NextResponse {
   const tokens = {
     accessToken: outcome.tokens.accessToken,
@@ -299,13 +311,20 @@ function buildRefreshSuccessResponse(
       status: outcome.status,
       routeType: getRouteType(request.nextUrl.pathname),
       mode,
-      disposition,
     });
   }
 
   return response;
 }
 
+/**
+ * hard 갱신 실패를 보호 페이지의 로그인 이동 또는 보호 API의 JSON 오류 응답으로 바꾼다.
+ * hard 요청은 유효한 Access Token 없이 진행할 수 없으므로 인증 Cookie도 함께 삭제한다.
+ *
+ * @param request 페이지 요청인지 API 요청인지 판단할 현재 요청.
+ * @param outcome 백엔드 HTTP 오류, 잘못된 응답, timeout 또는 network 오류 정보.
+ * @returns 요청 종류와 실패 원인에 맞는 인증 실패 응답.
+ */
 function buildHardRefreshFailureResponse(
   request: NextRequest,
   outcome: Extract<RefreshOutcome, { kind: "failure" }>
@@ -335,14 +354,23 @@ function buildHardRefreshFailureResponse(
   });
 }
 
+/**
+ * coordinator가 돌려준 Refresh 결과와 갱신 모드에 맞는 최종 응답을 선택한다.
+ * 성공이면 두 모드 모두 새 토큰을 전달한다. 실패이면 로그를 남긴 뒤 soft 요청은 기존 토큰으로
+ * 계속 진행시키고, hard 요청은 로그인 이동 또는 API 오류 응답으로 변환한다.
+ *
+ * @param request 최종 응답을 받아야 하는 현재 요청.
+ * @param outcome coordinator가 정리한 성공 또는 실패 결과.
+ * @param mode 실패했을 때 통과할지 차단할지를 결정하는 soft 또는 hard 모드.
+ * @returns 현재 caller에게 전달할 NextResponse.
+ */
 function buildResponseFromRefreshOutcome(
   request: NextRequest,
   outcome: RefreshOutcome,
-  mode: RefreshMode,
-  disposition: RefreshDisposition
+  mode: RefreshMode
 ): NextResponse {
   if (outcome.kind === "success") {
-    return buildRefreshSuccessResponse(request, outcome, mode, disposition);
+    return buildRefreshSuccessResponse(request, outcome, mode);
   }
 
   logRefreshFailure(request, {
@@ -350,7 +378,6 @@ function buildResponseFromRefreshOutcome(
     status: outcome.status,
     cookieClear: mode === "hard",
     mode,
-    disposition,
   });
 
   if (mode === "soft") {
@@ -360,18 +387,36 @@ function buildResponseFromRefreshOutcome(
   return buildHardRefreshFailureResponse(request, outcome);
 }
 
+/**
+ * 새 Refresh를 시작하지 않고 같은 Refresh Token의 기존 작업에만 합류한다.
+ * 작업이 없거나 대기 시간이 지나 null을 받으면 현재 요청을 그대로 통과시킨다.
+ * 결과를 받았을 때만 성공 Cookie 또는 soft 실패 정책을 현재 응답에 적용한다.
+ *
+ * @param request 기존 Access Token으로 계속 진행할 수 있는 현재 요청.
+ * @param refreshToken 기존 Refresh 작업을 찾을 때 사용할 Refresh Token.
+ * @returns 그대로 통과하거나 기존 Refresh 결과가 적용된 응답.
+ */
 async function trySoftRefreshToken(
   request: NextRequest,
   refreshToken: string
 ): Promise<NextResponse> {
-  const result = await joinSoftRefreshSingleFlight(refreshToken);
-  if (result.kind === "miss" || result.kind === "caller_timeout") {
+  const outcome = await joinSoftRefreshSingleFlight(refreshToken);
+  if (!outcome) {
     return NextResponse.next();
   }
 
-  return buildResponseFromRefreshOutcome(request, result.outcome, "soft", result.disposition);
+  return buildResponseFromRefreshOutcome(request, outcome, "soft");
 }
 
+/**
+ * 유효한 Access Token이 없어 반드시 갱신 결과가 필요한 요청을 처리한다.
+ * 백엔드 주소가 없으면 설정 오류 응답을 만들고, 주소가 있으면 같은 Refresh Token의 hard 작업을
+ * 공유하거나 새로 시작한 뒤 그 결과를 현재 요청의 성공 또는 실패 응답으로 변환한다.
+ *
+ * @param request 새 Access Token이 있어야 계속 진행할 수 있는 현재 요청.
+ * @param refreshToken 기존 작업을 찾거나 새 백엔드 갱신에 사용할 Refresh Token.
+ * @returns Refresh 성공 또는 hard 실패 정책이 적용된 응답.
+ */
 async function tryHardRefreshToken(
   request: NextRequest,
   refreshToken: string
@@ -386,12 +431,8 @@ async function tryHardRefreshToken(
     });
   }
 
-  const result = await runHardRefreshSingleFlight(refreshToken, backendUrl);
-  if (result.disposition === "bypass") {
-    logFingerprintBypassOnce();
-  }
-
-  return buildResponseFromRefreshOutcome(request, result.outcome, "hard", result.disposition);
+  const outcome = await runHardRefreshSingleFlight(refreshToken, backendUrl);
+  return buildResponseFromRefreshOutcome(request, outcome, "hard");
 }
 
 // Matcher: 불필요한 요청 제외 (정적 파일, 이미지, prefetch 등)

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -3,14 +3,16 @@ import { NextResponse } from "next/server";
 
 import { clearAuthCookies, setAuthCookies } from "@/lib/auth/auth-cookies";
 import { ACCESS_TOKEN_COOKIE, REFRESH_TOKEN_COOKIE } from "@/lib/auth/cookie-constants";
-import {
-  buildRefreshCookieHeader,
-  mergeCookieHeaderWithAuthTokens,
-} from "@/lib/auth/cookie-header-utils";
+import { mergeCookieHeaderWithAuthTokens } from "@/lib/auth/cookie-header-utils";
 import { buildLoginRedirectUrl } from "@/lib/auth/login-redirect-utils";
 import { setRedirectAfterLoginCookie } from "@/lib/auth/redirect-after-login-cookie";
+import {
+  joinSoftRefreshSingleFlight,
+  runHardRefreshSingleFlight,
+  type HardRefreshResult,
+  type RefreshOutcome,
+} from "@/lib/auth/refresh-token-single-flight";
 import { isKnownPublicPageRoute, isProtectedPageRoute } from "@/lib/auth/route-access-policy";
-import { getErrorCodeFromResponse, parseRefreshTokenPair } from "@/lib/auth/token-refresh-utils";
 import { BACKEND_ERROR_CODES, LOGIN_INTERNAL_ERROR_CODES } from "@/lib/error/error-codes";
 import { LOGIN_ROUTE } from "@/lib/routes/route-paths";
 import { isMockModeEnabled } from "@/mocks/is-mock-mode-enabled";
@@ -26,30 +28,19 @@ const PUBLIC_API_ROUTE_PATTERNS = [
 // 토큰 갱신 임계값 (5분)
 const REFRESH_THRESHOLD_MS = 5 * 60 * 1000;
 
-// 토큰 갱신 API 타임아웃 (10초)
-const REFRESH_TIMEOUT_MS = 10000;
-// 공개 페이지에서 사용하는 소프트 갱신 타임아웃 (짧게 제한)
-const SOFT_REFRESH_TIMEOUT_MS = 1500;
-
-interface TryRefreshTokenOptions {
-  allowPassThroughOnFailure?: boolean;
-  timeoutMs?: number;
-}
-
-const SOFT_REFRESH_OPTIONS: TryRefreshTokenOptions = {
-  allowPassThroughOnFailure: true,
-  timeoutMs: SOFT_REFRESH_TIMEOUT_MS,
-};
-
 interface AuthFailureResponseOptions {
   clearAuth?: boolean;
   reason?: string;
   status?: number;
 }
 
-type RefreshFailureReason = "http_error" | "invalid_response" | "timeout" | "network_error";
 type RouteType = "public" | "protected" | "api";
 type AccessTokenState = "valid" | "expiring" | "expired_or_invalid";
+type RefreshMode = "soft" | "hard";
+type RefreshFailureReason = Extract<RefreshOutcome, { kind: "failure" }>["reason"];
+type RefreshDisposition = HardRefreshResult["disposition"];
+
+let fingerprintBypassLogged = false;
 
 export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
@@ -86,7 +77,7 @@ export async function proxy(request: NextRequest) {
     }
 
     if (!accessToken || getAccessTokenState(accessToken) !== "valid") {
-      return await tryRefreshToken(request, refreshToken, SOFT_REFRESH_OPTIONS);
+      return await trySoftRefreshToken(request, refreshToken);
     }
 
     return NextResponse.next();
@@ -101,7 +92,7 @@ export async function proxy(request: NextRequest) {
         status: 401,
       });
     }
-    return await tryRefreshToken(request, refreshToken);
+    return await tryHardRefreshToken(request, refreshToken);
   }
 
   // 토큰 만료 상태 체크
@@ -112,12 +103,12 @@ export async function proxy(request: NextRequest) {
       return NextResponse.next();
     }
 
-    return await tryRefreshToken(request, refreshToken, SOFT_REFRESH_OPTIONS);
+    return await trySoftRefreshToken(request, refreshToken);
   }
 
   if (accessTokenState === "expired_or_invalid") {
     if (refreshToken) {
-      return await tryRefreshToken(request, refreshToken);
+      return await tryHardRefreshToken(request, refreshToken);
     }
 
     return buildAuthFailureResponse(request, {
@@ -210,23 +201,31 @@ function logRefreshFailure(
     reason: RefreshFailureReason;
     status: number;
     cookieClear: boolean;
-    error?: unknown;
+    mode: RefreshMode;
+    disposition: RefreshDisposition;
   }
 ) {
   const context = {
     reason: details.reason,
     status: details.status,
-    path: request.nextUrl.pathname,
     routeType: getRouteType(request.nextUrl.pathname),
     cookieClear: details.cookieClear,
+    mode: details.mode,
+    disposition: details.disposition,
   };
 
-  if (details.error) {
-    console.error("Proxy: Token refresh failed", context, details.error);
+  console.error("Proxy: Token refresh failed", context);
+}
+
+function logFingerprintBypassOnce() {
+  if (fingerprintBypassLogged) {
     return;
   }
 
-  console.error("Proxy: Token refresh failed", context);
+  fingerprintBypassLogged = true;
+  console.warn("Proxy: Token refresh fingerprint bypass", {
+    mode: "hard",
+  });
 }
 
 /**
@@ -266,139 +265,128 @@ function getAccessTokenState(token: string): AccessTokenState {
   }
 }
 
-/**
- * 백엔드에 토큰 갱신 요청
- */
-async function tryRefreshToken(
+function buildRefreshSuccessResponse(
   request: NextRequest,
-  refreshToken: string,
-  options?: TryRefreshTokenOptions
-): Promise<NextResponse> {
-  const allowPassThroughOnFailure = options?.allowPassThroughOnFailure ?? false;
-  const refreshTimeoutMs = options?.timeoutMs ?? REFRESH_TIMEOUT_MS;
+  outcome: Extract<RefreshOutcome, { kind: "success" }>,
+  mode: RefreshMode,
+  disposition: RefreshDisposition
+): NextResponse {
+  const tokens = {
+    accessToken: outcome.tokens.accessToken,
+    refreshToken: outcome.tokens.refreshToken,
+  };
+  const requestHeaders = new Headers(request.headers);
+  const updatedCookieHeader = mergeCookieHeaderWithAuthTokens(
+    request.headers.get("cookie"),
+    tokens
+  );
+  if (updatedCookieHeader) {
+    requestHeaders.set("cookie", updatedCookieHeader);
+  }
 
-  try {
-    const backendUrl = process.env.BACKEND_API_BASE;
+  const response = NextResponse.next({
+    request: { headers: requestHeaders },
+  });
+  setAuthCookies(response.cookies, tokens);
 
-    if (!backendUrl) {
-      console.error("Proxy: BACKEND_API_BASE is not configured");
-      if (allowPassThroughOnFailure) {
-        return NextResponse.next();
-      }
-      return buildAuthFailureResponse(request, {
-        clearAuth: true,
-        reason: LOGIN_INTERNAL_ERROR_CODES.CONFIG_ERROR,
-        status: 500,
-      });
-    }
-
-    // fetch 타임아웃 설정 (필수 버그 픽스)
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), refreshTimeoutMs);
-
-    let reissueResponse: Response;
-    try {
-      reissueResponse = await fetch(`${backendUrl}/auth/refresh`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Cookie: buildRefreshCookieHeader(refreshToken),
-        },
-        credentials: "include",
-        signal: controller.signal,
-      });
-    } finally {
-      clearTimeout(timeoutId);
-    }
-
-    if (!reissueResponse.ok) {
-      logRefreshFailure(request, {
-        reason: "http_error",
-        status: reissueResponse.status,
-        cookieClear: !allowPassThroughOnFailure,
-      });
-      if (allowPassThroughOnFailure) {
-        return NextResponse.next();
-      }
-
-      const errorCode = await getErrorCodeFromResponse(reissueResponse);
-      const status =
-        reissueResponse.status === 401 || reissueResponse.status === 403
-          ? 401
-          : reissueResponse.status >= 500
-            ? 500
-            : 400;
-      return buildAuthFailureResponse(request, {
-        clearAuth: true,
-        reason: errorCode ?? BACKEND_ERROR_CODES.COMMON_INTERNAL_SERVER_ERROR,
-        status,
-      });
-    }
-
-    const data: unknown = await reissueResponse.json();
-    const tokens = parseRefreshTokenPair(data);
-
-    // API 응답 검증 (필수 버그 픽스)
-    if (!tokens) {
-      logRefreshFailure(request, {
-        reason: "invalid_response",
-        status: reissueResponse.status,
-        cookieClear: !allowPassThroughOnFailure,
-      });
-      if (allowPassThroughOnFailure) {
-        return NextResponse.next();
-      }
-      return buildAuthFailureResponse(request, {
-        clearAuth: true,
-        reason: BACKEND_ERROR_CODES.COMMON_INTERNAL_SERVER_ERROR,
-        status: 500,
-      });
-    }
-
-    // 현재 요청의 쿠키 헤더를 갱신해서 다운스트림(RSC, Route Handler)에 새 토큰을 전달한다.
-    const requestHeaders = new Headers(request.headers);
-    const updatedCookieHeader = mergeCookieHeaderWithAuthTokens(
-      request.headers.get("cookie"),
-      tokens
-    );
-    if (updatedCookieHeader) {
-      requestHeaders.set("cookie", updatedCookieHeader);
-    }
-
-    const response = NextResponse.next({
-      request: { headers: requestHeaders },
-    });
-    setAuthCookies(response.cookies, {
-      accessToken: tokens.accessToken,
-      refreshToken: tokens.refreshToken,
-    });
-
-    if (process.env.NODE_ENV !== "production") {
-      console.warn("Proxy: Token refresh succeeded", {
-        status: reissueResponse.status,
-        path: request.nextUrl.pathname,
-      });
-    }
-
-    return response;
-  } catch (error) {
-    const isTimeout = error instanceof Error && error.name === "AbortError";
-    logRefreshFailure(request, {
-      reason: isTimeout ? "timeout" : "network_error",
-      status: isTimeout ? 504 : 500,
-      cookieClear: !allowPassThroughOnFailure,
-      error,
-    });
-
-    if (allowPassThroughOnFailure) {
-      return NextResponse.next();
-    }
-    return buildAuthFailureResponse(request, {
-      clearAuth: true,
-      reason: LOGIN_INTERNAL_ERROR_CODES.NETWORK_ERROR,
-      status: isTimeout ? 504 : 500,
+  if (process.env.NODE_ENV !== "production") {
+    console.warn("Proxy: Token refresh succeeded", {
+      status: outcome.status,
+      routeType: getRouteType(request.nextUrl.pathname),
+      mode,
+      disposition,
     });
   }
+
+  return response;
+}
+
+function buildHardRefreshFailureResponse(
+  request: NextRequest,
+  outcome: Extract<RefreshOutcome, { kind: "failure" }>
+): NextResponse {
+  if (outcome.reason === "http_error") {
+    const status =
+      outcome.status === 401 || outcome.status === 403 ? 401 : outcome.status >= 500 ? 500 : 400;
+    return buildAuthFailureResponse(request, {
+      clearAuth: true,
+      reason: outcome.errorCode ?? BACKEND_ERROR_CODES.COMMON_INTERNAL_SERVER_ERROR,
+      status,
+    });
+  }
+
+  if (outcome.reason === "invalid_response") {
+    return buildAuthFailureResponse(request, {
+      clearAuth: true,
+      reason: BACKEND_ERROR_CODES.COMMON_INTERNAL_SERVER_ERROR,
+      status: 500,
+    });
+  }
+
+  return buildAuthFailureResponse(request, {
+    clearAuth: true,
+    reason: LOGIN_INTERNAL_ERROR_CODES.NETWORK_ERROR,
+    status: outcome.status,
+  });
+}
+
+function buildResponseFromRefreshOutcome(
+  request: NextRequest,
+  outcome: RefreshOutcome,
+  mode: RefreshMode,
+  disposition: RefreshDisposition
+): NextResponse {
+  if (outcome.kind === "success") {
+    return buildRefreshSuccessResponse(request, outcome, mode, disposition);
+  }
+
+  logRefreshFailure(request, {
+    reason: outcome.reason,
+    status: outcome.status,
+    cookieClear: mode === "hard",
+    mode,
+    disposition,
+  });
+
+  if (mode === "soft") {
+    return NextResponse.next();
+  }
+
+  return buildHardRefreshFailureResponse(request, outcome);
+}
+
+async function trySoftRefreshToken(
+  request: NextRequest,
+  refreshToken: string
+): Promise<NextResponse> {
+  const result = await joinSoftRefreshSingleFlight(refreshToken);
+  if (result.kind === "miss" || result.kind === "caller_timeout") {
+    return NextResponse.next();
+  }
+
+  return buildResponseFromRefreshOutcome(request, result.outcome, "soft", result.disposition);
+}
+
+async function tryHardRefreshToken(
+  request: NextRequest,
+  refreshToken: string
+): Promise<NextResponse> {
+  const backendUrl = process.env.BACKEND_API_BASE;
+  if (!backendUrl) {
+    console.error("Proxy: BACKEND_API_BASE is not configured");
+    return buildAuthFailureResponse(request, {
+      clearAuth: true,
+      reason: LOGIN_INTERNAL_ERROR_CODES.CONFIG_ERROR,
+      status: 500,
+    });
+  }
+
+  const result = await runHardRefreshSingleFlight(refreshToken, backendUrl);
+  if (result.disposition === "bypass") {
+    logFingerprintBypassOnce();
+  }
+
+  return buildResponseFromRefreshOutcome(request, result.outcome, "hard", result.disposition);
 }
 
 // Matcher: 불필요한 요청 제외 (정적 파일, 이미지, prefetch 등)

--- a/src/test/auth/refresh-token-single-flight.test.ts
+++ b/src/test/auth/refresh-token-single-flight.test.ts
@@ -1,0 +1,621 @@
+/**
+ * @jest-environment @edge-runtime/jest-environment
+ */
+
+import * as singleFlightModule from "@/lib/auth/refresh-token-single-flight";
+import {
+  joinSoftRefreshSingleFlight,
+  runHardRefreshSingleFlight,
+} from "@/lib/auth/refresh-token-single-flight";
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, resolve, reject };
+}
+
+function createRefreshSuccessResponse(accessToken = "new-access", refreshToken = "new-refresh") {
+  return {
+    ok: true,
+    status: 200,
+    json: jest.fn().mockResolvedValue({
+      result: { accessToken, refreshToken },
+    }),
+  } as unknown as Response;
+}
+
+function createRefreshFailureResponse(status = 401, code = "AUTH401_7") {
+  return {
+    ok: false,
+    status,
+    json: jest.fn().mockResolvedValue({ code }),
+  } as unknown as Response;
+}
+
+async function flushMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+const BACKEND_URL = "https://backend.example.com";
+let tokenSequence = 0;
+let digestSequence = 0;
+
+function uniqueRefreshToken(label: string) {
+  tokenSequence += 1;
+  return `${label}-${tokenSequence}`;
+}
+
+function mockSingleTokenDigest() {
+  digestSequence += 1;
+  const digest = new Uint8Array(32).fill(digestSequence).buffer;
+  return jest.spyOn(crypto.subtle, "digest").mockResolvedValue(digest);
+}
+
+describe("refresh-token-single-flight", () => {
+  const mockFetch = jest.fn();
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-08-14T00:00:00.000Z"));
+    jest.clearAllMocks();
+    global.fetch = mockFetch as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it("같은 Refresh Token의 동시 hard 요청은 백엔드를 한 번만 호출해야 함", async () => {
+    const refreshToken = uniqueRefreshToken("same-hard");
+    const response = deferred<Response>();
+    const fetchStarted = deferred<void>();
+    mockSingleTokenDigest();
+    mockFetch.mockImplementation(() => {
+      fetchStarted.resolve();
+      return response.promise;
+    });
+
+    const first = runHardRefreshSingleFlight(refreshToken, BACKEND_URL);
+    const second = runHardRefreshSingleFlight(refreshToken, BACKEND_URL);
+
+    await fetchStarted.promise;
+    await flushMicrotasks();
+    response.resolve(createRefreshSuccessResponse());
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect([firstResult.disposition, secondResult.disposition].sort()).toEqual([
+      "created",
+      "joined",
+    ]);
+    expect(firstResult.outcome).toEqual(secondResult.outcome);
+  });
+
+  it("서로 다른 Refresh Token은 결과를 공유하지 않아야 함", async () => {
+    mockFetch
+      .mockResolvedValueOnce(createRefreshSuccessResponse("access-a", "refresh-a"))
+      .mockResolvedValueOnce(createRefreshSuccessResponse("access-b", "refresh-b"));
+
+    const [first, second] = await Promise.all([
+      runHardRefreshSingleFlight(uniqueRefreshToken("user-a"), BACKEND_URL),
+      runHardRefreshSingleFlight(uniqueRefreshToken("user-b"), BACKEND_URL),
+    ]);
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(first.outcome).not.toEqual(second.outcome);
+  });
+
+  it("soft miss는 새 Refresh 작업을 만들지 않아야 함", async () => {
+    const result = await joinSoftRefreshSingleFlight(uniqueRefreshToken("soft-miss"));
+
+    expect(result).toEqual({ kind: "miss" });
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(jest.getTimerCount()).toBe(0);
+    await jest.advanceTimersByTimeAsync(1500);
+    expect(jest.getTimerCount()).toBe(0);
+  });
+
+  it("soft 요청은 기존 hard 작업의 결과에 합류해야 함", async () => {
+    const refreshToken = uniqueRefreshToken("hard-soft");
+    const response = deferred<Response>();
+    const fetchStarted = deferred<void>();
+    mockSingleTokenDigest();
+    mockFetch.mockImplementation(() => {
+      fetchStarted.resolve();
+      return response.promise;
+    });
+
+    const hardResultPromise = runHardRefreshSingleFlight(refreshToken, BACKEND_URL);
+    await fetchStarted.promise;
+    const softResultPromise = joinSoftRefreshSingleFlight(refreshToken);
+
+    await flushMicrotasks();
+    response.resolve(createRefreshSuccessResponse("shared-access", "shared-refresh"));
+    const [hardResult, softResult] = await Promise.all([hardResultPromise, softResultPromise]);
+
+    expect(hardResult.disposition).toBe("created");
+    expect(softResult).toEqual({
+      kind: "outcome",
+      disposition: "joined",
+      outcome: hardResult.outcome,
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(jest.getTimerCount()).toBe(1);
+  });
+
+  it("soft 요청은 2초 이내 성공 결과를 reused로 받고 caller timer를 즉시 정리해야 함", async () => {
+    const refreshToken = uniqueRefreshToken("soft-reused");
+    mockFetch.mockResolvedValueOnce(createRefreshSuccessResponse());
+
+    const hardResult = await runHardRefreshSingleFlight(refreshToken, BACKEND_URL);
+    const softResult = await joinSoftRefreshSingleFlight(refreshToken);
+
+    expect(softResult).toEqual({
+      kind: "outcome",
+      disposition: "reused",
+      outcome: hardResult.outcome,
+    });
+    expect(jest.getTimerCount()).toBe(1);
+    await jest.advanceTimersByTimeAsync(1500);
+    expect(jest.getTimerCount()).toBe(1);
+  });
+
+  it("soft 지문 계산이 1,499ms에 끝나면 남은 예산 안에서 기존 성공 결과를 재사용해야 함", async () => {
+    const refreshToken = uniqueRefreshToken("soft-delayed-reuse");
+    digestSequence += 1;
+    const fingerprint = new Uint8Array(32).fill(digestSequence).buffer;
+    const delayedDigest = deferred<ArrayBuffer>();
+    jest
+      .spyOn(crypto.subtle, "digest")
+      .mockResolvedValueOnce(fingerprint)
+      .mockReturnValueOnce(delayedDigest.promise);
+    mockFetch.mockResolvedValueOnce(createRefreshSuccessResponse());
+
+    const hardResult = await runHardRefreshSingleFlight(refreshToken, BACKEND_URL);
+    const softResultPromise = joinSoftRefreshSingleFlight(refreshToken);
+    await jest.advanceTimersByTimeAsync(1499);
+    delayedDigest.resolve(fingerprint);
+
+    await expect(softResultPromise).resolves.toEqual({
+      kind: "outcome",
+      disposition: "reused",
+      outcome: hardResult.outcome,
+    });
+    expect(jest.getTimerCount()).toBe(1);
+  });
+
+  it("soft shared wait는 지문 계산 뒤 남은 총 예산만 사용해야 함", async () => {
+    const refreshToken = uniqueRefreshToken("soft-remaining-budget");
+    digestSequence += 1;
+    const fingerprint = new Uint8Array(32).fill(digestSequence).buffer;
+    const delayedDigest = deferred<ArrayBuffer>();
+    const backendResponse = deferred<Response>();
+    const fetchStarted = deferred<void>();
+    jest
+      .spyOn(crypto.subtle, "digest")
+      .mockResolvedValueOnce(fingerprint)
+      .mockReturnValueOnce(delayedDigest.promise);
+    mockFetch.mockImplementation(() => {
+      fetchStarted.resolve();
+      return backendResponse.promise;
+    });
+
+    const hardResultPromise = runHardRefreshSingleFlight(refreshToken, BACKEND_URL);
+    await fetchStarted.promise;
+    const softResultPromise = joinSoftRefreshSingleFlight(refreshToken);
+    let settled = false;
+    void softResultPromise.then(() => {
+      settled = true;
+    });
+
+    await jest.advanceTimersByTimeAsync(1000);
+    delayedDigest.resolve(fingerprint);
+    await flushMicrotasks();
+    await jest.advanceTimersByTimeAsync(499);
+    expect(settled).toBe(false);
+
+    await jest.advanceTimersByTimeAsync(1);
+    await expect(softResultPromise).resolves.toEqual({ kind: "caller_timeout" });
+
+    backendResponse.resolve(createRefreshSuccessResponse());
+    await expect(hardResultPromise).resolves.toMatchObject({
+      outcome: { kind: "success" },
+    });
+  });
+
+  it("shared outcome이 정확히 1,500ms에 끝나면 최종 반환 전 caller_timeout으로 고정해야 함", async () => {
+    const refreshToken = uniqueRefreshToken("soft-exact-outcome-deadline");
+    const backendResponse = deferred<Response>();
+    const fetchStarted = deferred<void>();
+    mockSingleTokenDigest();
+    mockFetch.mockImplementation(() => {
+      fetchStarted.resolve();
+      return backendResponse.promise;
+    });
+
+    const hardResultPromise = runHardRefreshSingleFlight(refreshToken, BACKEND_URL);
+    await fetchStarted.promise;
+    const softResultPromise = joinSoftRefreshSingleFlight(refreshToken);
+    await flushMicrotasks();
+
+    jest.setSystemTime(new Date("2026-08-14T00:00:01.500Z"));
+    backendResponse.resolve(createRefreshSuccessResponse());
+
+    await expect(softResultPromise).resolves.toEqual({ kind: "caller_timeout" });
+    await expect(hardResultPromise).resolves.toMatchObject({
+      outcome: { kind: "success" },
+    });
+  });
+
+  it("soft 총 대기시간은 API 진입부터 1,500ms이고 늦은 지문 계산은 작업을 만들지 않아야 함", async () => {
+    const digest = deferred<ArrayBuffer>();
+    jest.spyOn(crypto.subtle, "digest").mockReturnValueOnce(digest.promise);
+
+    const resultPromise = joinSoftRefreshSingleFlight(uniqueRefreshToken("slow-digest"));
+    let settled = false;
+    void resultPromise.then(() => {
+      settled = true;
+    });
+
+    await jest.advanceTimersByTimeAsync(1499);
+    expect(settled).toBe(false);
+
+    await jest.advanceTimersByTimeAsync(1);
+    await expect(resultPromise).resolves.toEqual({ kind: "caller_timeout" });
+
+    digest.resolve(new ArrayBuffer(32));
+    await flushMicrotasks();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("soft timeout은 공유 hard 작업을 취소하지 않아야 함", async () => {
+    const refreshToken = uniqueRefreshToken("soft-timeout");
+    const response = deferred<Response>();
+    const fetchStarted = deferred<void>();
+    let sharedSignal: AbortSignal | undefined;
+    mockFetch.mockImplementation((_url, init) => {
+      sharedSignal = init?.signal ?? undefined;
+      fetchStarted.resolve();
+      return response.promise;
+    });
+
+    const hardResultPromise = runHardRefreshSingleFlight(refreshToken, BACKEND_URL);
+    await fetchStarted.promise;
+    const softResultPromise = joinSoftRefreshSingleFlight(refreshToken);
+
+    await jest.advanceTimersByTimeAsync(1500);
+    await expect(softResultPromise).resolves.toEqual({ kind: "caller_timeout" });
+    expect(sharedSignal?.aborted).toBe(false);
+
+    response.resolve(createRefreshSuccessResponse());
+    await expect(hardResultPromise).resolves.toMatchObject({
+      disposition: "created",
+      outcome: { kind: "success" },
+    });
+  });
+
+  it.each([
+    ["success", true, 200],
+    ["error", false, 503],
+  ])("hard %s body가 멈추면 전체 교환을 10초에 종료해야 함", async (_label, ok, status) => {
+    const fetchStarted = deferred<void>();
+    mockFetch
+      .mockImplementationOnce((_url, init) => {
+        const signal = init?.signal;
+        fetchStarted.resolve();
+        return Promise.resolve({
+          ok,
+          status,
+          json: jest.fn().mockImplementation(
+            () =>
+              new Promise((_resolve, reject) => {
+                signal?.addEventListener("abort", () => {
+                  reject(new DOMException("Aborted", "AbortError"));
+                });
+              })
+          ),
+        } as unknown as Response);
+      })
+      .mockResolvedValueOnce(createRefreshSuccessResponse());
+
+    const refreshToken = uniqueRefreshToken(`body-${_label}`);
+    const resultPromise = runHardRefreshSingleFlight(refreshToken, BACKEND_URL);
+    await fetchStarted.promise;
+    let settled = false;
+    void resultPromise.then(() => {
+      settled = true;
+    });
+
+    await jest.advanceTimersByTimeAsync(9999);
+    expect(settled).toBe(false);
+
+    await jest.advanceTimersByTimeAsync(1);
+    await expect(resultPromise).resolves.toMatchObject({
+      outcome: { kind: "failure", reason: "timeout", status: 504 },
+    });
+    await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toMatchObject({
+      disposition: "created",
+      outcome: { kind: "success" },
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("hard response headers가 오지 않아도 10초에 timeout되고 다음 요청이 재시도해야 함", async () => {
+    const refreshToken = uniqueRefreshToken("headers-timeout");
+    const fetchStarted = deferred<void>();
+    mockFetch
+      .mockImplementationOnce((_url, init) => {
+        fetchStarted.resolve();
+        return new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("Aborted", "AbortError"));
+          });
+        });
+      })
+      .mockResolvedValueOnce(createRefreshSuccessResponse());
+
+    const resultPromise = runHardRefreshSingleFlight(refreshToken, BACKEND_URL);
+    await fetchStarted.promise;
+    await jest.advanceTimersByTimeAsync(9999);
+    let settled = false;
+    void resultPromise.then(() => {
+      settled = true;
+    });
+    await flushMicrotasks();
+    expect(settled).toBe(false);
+
+    await jest.advanceTimersByTimeAsync(1);
+    await expect(resultPromise).resolves.toMatchObject({
+      outcome: { kind: "failure", reason: "timeout", status: 504 },
+    });
+    await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toMatchObject({
+      disposition: "created",
+      outcome: { kind: "success" },
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("성공 결과는 2초 미만에 재사용하고 2초부터 새 교환을 허용해야 함", async () => {
+    const refreshToken = uniqueRefreshToken("success-reuse");
+    mockFetch
+      .mockResolvedValueOnce(createRefreshSuccessResponse("access-1", "refresh-1"))
+      .mockResolvedValueOnce(createRefreshSuccessResponse("access-2", "refresh-2"));
+
+    const created = await runHardRefreshSingleFlight(refreshToken, BACKEND_URL);
+    const immediate = await runHardRefreshSingleFlight(refreshToken, BACKEND_URL);
+    expect(created.disposition).toBe("created");
+    expect(immediate.disposition).toBe("reused");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    await jest.advanceTimersByTimeAsync(1999);
+    await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toMatchObject({
+      disposition: "reused",
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    await jest.advanceTimersByTimeAsync(1);
+    await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toMatchObject({
+      disposition: "created",
+      outcome: {
+        kind: "success",
+        tokens: { accessToken: "access-2", refreshToken: "refresh-2" },
+      },
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("stale sweep로 만료 결과를 교체하고 늦은 이전 timer가 새 entry를 지우지 않아야 함", async () => {
+    const refreshToken = uniqueRefreshToken("stale-identity");
+    const setTimeoutSpy = jest.spyOn(globalThis, "setTimeout");
+    mockFetch
+      .mockResolvedValueOnce(createRefreshSuccessResponse("access-old", "refresh-old"))
+      .mockResolvedValueOnce(createRefreshSuccessResponse("access-new", "refresh-new"));
+
+    await runHardRefreshSingleFlight(refreshToken, BACKEND_URL);
+    const oldCleanup = setTimeoutSpy.mock.calls.find(([, delay]) => delay === 2000)?.[0] as
+      | (() => void)
+      | undefined;
+    expect(oldCleanup).toBeDefined();
+
+    jest.setSystemTime(new Date("2026-08-14T00:00:02.000Z"));
+    await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toMatchObject({
+      disposition: "created",
+      outcome: {
+        kind: "success",
+        tokens: { accessToken: "access-new", refreshToken: "refresh-new" },
+      },
+    });
+
+    oldCleanup?.();
+    await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toMatchObject({
+      disposition: "reused",
+      outcome: {
+        kind: "success",
+        tokens: { accessToken: "access-new", refreshToken: "refresh-new" },
+      },
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("실패 결과는 즉시 제거해 다음 hard 요청이 재시도할 수 있어야 함", async () => {
+    const refreshToken = uniqueRefreshToken("failure-retry");
+    mockFetch
+      .mockResolvedValueOnce(createRefreshFailureResponse())
+      .mockResolvedValueOnce(createRefreshSuccessResponse());
+
+    await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toMatchObject({
+      outcome: { kind: "failure", reason: "http_error", errorCode: "AUTH401_7" },
+    });
+    await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toMatchObject({
+      disposition: "created",
+      outcome: { kind: "success" },
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    [
+      "malformed JSON",
+      {
+        ok: true,
+        status: 200,
+        json: jest.fn().mockRejectedValue(new SyntaxError("invalid json")),
+      },
+    ],
+    [
+      "invalid shape",
+      {
+        ok: true,
+        status: 200,
+        json: jest.fn().mockResolvedValue({
+          result: { accessToken: "access", refreshToken: null },
+        }),
+      },
+    ],
+  ])(
+    "성공 응답의 %s는 invalid_response이고 즉시 재시도할 수 있어야 함",
+    async (_label, response) => {
+      const refreshToken = uniqueRefreshToken(`invalid-${_label}`);
+      mockFetch
+        .mockResolvedValueOnce(response as unknown as Response)
+        .mockResolvedValueOnce(createRefreshSuccessResponse());
+
+      await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toMatchObject({
+        outcome: { kind: "failure", reason: "invalid_response", status: 200 },
+      });
+      await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toMatchObject({
+        disposition: "created",
+        outcome: { kind: "success" },
+      });
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    }
+  );
+
+  it("오류 응답의 malformed JSON은 errorCode 없는 http_error로 처리해야 함", async () => {
+    const refreshToken = uniqueRefreshToken("malformed-error");
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 502,
+        json: jest.fn().mockRejectedValue(new SyntaxError("invalid json")),
+      } as unknown as Response)
+      .mockResolvedValueOnce(createRefreshSuccessResponse());
+
+    await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toMatchObject({
+      outcome: {
+        kind: "failure",
+        reason: "http_error",
+        status: 502,
+        errorCode: null,
+      },
+    });
+    await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toMatchObject({
+      outcome: { kind: "success" },
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("network failure도 즉시 제거해 다음 hard 요청이 재시도할 수 있어야 함", async () => {
+    const refreshToken = uniqueRefreshToken("network-retry");
+    mockFetch
+      .mockRejectedValueOnce(new TypeError("network unavailable"))
+      .mockResolvedValueOnce(createRefreshSuccessResponse());
+
+    await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toMatchObject({
+      outcome: { kind: "failure", reason: "network_error", status: 500 },
+    });
+    await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toMatchObject({
+      disposition: "created",
+      outcome: { kind: "success" },
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("지문 계산 실패 시 hard는 안전하게 우회하고 soft는 miss 처리해야 함", async () => {
+    const digestSpy = jest
+      .spyOn(crypto.subtle, "digest")
+      .mockRejectedValueOnce(new Error("digest unavailable"))
+      .mockRejectedValueOnce(new Error("digest unavailable"));
+    mockFetch.mockResolvedValueOnce(createRefreshSuccessResponse());
+
+    await expect(
+      runHardRefreshSingleFlight(uniqueRefreshToken("digest-hard"), BACKEND_URL)
+    ).resolves.toMatchObject({ disposition: "bypass", outcome: { kind: "success" } });
+    await expect(joinSoftRefreshSingleFlight(uniqueRefreshToken("digest-soft"))).resolves.toEqual({
+      kind: "miss",
+    });
+
+    expect(digestSpy).toHaveBeenCalledTimes(2);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("Refresh Token 원문 bytes를 SHA-256 Web Crypto 경계에만 전달해야 함", async () => {
+    const refreshToken = uniqueRefreshToken("sha-256-boundary");
+    const originalDigest = crypto.subtle.digest.bind(crypto.subtle);
+    const digestSpy = jest
+      .spyOn(crypto.subtle, "digest")
+      .mockImplementation((algorithm, data) => originalDigest(algorithm, data));
+    mockFetch.mockResolvedValueOnce(createRefreshSuccessResponse());
+
+    await runHardRefreshSingleFlight(refreshToken, BACKEND_URL);
+
+    expect(digestSpy).toHaveBeenCalledWith("SHA-256", expect.any(Uint8Array));
+    const digestInput = digestSpy.mock.calls[0][1];
+    const inputBytes = ArrayBuffer.isView(digestInput)
+      ? new Uint8Array(digestInput.buffer, digestInput.byteOffset, digestInput.byteLength)
+      : new Uint8Array(digestInput);
+    expect(new TextDecoder().decode(inputBytes)).toBe(refreshToken);
+  });
+
+  it("private fingerprint와 Map을 production test API로 노출하지 않아야 함", () => {
+    expect(Object.keys(singleFlightModule).sort()).toEqual(
+      ["joinSoftRefreshSingleFlight", "runHardRefreshSingleFlight"].sort()
+    );
+    expect(singleFlightModule).not.toHaveProperty("createRefreshTokenFingerprint");
+    expect(singleFlightModule).not.toHaveProperty("refreshFlights");
+    expect(singleFlightModule).not.toHaveProperty("resetRefreshFlights");
+  });
+
+  it("격리된 cold module끼리 상태를 공유하지 않아도 hard는 안전하고 soft는 miss여야 함", async () => {
+    const refreshToken = uniqueRefreshToken("cold-module");
+    mockFetch.mockResolvedValue(createRefreshSuccessResponse());
+
+    await jest.isolateModulesAsync(async () => {
+      const coldModule = await import("@/lib/auth/refresh-token-single-flight");
+      await expect(
+        coldModule.runHardRefreshSingleFlight(refreshToken, BACKEND_URL)
+      ).resolves.toMatchObject({
+        disposition: "created",
+        outcome: { kind: "success" },
+      });
+    });
+    await jest.isolateModulesAsync(async () => {
+      const coldModule = await import("@/lib/auth/refresh-token-single-flight");
+      await expect(
+        coldModule.runHardRefreshSingleFlight(refreshToken, BACKEND_URL)
+      ).resolves.toMatchObject({
+        disposition: "created",
+        outcome: { kind: "success" },
+      });
+      await expect(coldModule.joinSoftRefreshSingleFlight("unseen-soft-token")).resolves.toEqual({
+        kind: "miss",
+      });
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/test/auth/refresh-token-single-flight.test.ts
+++ b/src/test/auth/refresh-token-single-flight.test.ts
@@ -50,23 +50,10 @@ async function flushMicrotasks() {
 
 const BACKEND_URL = "https://backend.example.com";
 let tokenSequence = 0;
-let digestSequence = 0;
 
 function uniqueRefreshToken(label: string) {
   tokenSequence += 1;
   return `${label}-${tokenSequence}`;
-}
-
-function createUniqueDigest() {
-  digestSequence += 1;
-  const digest = new ArrayBuffer(32);
-  new DataView(digest).setUint32(0, digestSequence);
-  return digest;
-}
-
-function mockSingleTokenDigest() {
-  const digest = createUniqueDigest();
-  return jest.spyOn(crypto.subtle, "digest").mockResolvedValue(digest);
 }
 
 describe("refresh-token-single-flight", () => {
@@ -85,11 +72,10 @@ describe("refresh-token-single-flight", () => {
     jest.restoreAllMocks();
   });
 
-  it("같은 Refresh Token의 동시 hard 요청은 백엔드를 한 번만 호출해야 함", async () => {
+  it("같은 Refresh Token의 동시 hard 요청은 백엔드를 한 번만 호출하고 동일한 결과를 공유해야 함", async () => {
     const refreshToken = uniqueRefreshToken("same-hard");
     const response = deferred<Response>();
     const fetchStarted = deferred<void>();
-    mockSingleTokenDigest();
     mockFetch.mockImplementation(() => {
       fetchStarted.resolve();
       return response.promise;
@@ -104,11 +90,12 @@ describe("refresh-token-single-flight", () => {
     const [firstResult, secondResult] = await Promise.all([first, second]);
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
-    expect([firstResult.disposition, secondResult.disposition].sort()).toEqual([
-      "created",
-      "joined",
-    ]);
-    expect(firstResult.outcome).toEqual(secondResult.outcome);
+    expect(firstResult).toEqual(secondResult);
+    expect(firstResult).toEqual({
+      kind: "success",
+      status: 200,
+      tokens: { accessToken: "new-access", refreshToken: "new-refresh" },
+    });
   });
 
   it("서로 다른 Refresh Token은 결과를 공유하지 않아야 함", async () => {
@@ -122,24 +109,20 @@ describe("refresh-token-single-flight", () => {
     ]);
 
     expect(mockFetch).toHaveBeenCalledTimes(2);
-    expect(first.outcome).not.toEqual(second.outcome);
+    expect(first).not.toEqual(second);
   });
 
-  it("soft miss는 새 Refresh 작업을 만들지 않아야 함", async () => {
+  it("soft miss는 새 작업을 만들지 않고 즉시 null을 반환해야 함", async () => {
     const result = await joinSoftRefreshSingleFlight(uniqueRefreshToken("soft-miss"));
 
-    expect(result).toEqual({ kind: "miss" });
+    expect(result).toBeNull();
     expect(mockFetch).not.toHaveBeenCalled();
-    expect(jest.getTimerCount()).toBe(0);
-    await jest.advanceTimersByTimeAsync(1500);
-    expect(jest.getTimerCount()).toBe(0);
   });
 
   it("soft 요청은 기존 hard 작업의 결과에 합류해야 함", async () => {
     const refreshToken = uniqueRefreshToken("hard-soft");
     const response = deferred<Response>();
     const fetchStarted = deferred<void>();
-    mockSingleTokenDigest();
     mockFetch.mockImplementation(() => {
       fetchStarted.resolve();
       return response.promise;
@@ -153,140 +136,11 @@ describe("refresh-token-single-flight", () => {
     response.resolve(createRefreshSuccessResponse("shared-access", "shared-refresh"));
     const [hardResult, softResult] = await Promise.all([hardResultPromise, softResultPromise]);
 
-    expect(hardResult.disposition).toBe("created");
-    expect(softResult).toEqual({
-      kind: "outcome",
-      disposition: "joined",
-      outcome: hardResult.outcome,
-    });
+    expect(softResult).toEqual(hardResult);
     expect(mockFetch).toHaveBeenCalledTimes(1);
-    expect(jest.getTimerCount()).toBe(1);
   });
 
-  it("soft 요청은 2초 이내 성공 결과를 reused로 받고 caller timer를 즉시 정리해야 함", async () => {
-    const refreshToken = uniqueRefreshToken("soft-reused");
-    mockFetch.mockResolvedValueOnce(createRefreshSuccessResponse());
-
-    const hardResult = await runHardRefreshSingleFlight(refreshToken, BACKEND_URL);
-    const softResult = await joinSoftRefreshSingleFlight(refreshToken);
-
-    expect(softResult).toEqual({
-      kind: "outcome",
-      disposition: "reused",
-      outcome: hardResult.outcome,
-    });
-    expect(jest.getTimerCount()).toBe(1);
-    await jest.advanceTimersByTimeAsync(1500);
-    expect(jest.getTimerCount()).toBe(1);
-  });
-
-  it("soft 지문 계산이 1,499ms에 끝나면 남은 예산 안에서 기존 성공 결과를 재사용해야 함", async () => {
-    const refreshToken = uniqueRefreshToken("soft-delayed-reuse");
-    const fingerprint = createUniqueDigest();
-    const delayedDigest = deferred<ArrayBuffer>();
-    jest
-      .spyOn(crypto.subtle, "digest")
-      .mockResolvedValueOnce(fingerprint)
-      .mockReturnValueOnce(delayedDigest.promise);
-    mockFetch.mockResolvedValueOnce(createRefreshSuccessResponse());
-
-    const hardResult = await runHardRefreshSingleFlight(refreshToken, BACKEND_URL);
-    const softResultPromise = joinSoftRefreshSingleFlight(refreshToken);
-    await jest.advanceTimersByTimeAsync(1499);
-    delayedDigest.resolve(fingerprint);
-
-    await expect(softResultPromise).resolves.toEqual({
-      kind: "outcome",
-      disposition: "reused",
-      outcome: hardResult.outcome,
-    });
-    expect(jest.getTimerCount()).toBe(1);
-  });
-
-  it("soft shared wait는 지문 계산 뒤 남은 총 예산만 사용해야 함", async () => {
-    const refreshToken = uniqueRefreshToken("soft-remaining-budget");
-    const fingerprint = createUniqueDigest();
-    const delayedDigest = deferred<ArrayBuffer>();
-    const backendResponse = deferred<Response>();
-    const fetchStarted = deferred<void>();
-    jest
-      .spyOn(crypto.subtle, "digest")
-      .mockResolvedValueOnce(fingerprint)
-      .mockReturnValueOnce(delayedDigest.promise);
-    mockFetch.mockImplementation(() => {
-      fetchStarted.resolve();
-      return backendResponse.promise;
-    });
-
-    const hardResultPromise = runHardRefreshSingleFlight(refreshToken, BACKEND_URL);
-    await fetchStarted.promise;
-    const softResultPromise = joinSoftRefreshSingleFlight(refreshToken);
-    let settled = false;
-    void softResultPromise.then(() => {
-      settled = true;
-    });
-
-    await jest.advanceTimersByTimeAsync(1000);
-    delayedDigest.resolve(fingerprint);
-    await flushMicrotasks();
-    await jest.advanceTimersByTimeAsync(499);
-    expect(settled).toBe(false);
-
-    await jest.advanceTimersByTimeAsync(1);
-    await expect(softResultPromise).resolves.toEqual({ kind: "caller_timeout" });
-
-    backendResponse.resolve(createRefreshSuccessResponse());
-    await expect(hardResultPromise).resolves.toMatchObject({
-      outcome: { kind: "success" },
-    });
-  });
-
-  it("shared outcome이 정확히 1,500ms에 끝나면 최종 반환 전 caller_timeout으로 고정해야 함", async () => {
-    const refreshToken = uniqueRefreshToken("soft-exact-outcome-deadline");
-    const backendResponse = deferred<Response>();
-    const fetchStarted = deferred<void>();
-    mockSingleTokenDigest();
-    mockFetch.mockImplementation(() => {
-      fetchStarted.resolve();
-      return backendResponse.promise;
-    });
-
-    const hardResultPromise = runHardRefreshSingleFlight(refreshToken, BACKEND_URL);
-    await fetchStarted.promise;
-    const softResultPromise = joinSoftRefreshSingleFlight(refreshToken);
-    await flushMicrotasks();
-
-    jest.setSystemTime(new Date("2026-08-14T00:00:01.500Z"));
-    backendResponse.resolve(createRefreshSuccessResponse());
-
-    await expect(softResultPromise).resolves.toEqual({ kind: "caller_timeout" });
-    await expect(hardResultPromise).resolves.toMatchObject({
-      outcome: { kind: "success" },
-    });
-  });
-
-  it("soft 총 대기시간은 API 진입부터 1,500ms이고 늦은 지문 계산은 작업을 만들지 않아야 함", async () => {
-    const digest = deferred<ArrayBuffer>();
-    jest.spyOn(crypto.subtle, "digest").mockReturnValueOnce(digest.promise);
-
-    const resultPromise = joinSoftRefreshSingleFlight(uniqueRefreshToken("slow-digest"));
-    let settled = false;
-    void resultPromise.then(() => {
-      settled = true;
-    });
-
-    await jest.advanceTimersByTimeAsync(1499);
-    expect(settled).toBe(false);
-
-    await jest.advanceTimersByTimeAsync(1);
-    await expect(resultPromise).resolves.toEqual({ kind: "caller_timeout" });
-
-    digest.resolve(new ArrayBuffer(32));
-    await flushMicrotasks();
-    expect(mockFetch).not.toHaveBeenCalled();
-  });
-
-  it("soft timeout은 공유 hard 작업을 취소하지 않아야 함", async () => {
+  it("soft timeout은 null을 반환하고 공유 hard 작업을 취소하지 않아야 함", async () => {
     const refreshToken = uniqueRefreshToken("soft-timeout");
     const response = deferred<Response>();
     const fetchStarted = deferred<void>();
@@ -302,61 +156,86 @@ describe("refresh-token-single-flight", () => {
     const softResultPromise = joinSoftRefreshSingleFlight(refreshToken);
 
     await jest.advanceTimersByTimeAsync(1500);
-    await expect(softResultPromise).resolves.toEqual({ kind: "caller_timeout" });
+    await expect(softResultPromise).resolves.toBeNull();
     expect(sharedSignal?.aborted).toBe(false);
 
     response.resolve(createRefreshSuccessResponse());
-    await expect(hardResultPromise).resolves.toMatchObject({
-      disposition: "created",
-      outcome: { kind: "success" },
+    await expect(hardResultPromise).resolves.toEqual({
+      kind: "success",
+      status: 200,
+      tokens: { accessToken: "new-access", refreshToken: "new-refresh" },
     });
+  });
+
+  it("성공 결과는 timer 전까지 재사용되고 timer 이후에는 새 갱신을 시작해야 함", async () => {
+    const refreshToken = uniqueRefreshToken("success-reuse");
+    mockFetch
+      .mockResolvedValueOnce(createRefreshSuccessResponse("access-1", "refresh-1"))
+      .mockResolvedValueOnce(createRefreshSuccessResponse("access-2", "refresh-2"));
+
+    const created = await runHardRefreshSingleFlight(refreshToken, BACKEND_URL);
+    const reused = await runHardRefreshSingleFlight(refreshToken, BACKEND_URL);
+    const softReused = await joinSoftRefreshSingleFlight(refreshToken);
+
+    expect(reused).toEqual(created);
+    expect(softReused).toEqual(created);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    await jest.runOnlyPendingTimersAsync();
+    const renewed = await runHardRefreshSingleFlight(refreshToken, BACKEND_URL);
+    expect(renewed).toEqual({
+      kind: "success",
+      status: 200,
+      tokens: { accessToken: "access-2", refreshToken: "refresh-2" },
+    });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 
   it.each([
     ["success", true, 200],
     ["error", false, 503],
-  ])("hard %s body가 멈추면 전체 교환을 10초에 종료해야 함", async (_label, ok, status) => {
-    const fetchStarted = deferred<void>();
-    mockFetch
-      .mockImplementationOnce((_url, init) => {
-        const signal = init?.signal;
-        fetchStarted.resolve();
-        return Promise.resolve({
-          ok,
-          status,
-          json: jest.fn().mockImplementation(
-            () =>
-              new Promise((_resolve, reject) => {
-                signal?.addEventListener("abort", () => {
-                  reject(new DOMException("Aborted", "AbortError"));
-                });
-              })
-          ),
-        } as unknown as Response);
-      })
-      .mockResolvedValueOnce(createRefreshSuccessResponse());
+  ])(
+    "hard %s body가 멈추면 전체 교환을 10초에 종료하고 재시도할 수 있어야 함",
+    async (_label, ok, status) => {
+      const fetchStarted = deferred<void>();
+      mockFetch
+        .mockImplementationOnce((_url, init) => {
+          const signal = init?.signal;
+          fetchStarted.resolve();
+          return Promise.resolve({
+            ok,
+            status,
+            json: jest.fn().mockImplementation(
+              () =>
+                new Promise((_resolve, reject) => {
+                  signal?.addEventListener("abort", () => {
+                    reject(new DOMException("Aborted", "AbortError"));
+                  });
+                })
+            ),
+          } as unknown as Response);
+        })
+        .mockResolvedValueOnce(createRefreshSuccessResponse());
 
-    const refreshToken = uniqueRefreshToken(`body-${_label}`);
-    const resultPromise = runHardRefreshSingleFlight(refreshToken, BACKEND_URL);
-    await fetchStarted.promise;
-    let settled = false;
-    void resultPromise.then(() => {
-      settled = true;
-    });
+      const refreshToken = uniqueRefreshToken(`body-${_label}`);
+      const resultPromise = runHardRefreshSingleFlight(refreshToken, BACKEND_URL);
+      await fetchStarted.promise;
 
-    await jest.advanceTimersByTimeAsync(9999);
-    expect(settled).toBe(false);
-
-    await jest.advanceTimersByTimeAsync(1);
-    await expect(resultPromise).resolves.toMatchObject({
-      outcome: { kind: "failure", reason: "timeout", status: 504 },
-    });
-    await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toMatchObject({
-      disposition: "created",
-      outcome: { kind: "success" },
-    });
-    expect(mockFetch).toHaveBeenCalledTimes(2);
-  });
+      await jest.advanceTimersByTimeAsync(10000);
+      await expect(resultPromise).resolves.toEqual({
+        kind: "failure",
+        reason: "timeout",
+        status: 504,
+        errorCode: null,
+      });
+      await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toEqual({
+        kind: "success",
+        status: 200,
+        tokens: { accessToken: "new-access", refreshToken: "new-refresh" },
+      });
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    }
+  );
 
   it("hard response headers가 오지 않아도 10초에 timeout되고 다음 요청이 재시도해야 함", async () => {
     const refreshToken = uniqueRefreshToken("headers-timeout");
@@ -374,99 +253,38 @@ describe("refresh-token-single-flight", () => {
 
     const resultPromise = runHardRefreshSingleFlight(refreshToken, BACKEND_URL);
     await fetchStarted.promise;
-    await jest.advanceTimersByTimeAsync(9999);
-    let settled = false;
-    void resultPromise.then(() => {
-      settled = true;
-    });
-    await flushMicrotasks();
-    expect(settled).toBe(false);
+    await jest.advanceTimersByTimeAsync(10000);
 
-    await jest.advanceTimersByTimeAsync(1);
-    await expect(resultPromise).resolves.toMatchObject({
-      outcome: { kind: "failure", reason: "timeout", status: 504 },
+    await expect(resultPromise).resolves.toEqual({
+      kind: "failure",
+      reason: "timeout",
+      status: 504,
+      errorCode: null,
     });
-    await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toMatchObject({
-      disposition: "created",
-      outcome: { kind: "success" },
+    await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toEqual({
+      kind: "success",
+      status: 200,
+      tokens: { accessToken: "new-access", refreshToken: "new-refresh" },
     });
     expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 
-  it("성공 결과는 2초 미만에 재사용하고 2초부터 새 교환을 허용해야 함", async () => {
-    const refreshToken = uniqueRefreshToken("success-reuse");
-    mockFetch
-      .mockResolvedValueOnce(createRefreshSuccessResponse("access-1", "refresh-1"))
-      .mockResolvedValueOnce(createRefreshSuccessResponse("access-2", "refresh-2"));
-
-    const created = await runHardRefreshSingleFlight(refreshToken, BACKEND_URL);
-    const immediate = await runHardRefreshSingleFlight(refreshToken, BACKEND_URL);
-    expect(created.disposition).toBe("created");
-    expect(immediate.disposition).toBe("reused");
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-
-    await jest.advanceTimersByTimeAsync(1999);
-    await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toMatchObject({
-      disposition: "reused",
-    });
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-
-    await jest.advanceTimersByTimeAsync(1);
-    await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toMatchObject({
-      disposition: "created",
-      outcome: {
-        kind: "success",
-        tokens: { accessToken: "access-2", refreshToken: "refresh-2" },
-      },
-    });
-    expect(mockFetch).toHaveBeenCalledTimes(2);
-  });
-
-  it("stale sweep로 만료 결과를 교체하고 늦은 이전 timer가 새 entry를 지우지 않아야 함", async () => {
-    const refreshToken = uniqueRefreshToken("stale-identity");
-    const setTimeoutSpy = jest.spyOn(globalThis, "setTimeout");
-    mockFetch
-      .mockResolvedValueOnce(createRefreshSuccessResponse("access-old", "refresh-old"))
-      .mockResolvedValueOnce(createRefreshSuccessResponse("access-new", "refresh-new"));
-
-    await runHardRefreshSingleFlight(refreshToken, BACKEND_URL);
-    const oldCleanup = setTimeoutSpy.mock.calls.find(([, delay]) => delay === 2000)?.[0] as
-      | (() => void)
-      | undefined;
-    expect(oldCleanup).toBeDefined();
-
-    jest.setSystemTime(new Date("2026-08-14T00:00:02.000Z"));
-    await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toMatchObject({
-      disposition: "created",
-      outcome: {
-        kind: "success",
-        tokens: { accessToken: "access-new", refreshToken: "refresh-new" },
-      },
-    });
-
-    oldCleanup?.();
-    await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toMatchObject({
-      disposition: "reused",
-      outcome: {
-        kind: "success",
-        tokens: { accessToken: "access-new", refreshToken: "refresh-new" },
-      },
-    });
-    expect(mockFetch).toHaveBeenCalledTimes(2);
-  });
-
-  it("실패 결과는 즉시 제거해 다음 hard 요청이 재시도할 수 있어야 함", async () => {
+  it("HTTP 실패 결과는 즉시 제거되어 다음 hard 요청이 재시도해야 함", async () => {
     const refreshToken = uniqueRefreshToken("failure-retry");
     mockFetch
       .mockResolvedValueOnce(createRefreshFailureResponse())
       .mockResolvedValueOnce(createRefreshSuccessResponse());
 
-    await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toMatchObject({
-      outcome: { kind: "failure", reason: "http_error", errorCode: "AUTH401_7" },
+    await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toEqual({
+      kind: "failure",
+      reason: "http_error",
+      status: 401,
+      errorCode: "AUTH401_7",
     });
-    await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toMatchObject({
-      disposition: "created",
-      outcome: { kind: "success" },
+    await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toEqual({
+      kind: "success",
+      status: 200,
+      tokens: { accessToken: "new-access", refreshToken: "new-refresh" },
     });
     expect(mockFetch).toHaveBeenCalledTimes(2);
   });
@@ -498,18 +316,22 @@ describe("refresh-token-single-flight", () => {
         .mockResolvedValueOnce(response as unknown as Response)
         .mockResolvedValueOnce(createRefreshSuccessResponse());
 
-      await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toMatchObject({
-        outcome: { kind: "failure", reason: "invalid_response", status: 200 },
+      await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toEqual({
+        kind: "failure",
+        reason: "invalid_response",
+        status: 200,
+        errorCode: null,
       });
-      await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toMatchObject({
-        disposition: "created",
-        outcome: { kind: "success" },
+      await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toEqual({
+        kind: "success",
+        status: 200,
+        tokens: { accessToken: "new-access", refreshToken: "new-refresh" },
       });
       expect(mockFetch).toHaveBeenCalledTimes(2);
     }
   );
 
-  it("오류 응답의 malformed JSON은 errorCode 없는 http_error로 처리해야 함", async () => {
+  it("오류 응답의 malformed JSON은 errorCode 없는 http_error로 처리하고 즉시 재시도해야 함", async () => {
     const refreshToken = uniqueRefreshToken("malformed-error");
     mockFetch
       .mockResolvedValueOnce({
@@ -519,16 +341,16 @@ describe("refresh-token-single-flight", () => {
       } as unknown as Response)
       .mockResolvedValueOnce(createRefreshSuccessResponse());
 
-    await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toMatchObject({
-      outcome: {
-        kind: "failure",
-        reason: "http_error",
-        status: 502,
-        errorCode: null,
-      },
+    await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toEqual({
+      kind: "failure",
+      reason: "http_error",
+      status: 502,
+      errorCode: null,
     });
-    await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toMatchObject({
-      outcome: { kind: "success" },
+    await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toEqual({
+      kind: "success",
+      status: 200,
+      tokens: { accessToken: "new-access", refreshToken: "new-refresh" },
     });
     expect(mockFetch).toHaveBeenCalledTimes(2);
   });
@@ -539,59 +361,25 @@ describe("refresh-token-single-flight", () => {
       .mockRejectedValueOnce(new TypeError("network unavailable"))
       .mockResolvedValueOnce(createRefreshSuccessResponse());
 
-    await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toMatchObject({
-      outcome: { kind: "failure", reason: "network_error", status: 500 },
+    await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toEqual({
+      kind: "failure",
+      reason: "network_error",
+      status: 500,
+      errorCode: null,
     });
-    await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toMatchObject({
-      disposition: "created",
-      outcome: { kind: "success" },
+    await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toEqual({
+      kind: "success",
+      status: 200,
+      tokens: { accessToken: "new-access", refreshToken: "new-refresh" },
     });
     expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 
-  it("지문 계산 실패 시 hard는 안전하게 우회하고 soft는 miss 처리해야 함", async () => {
-    const digestSpy = jest
-      .spyOn(crypto.subtle, "digest")
-      .mockRejectedValueOnce(new Error("digest unavailable"))
-      .mockRejectedValueOnce(new Error("digest unavailable"));
-    mockFetch.mockResolvedValueOnce(createRefreshSuccessResponse());
-
-    await expect(
-      runHardRefreshSingleFlight(uniqueRefreshToken("digest-hard"), BACKEND_URL)
-    ).resolves.toMatchObject({ disposition: "bypass", outcome: { kind: "success" } });
-    await expect(joinSoftRefreshSingleFlight(uniqueRefreshToken("digest-soft"))).resolves.toEqual({
-      kind: "miss",
-    });
-
-    expect(digestSpy).toHaveBeenCalledTimes(2);
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-  });
-
-  it("Refresh Token 원문 bytes를 SHA-256 Web Crypto 경계에만 전달해야 함", async () => {
-    const refreshToken = uniqueRefreshToken("sha-256-boundary");
-    const originalDigest = crypto.subtle.digest.bind(crypto.subtle);
-    const digestSpy = jest
-      .spyOn(crypto.subtle, "digest")
-      .mockImplementation((algorithm, data) => originalDigest(algorithm, data));
-    mockFetch.mockResolvedValueOnce(createRefreshSuccessResponse());
-
-    await runHardRefreshSingleFlight(refreshToken, BACKEND_URL);
-
-    expect(digestSpy).toHaveBeenCalledWith("SHA-256", expect.any(Uint8Array));
-    const digestInput = digestSpy.mock.calls[0][1];
-    const inputBytes = ArrayBuffer.isView(digestInput)
-      ? new Uint8Array(digestInput.buffer, digestInput.byteOffset, digestInput.byteLength)
-      : new Uint8Array(digestInput);
-    expect(new TextDecoder().decode(inputBytes)).toBe(refreshToken);
-  });
-
-  it("private fingerprint와 Map을 production test API로 노출하지 않아야 함", () => {
+  it("private Map과 내부 상태를 모듈 외부로 노출하지 않아야 함", () => {
     expect(Object.keys(singleFlightModule).sort()).toEqual(
       ["joinSoftRefreshSingleFlight", "runHardRefreshSingleFlight"].sort()
     );
-    expect(singleFlightModule).not.toHaveProperty("createRefreshTokenFingerprint");
     expect(singleFlightModule).not.toHaveProperty("refreshFlights");
-    expect(singleFlightModule).not.toHaveProperty("resetRefreshFlights");
   });
 
   it("격리된 cold module끼리 상태를 공유하지 않아도 hard는 안전하고 soft는 miss여야 함", async () => {
@@ -602,22 +390,22 @@ describe("refresh-token-single-flight", () => {
       const coldModule = await import("@/lib/auth/refresh-token-single-flight");
       await expect(
         coldModule.runHardRefreshSingleFlight(refreshToken, BACKEND_URL)
-      ).resolves.toMatchObject({
-        disposition: "created",
-        outcome: { kind: "success" },
+      ).resolves.toEqual({
+        kind: "success",
+        status: 200,
+        tokens: { accessToken: "new-access", refreshToken: "new-refresh" },
       });
     });
     await jest.isolateModulesAsync(async () => {
       const coldModule = await import("@/lib/auth/refresh-token-single-flight");
       await expect(
         coldModule.runHardRefreshSingleFlight(refreshToken, BACKEND_URL)
-      ).resolves.toMatchObject({
-        disposition: "created",
-        outcome: { kind: "success" },
+      ).resolves.toEqual({
+        kind: "success",
+        status: 200,
+        tokens: { accessToken: "new-access", refreshToken: "new-refresh" },
       });
-      await expect(coldModule.joinSoftRefreshSingleFlight("unseen-soft-token")).resolves.toEqual({
-        kind: "miss",
-      });
+      await expect(coldModule.joinSoftRefreshSingleFlight("unseen-soft-token")).resolves.toBeNull();
     });
 
     expect(mockFetch).toHaveBeenCalledTimes(2);

--- a/src/test/auth/refresh-token-single-flight.test.ts
+++ b/src/test/auth/refresh-token-single-flight.test.ts
@@ -57,9 +57,15 @@ function uniqueRefreshToken(label: string) {
   return `${label}-${tokenSequence}`;
 }
 
-function mockSingleTokenDigest() {
+function createUniqueDigest() {
   digestSequence += 1;
-  const digest = new Uint8Array(32).fill(digestSequence).buffer;
+  const digest = new ArrayBuffer(32);
+  new DataView(digest).setUint32(0, digestSequence);
+  return digest;
+}
+
+function mockSingleTokenDigest() {
+  const digest = createUniqueDigest();
   return jest.spyOn(crypto.subtle, "digest").mockResolvedValue(digest);
 }
 
@@ -176,8 +182,7 @@ describe("refresh-token-single-flight", () => {
 
   it("soft 지문 계산이 1,499ms에 끝나면 남은 예산 안에서 기존 성공 결과를 재사용해야 함", async () => {
     const refreshToken = uniqueRefreshToken("soft-delayed-reuse");
-    digestSequence += 1;
-    const fingerprint = new Uint8Array(32).fill(digestSequence).buffer;
+    const fingerprint = createUniqueDigest();
     const delayedDigest = deferred<ArrayBuffer>();
     jest
       .spyOn(crypto.subtle, "digest")
@@ -200,8 +205,7 @@ describe("refresh-token-single-flight", () => {
 
   it("soft shared wait는 지문 계산 뒤 남은 총 예산만 사용해야 함", async () => {
     const refreshToken = uniqueRefreshToken("soft-remaining-budget");
-    digestSequence += 1;
-    const fingerprint = new Uint8Array(32).fill(digestSequence).buffer;
+    const fingerprint = createUniqueDigest();
     const delayedDigest = deferred<ArrayBuffer>();
     const backendResponse = deferred<Response>();
     const fetchStarted = deferred<void>();

--- a/src/test/auth/refresh-token-single-flight.test.ts
+++ b/src/test/auth/refresh-token-single-flight.test.ts
@@ -240,8 +240,10 @@ describe("refresh-token-single-flight", () => {
   it("hard response headers가 오지 않아도 10초에 timeout되고 다음 요청이 재시도해야 함", async () => {
     const refreshToken = uniqueRefreshToken("headers-timeout");
     const fetchStarted = deferred<void>();
+    let requestSignal: AbortSignal | undefined;
     mockFetch
       .mockImplementationOnce((_url, init) => {
+        requestSignal = init?.signal;
         fetchStarted.resolve();
         return new Promise((_resolve, reject) => {
           init?.signal?.addEventListener("abort", () => {
@@ -255,6 +257,7 @@ describe("refresh-token-single-flight", () => {
     await fetchStarted.promise;
     await jest.advanceTimersByTimeAsync(10000);
 
+    expect(requestSignal?.aborted).toBe(true);
     await expect(resultPromise).resolves.toEqual({
       kind: "failure",
       reason: "timeout",
@@ -294,9 +297,10 @@ describe("refresh-token-single-flight", () => {
       "malformed JSON",
       {
         ok: true,
-        status: 200,
+        status: 201,
         json: jest.fn().mockRejectedValue(new SyntaxError("invalid json")),
       },
+      201,
     ],
     [
       "invalid shape",
@@ -307,10 +311,11 @@ describe("refresh-token-single-flight", () => {
           result: { accessToken: "access", refreshToken: null },
         }),
       },
+      200,
     ],
   ])(
     "성공 응답의 %s는 invalid_response이고 즉시 재시도할 수 있어야 함",
-    async (_label, response) => {
+    async (_label, response, status) => {
       const refreshToken = uniqueRefreshToken(`invalid-${_label}`);
       mockFetch
         .mockResolvedValueOnce(response as unknown as Response)
@@ -319,7 +324,7 @@ describe("refresh-token-single-flight", () => {
       await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toEqual({
         kind: "failure",
         reason: "invalid_response",
-        status: 200,
+        status,
         errorCode: null,
       });
       await expect(runHardRefreshSingleFlight(refreshToken, BACKEND_URL)).resolves.toEqual({

--- a/src/test/proxy.test.ts
+++ b/src/test/proxy.test.ts
@@ -197,7 +197,9 @@ describe("Proxy Middleware", () => {
       disposition: RefreshDisposition;
     }>
   ) {
-    const matchingCall = consoleErrorSpy.mock.calls.find(([message, context]) => {
+    const logCalls =
+      details.mode === "soft" ? consoleWarnSpy.mock.calls : consoleErrorSpy.mock.calls;
+    const matchingCall = logCalls.find(([message, context]) => {
       if (message !== "Proxy: Token refresh failed") {
         return false;
       }
@@ -806,6 +808,10 @@ describe("Proxy Middleware", () => {
     });
 
     it("지문 계산 실패 경고는 정적 필드만 사용해 warm module당 한 번만 남겨야 함", async () => {
+      let isolatedProxy!: typeof proxy;
+      await jest.isolateModulesAsync(async () => {
+        ({ proxy: isolatedProxy } = await import("@/proxy"));
+      });
       const createRequest = () =>
         new NextRequest(`http://localhost:3000${PRIMARY_PROTECTED_PAGE_PATH}`, {
           headers: {
@@ -817,8 +823,8 @@ describe("Proxy Middleware", () => {
         .mockResolvedValueOnce(createRefreshSuccessResponse())
         .mockResolvedValueOnce(createRefreshSuccessResponse());
 
-      await proxy(createRequest());
-      await proxy(createRequest());
+      await isolatedProxy(createRequest());
+      await isolatedProxy(createRequest());
 
       const bypassCalls = consoleWarnSpy.mock.calls.filter(
         ([message]) => message === "Proxy: Token refresh fingerprint bypass"

--- a/src/test/proxy.test.ts
+++ b/src/test/proxy.test.ts
@@ -49,7 +49,6 @@ describe("Proxy Middleware", () => {
   type RefreshFailureReason = "http_error" | "invalid_response" | "timeout" | "network_error";
   type RouteType = "public" | "protected" | "api";
   type RefreshMode = "soft" | "hard";
-  type RefreshDisposition = "created" | "joined" | "reused" | "bypass";
 
   function createRefreshSuccessResponse(
     accessToken: string = "new_access",
@@ -194,7 +193,6 @@ describe("Proxy Middleware", () => {
       status: number;
       cookieClear: boolean;
       mode: RefreshMode;
-      disposition: RefreshDisposition;
     }>
   ) {
     const logCalls =
@@ -210,7 +208,7 @@ describe("Proxy Middleware", () => {
     expect(matchingCall).toBeDefined();
     expect(matchingCall).toHaveLength(2);
     expect(Object.keys(matchingCall?.[1] as Record<string, unknown>).sort()).toEqual(
-      ["cookieClear", "disposition", "mode", "reason", "routeType", "status"].sort()
+      ["cookieClear", "mode", "reason", "routeType", "status"].sort()
     );
   }
 
@@ -571,7 +569,6 @@ describe("Proxy Middleware", () => {
       const refreshToken = createMockToken(30 * 24 * 60 * 60);
       const backendResponse = deferred<ReturnType<typeof createRefreshSuccessResponse>>();
       const fetchStarted = deferred<void>();
-      jest.spyOn(crypto.subtle, "digest").mockResolvedValue(new Uint8Array(32).fill(249).buffer);
       mockFetch.mockImplementation(() => {
         fetchStarted.resolve();
         return backendResponse.promise;
@@ -801,38 +798,12 @@ describe("Proxy Middleware", () => {
             status: 200,
             routeType: "protected",
             mode: "hard",
-            disposition: "created",
           },
         ],
       ]);
     });
 
-    it("지문 계산 실패 경고는 정적 필드만 사용해 warm module당 한 번만 남겨야 함", async () => {
-      let isolatedProxy!: typeof proxy;
-      await jest.isolateModulesAsync(async () => {
-        ({ proxy: isolatedProxy } = await import("@/proxy"));
-      });
-      const createRequest = () =>
-        new NextRequest(`http://localhost:3000${PRIMARY_PROTECTED_PAGE_PATH}`, {
-          headers: {
-            cookie: `refreshToken=${createMockToken(30 * 24 * 60 * 60)}`,
-          },
-        });
-      jest.spyOn(crypto.subtle, "digest").mockRejectedValue(new Error("digest unavailable"));
-      mockFetch
-        .mockResolvedValueOnce(createRefreshSuccessResponse())
-        .mockResolvedValueOnce(createRefreshSuccessResponse());
-
-      await isolatedProxy(createRequest());
-      await isolatedProxy(createRequest());
-
-      const bypassCalls = consoleWarnSpy.mock.calls.filter(
-        ([message]) => message === "Proxy: Token refresh fingerprint bypass"
-      );
-      expect(bypassCalls).toEqual([["Proxy: Token refresh fingerprint bypass", { mode: "hard" }]]);
-    });
-
-    it("성공한 hard 갱신 결과는 2초 미만에 재사용하고 2초부터 새로 호출해야 함", async () => {
+    it("성공한 hard 갱신 결과는 timer 전까지 재사용하고 timer 이후 새로 호출해야 함", async () => {
       jest.useFakeTimers();
       const refreshToken = createMockToken(30 * 24 * 60 * 60);
       const createRequest = () =>
@@ -844,14 +815,13 @@ describe("Proxy Middleware", () => {
         .mockResolvedValueOnce(createRefreshSuccessResponse("access-2", "refresh-2"));
 
       const firstResponse = await proxy(createRequest());
-      await jest.advanceTimersByTimeAsync(1999);
       const reusedResponse = await proxy(createRequest());
 
       expect(mockFetch).toHaveBeenCalledTimes(1);
       expect(firstResponse).not.toBe(reusedResponse);
       expect(hasSetCookie(reusedResponse, (cookie) => cookie.includes("access-1"))).toBe(true);
 
-      await jest.advanceTimersByTimeAsync(1);
+      await jest.runOnlyPendingTimersAsync();
       const refreshedResponse = await proxy(createRequest());
       expect(mockFetch).toHaveBeenCalledTimes(2);
       expect(hasSetCookie(refreshedResponse, (cookie) => cookie.includes("access-2"))).toBe(true);
@@ -1336,7 +1306,6 @@ describe("Proxy Middleware", () => {
       });
       const backendResponse = deferred<ReturnType<typeof createRefreshMismatchResponse>>();
       const fetchStarted = deferred<void>();
-      jest.spyOn(crypto.subtle, "digest").mockResolvedValue(new Uint8Array(32).fill(250).buffer);
       mockFetch.mockImplementation(() => {
         fetchStarted.resolve();
         return backendResponse.promise;
@@ -1365,7 +1334,6 @@ describe("Proxy Middleware", () => {
       const refreshToken = createMockToken(30 * 24 * 60 * 60);
       const backendResponse = deferred<ReturnType<typeof createRefreshMismatchResponse>>();
       const fetchStarted = deferred<void>();
-      jest.spyOn(crypto.subtle, "digest").mockResolvedValue(new Uint8Array(32).fill(248).buffer);
       mockFetch.mockImplementation(() => {
         fetchStarted.resolve();
         return backendResponse.promise;
@@ -1405,7 +1373,6 @@ describe("Proxy Middleware", () => {
         status: 401,
         cookieClear: false,
         mode: "soft",
-        disposition: "joined",
       });
     });
 

--- a/src/test/proxy.test.ts
+++ b/src/test/proxy.test.ts
@@ -4,6 +4,7 @@
 
 import { NextRequest } from "next/server";
 
+import { getCookieValue } from "@/lib/auth/cookie-header-utils";
 import { proxy } from "@/proxy";
 
 // Global fetch mock
@@ -29,11 +30,26 @@ const PROTECTED_PAGE_ACCESS_PATHS = [
   "/session/1/result",
 ];
 const originalMockMode = process.env.NEXT_PUBLIC_USE_MOCK;
+let tokenSequence = 0;
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, resolve, reject };
+}
 
 describe("Proxy Middleware", () => {
   let consoleErrorSpy: jest.SpyInstance;
+  let consoleWarnSpy: jest.SpyInstance;
   type RefreshFailureReason = "http_error" | "invalid_response" | "timeout" | "network_error";
   type RouteType = "public" | "protected" | "api";
+  type RefreshMode = "soft" | "hard";
+  type RefreshDisposition = "created" | "joined" | "reused" | "bypass";
 
   function createRefreshSuccessResponse(
     accessToken: string = "new_access",
@@ -67,6 +83,7 @@ describe("Proxy Middleware", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
     // 환경 변수 설정
     process.env.BACKEND_API_BASE = "http://localhost:8080";
     process.env.NEXT_PUBLIC_USE_MOCK = "false";
@@ -74,6 +91,9 @@ describe("Proxy Middleware", () => {
 
   afterEach(() => {
     consoleErrorSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+    jest.restoreAllMocks();
+    jest.useRealTimers();
     // 환경 변수 정리
     delete process.env.BACKEND_API_BASE;
     if (originalMockMode === undefined) {
@@ -89,9 +109,11 @@ describe("Proxy Middleware", () => {
    */
   function createMockToken(expiresInSeconds: number): string {
     const now = Math.floor(Date.now() / 1000);
+    tokenSequence += 1;
     const payload = {
       exp: now + expiresInSeconds,
       userId: "test-user-123",
+      jti: `proxy-test-${tokenSequence}`,
     };
 
     // Base64 인코딩 (실제 서명은 불필요, 디코딩만 테스트)
@@ -108,10 +130,12 @@ describe("Proxy Middleware", () => {
 
   function createBase64UrlMockToken(expiresInSeconds: number): string {
     const now = Math.floor(Date.now() / 1000);
+    tokenSequence += 1;
     const payload = {
       exp: now + expiresInSeconds,
       // `?`는 base64 결과에 `/`가 포함될 확률을 높여 base64url 변환 케이스를 강제한다.
       userId: "???",
+      jti: `proxy-base64url-test-${tokenSequence}`,
     };
 
     const header = toBase64Url(btoa(JSON.stringify({ alg: "HS256", typ: "JWT" })));
@@ -169,10 +193,22 @@ describe("Proxy Middleware", () => {
       routeType: RouteType;
       status: number;
       cookieClear: boolean;
+      mode: RefreshMode;
+      disposition: RefreshDisposition;
     }>
   ) {
-    expect(consoleErrorSpy.mock.calls).toEqual(
-      expect.arrayContaining([["Proxy: Token refresh failed", expect.objectContaining(details)]])
+    const matchingCall = consoleErrorSpy.mock.calls.find(([message, context]) => {
+      if (message !== "Proxy: Token refresh failed") {
+        return false;
+      }
+
+      const logContext = context as Record<string, unknown>;
+      return Object.entries(details).every(([key, value]) => logContext[key] === value);
+    });
+    expect(matchingCall).toBeDefined();
+    expect(matchingCall).toHaveLength(2);
+    expect(Object.keys(matchingCall?.[1] as Record<string, unknown>).sort()).toEqual(
+      ["cookieClear", "disposition", "mode", "reason", "routeType", "status"].sort()
     );
   }
 
@@ -213,7 +249,7 @@ describe("Proxy Middleware", () => {
       expect(mockFetch).not.toHaveBeenCalled();
     });
 
-    it("공개 라우트에서 accessToken이 없고 refreshToken이 있으면 재발급을 시도해야 함", async () => {
+    it("공개 라우트에서 accessToken 없이 refreshToken만 있으면 새 갱신을 시작하지 않아야 함", async () => {
       const refreshToken = createMockToken(30 * 24 * 60 * 60);
       const request = new NextRequest("http://localhost:3000/", {
         headers: {
@@ -221,123 +257,51 @@ describe("Proxy Middleware", () => {
         },
       });
 
-      mockFetch.mockResolvedValueOnce(createRefreshSuccessResponse("new_access", "new_refresh"));
-
       const response = await proxy(request);
 
       expect(response.status).toBe(200);
       expect(response.headers.get("location")).toBeNull();
-      expect(mockFetch).toHaveBeenCalledWith(
-        "http://localhost:8080/auth/refresh",
-        expect.objectContaining({
-          method: "POST",
-          headers: expect.objectContaining({
-            Cookie: `refreshToken=${refreshToken}`,
-          }),
-        })
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(hasSetCookie(response, (cookie) => cookie.includes("accessToken="))).toBe(false);
+      expect(hasSetCookie(response, (cookie) => cookie.includes("refreshToken="))).toBe(false);
+    });
+
+    it("공개 라우트는 기존 hard 갱신 작업에 합류해 새 쿠키를 받아야 함", async () => {
+      const refreshToken = createMockToken(30 * 24 * 60 * 60);
+      const expiredAccessToken = createMockToken(-60);
+      const hardRequest = new NextRequest(`http://localhost:3000${PRIMARY_PROTECTED_PAGE_PATH}`, {
+        headers: {
+          cookie: `accessToken=${expiredAccessToken}; refreshToken=${refreshToken}`,
+        },
+      });
+      const publicRequest = new NextRequest("http://localhost:3000/", {
+        headers: {
+          cookie: `refreshToken=${refreshToken}`,
+        },
+      });
+      const backendResponse = deferred<ReturnType<typeof createRefreshSuccessResponse>>();
+      const fetchStarted = deferred<void>();
+      mockFetch.mockImplementation(() => {
+        fetchStarted.resolve();
+        return backendResponse.promise;
+      });
+
+      const hardResponsePromise = proxy(hardRequest);
+      await fetchStarted.promise;
+      const publicResponsePromise = proxy(publicRequest);
+      backendResponse.resolve(createRefreshSuccessResponse("shared-access", "shared-refresh"));
+      const [hardResponse, publicResponse] = await Promise.all([
+        hardResponsePromise,
+        publicResponsePromise,
+      ]);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(hardResponse.status).toBe(200);
+      expect(publicResponse.status).toBe(200);
+      expect(hasSetCookie(publicResponse, (cookie) => cookie.includes("shared-access"))).toBe(true);
+      expect(hasSetCookie(publicResponse, (cookie) => cookie.includes("shared-refresh"))).toBe(
+        true
       );
-      expect(hasSetCookie(response, (cookie) => cookie.includes("accessToken="))).toBe(true);
-      expect(hasSetCookie(response, (cookie) => cookie.includes("refreshToken="))).toBe(true);
-    });
-
-    it.each([401, 403])(
-      "공개 라우트에서 재발급이 %i이면 리다이렉트와 쿠키 정리 없이 통과해야 함",
-      async (status) => {
-        const refreshToken = createMockToken(30 * 24 * 60 * 60);
-        const request = new NextRequest("http://localhost:3000/login", {
-          headers: {
-            cookie: `refreshToken=${refreshToken}`,
-          },
-        });
-
-        mockFetch.mockResolvedValueOnce({
-          ok: false,
-          status,
-        });
-
-        const response = await proxy(request);
-
-        expect(response.status).toBe(200);
-        expect(response.headers.get("location")).toBeNull();
-        expect(hasSetCookie(response, (cookie) => cookie.startsWith("accessToken=;"))).toBe(false);
-        expect(hasSetCookie(response, (cookie) => cookie.startsWith("refreshToken=;"))).toBe(false);
-        expectRefreshFailureLog({
-          reason: "http_error",
-          routeType: "public",
-          status,
-          cookieClear: false,
-        });
-      }
-    );
-
-    it("공개 라우트에서 재발급이 5xx로 실패하면 리다이렉트 없이 통과해야 함", async () => {
-      const refreshToken = createMockToken(30 * 24 * 60 * 60);
-      const request = new NextRequest("http://localhost:3000/", {
-        headers: {
-          cookie: `refreshToken=${refreshToken}`,
-        },
-      });
-
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 500,
-      });
-
-      const response = await proxy(request);
-
-      expect(response.status).toBe(200);
-      expect(response.headers.get("location")).toBeNull();
-      expect(hasSetCookie(response, (cookie) => cookie.startsWith("accessToken=;"))).toBe(false);
-      expect(hasSetCookie(response, (cookie) => cookie.startsWith("refreshToken=;"))).toBe(false);
-    });
-
-    it("공개 라우트에서 재발급 응답 형식이 비정상이면 리다이렉트 없이 통과해야 함", async () => {
-      const refreshToken = createMockToken(30 * 24 * 60 * 60);
-      const request = new NextRequest("http://localhost:3000/login", {
-        headers: {
-          cookie: `refreshToken=${refreshToken}`,
-        },
-      });
-
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        json: jest.fn().mockResolvedValue({
-          result: {
-            accessToken: "new_access",
-            refreshToken: null,
-          },
-        }),
-      });
-
-      const response = await proxy(request);
-
-      expect(response.status).toBe(200);
-      expect(response.headers.get("location")).toBeNull();
-      expect(hasSetCookie(response, (cookie) => cookie.startsWith("accessToken=;"))).toBe(false);
-      expect(hasSetCookie(response, (cookie) => cookie.startsWith("refreshToken=;"))).toBe(false);
-      expectRefreshFailureLog({
-        reason: "invalid_response",
-        routeType: "public",
-        status: 200,
-        cookieClear: false,
-      });
-    });
-
-    it("공개 라우트에서 재발급 네트워크 에러가 나도 리다이렉트 없이 통과해야 함", async () => {
-      const refreshToken = createMockToken(30 * 24 * 60 * 60);
-      const request = new NextRequest("http://localhost:3000/", {
-        headers: {
-          cookie: `refreshToken=${refreshToken}`,
-        },
-      });
-
-      mockFetch.mockRejectedValueOnce(new Error("Network error"));
-
-      const response = await proxy(request);
-
-      expect(response.status).toBe(200);
-      expect(response.headers.get("location")).toBeNull();
     });
   });
 
@@ -536,7 +500,7 @@ describe("Proxy Middleware", () => {
       expect(mockFetch).not.toHaveBeenCalled();
     });
 
-    it("토큰이 5분 이내로 남았으면 재발급을 시도해야 함", async () => {
+    it("토큰이 5분 이내로 남아도 기존 hard 작업이 없으면 재발급을 시작하지 않아야 함", async () => {
       // Given: 3분 후 만료되는 토큰
       const accessToken = createMockToken(3 * 60); // 3분
       const refreshToken = createMockToken(30 * 24 * 60 * 60);
@@ -547,63 +511,139 @@ describe("Proxy Middleware", () => {
         },
       });
 
-      // Mock: 재발급 API 성공 응답
-      const newAccessToken = createMockToken(60 * 60); // 1시간
-      mockFetch.mockResolvedValueOnce(
-        createRefreshSuccessResponse(newAccessToken, "new_refresh_token")
-      );
-
       // When
       const response = await proxy(request);
 
-      // Then: 재발급 API 호출 확인
-      expect(mockFetch).toHaveBeenCalledWith(
-        "http://localhost:8080/auth/refresh",
-        expect.objectContaining({
-          method: "POST",
-          headers: expect.objectContaining({
-            "Content-Type": "application/json",
-            Cookie: `refreshToken=${refreshToken}`,
-          }),
-          credentials: "include",
-        })
-      );
-
-      // 새 쿠키가 응답에 포함되었는지 확인
+      // Then: 아직 유효한 Access Token으로 통과
+      expect(mockFetch).not.toHaveBeenCalled();
       expect(response.status).toBe(200);
-      const setCookieHeaders = response.headers.getSetCookie();
-      expect(setCookieHeaders.some((cookie) => cookie.includes("accessToken="))).toBe(true);
+      expect(hasSetCookie(response, (cookie) => cookie.includes("accessToken="))).toBe(false);
+      expect(hasSetCookie(response, (cookie) => cookie.includes("refreshToken="))).toBe(false);
     });
 
-    it("동일한 refreshToken 병렬 요청 중 하나가 AUTH401_7이어도 유효한 요청은 로그아웃하지 않아야 함", async () => {
-      const accessToken = createMockToken(3 * 60);
+    it("동일한 refreshToken의 병렬 hard 요청은 하나의 갱신 결과를 공유해야 함", async () => {
+      const accessToken = createMockToken(-60);
       const refreshToken = createMockToken(30 * 24 * 60 * 60);
-      const createRequest = () =>
-        new NextRequest(`http://localhost:3000${PRIMARY_PROTECTED_PAGE_PATH}`, {
+      const createRequest = (pathname: string, marker: string) =>
+        new NextRequest(`http://localhost:3000${pathname}`, {
           headers: {
-            cookie: `accessToken=${accessToken}; refreshToken=${refreshToken}`,
+            cookie: `accessToken=${accessToken}; refreshToken=${refreshToken}; marker=${marker}`,
+            "x-caller-id": marker,
           },
         });
 
-      mockFetch
-        .mockResolvedValueOnce(createRefreshSuccessResponse("new_access", "new_refresh"))
-        .mockResolvedValueOnce(createRefreshMismatchResponse());
+      mockFetch.mockResolvedValue(createRefreshSuccessResponse("new_access", "new_refresh"));
 
-      const [successResponse, mismatchResponse] = await Promise.all([
-        proxy(createRequest()),
-        proxy(createRequest()),
+      const [firstResponse, secondResponse] = await Promise.all([
+        proxy(createRequest(PRIMARY_PROTECTED_PAGE_PATH, "A")),
+        proxy(createRequest("/api/members/me/profile", "B")),
       ]);
 
-      expect(successResponse.status).toBe(200);
-      expect(hasSetCookie(successResponse, (cookie) => cookie.includes("new_access"))).toBe(true);
-      expect(mismatchResponse.status).toBe(200);
-      expect(mismatchResponse.headers.get("location")).toBeNull();
-      expect(hasSetCookie(mismatchResponse, (cookie) => cookie.startsWith("accessToken=;"))).toBe(
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(firstResponse).not.toBe(secondResponse);
+      expect(firstResponse.status).toBe(200);
+      expect(secondResponse.status).toBe(200);
+      expect(hasSetCookie(firstResponse, (cookie) => cookie.includes("new_access"))).toBe(true);
+      expect(hasSetCookie(secondResponse, (cookie) => cookie.includes("new_access"))).toBe(true);
+      for (const response of [firstResponse, secondResponse]) {
+        const overriddenHeaders = response.headers.get("x-middleware-override-headers")?.split(",");
+        expect(overriddenHeaders).toEqual(expect.arrayContaining(["cookie", "x-caller-id"]));
+      }
+      const firstCookie = firstResponse.headers.get("x-middleware-request-cookie");
+      const secondCookie = secondResponse.headers.get("x-middleware-request-cookie");
+      expect(firstResponse.headers.get("x-middleware-request-x-caller-id")).toBe("A");
+      expect(secondResponse.headers.get("x-middleware-request-x-caller-id")).toBe("B");
+      expect(getCookieValue(firstCookie, "marker")).toBe("A");
+      expect(getCookieValue(secondCookie, "marker")).toBe("B");
+      expect(getCookieValue(firstCookie, "accessToken")).toBe("new_access");
+      expect(getCookieValue(secondCookie, "accessToken")).toBe("new_access");
+      expect(getCookieValue(firstCookie, "refreshToken")).toBe("new_refresh");
+      expect(getCookieValue(secondCookie, "refreshToken")).toBe("new_refresh");
+      expect(firstCookie).not.toContain(accessToken);
+      expect(secondCookie).not.toContain(refreshToken);
+    });
+
+    it("만료 임박 보호 요청은 기존 hard 갱신에 합류해 새 쿠키를 받아야 함", async () => {
+      const expiredAccessToken = createMockToken(-60);
+      const expiringAccessToken = createMockToken(3 * 60);
+      const refreshToken = createMockToken(30 * 24 * 60 * 60);
+      const backendResponse = deferred<ReturnType<typeof createRefreshSuccessResponse>>();
+      const fetchStarted = deferred<void>();
+      jest.spyOn(crypto.subtle, "digest").mockResolvedValue(new Uint8Array(32).fill(249).buffer);
+      mockFetch.mockImplementation(() => {
+        fetchStarted.resolve();
+        return backendResponse.promise;
+      });
+
+      const hardResponsePromise = proxy(
+        new NextRequest(`http://localhost:3000${PRIMARY_PROTECTED_PAGE_PATH}`, {
+          headers: {
+            cookie: `accessToken=${expiredAccessToken}; refreshToken=${refreshToken}`,
+          },
+        })
+      );
+      await fetchStarted.promise;
+      const softResponsePromise = proxy(
+        new NextRequest("http://localhost:3000/profile/report", {
+          headers: {
+            cookie: `accessToken=${expiringAccessToken}; refreshToken=${refreshToken}`,
+          },
+        })
+      );
+      await Promise.resolve();
+      backendResponse.resolve(createRefreshSuccessResponse("joined-access", "joined-refresh"));
+
+      const [hardResponse, softResponse] = await Promise.all([
+        hardResponsePromise,
+        softResponsePromise,
+      ]);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(hasSetCookie(hardResponse, (cookie) => cookie.includes("joined-access"))).toBe(true);
+      expect(hasSetCookie(softResponse, (cookie) => cookie.includes("joined-access"))).toBe(true);
+    });
+
+    it("soft 요청이 1.5초에 통과해도 공유 hard 갱신은 계속되어야 함", async () => {
+      jest.useFakeTimers();
+      const expiredAccessToken = createMockToken(-60);
+      const expiringAccessToken = createMockToken(3 * 60);
+      const refreshToken = createMockToken(30 * 24 * 60 * 60);
+      const backendResponse = deferred<ReturnType<typeof createRefreshSuccessResponse>>();
+      const fetchStarted = deferred<void>();
+      let sharedSignal: AbortSignal | null | undefined;
+      mockFetch.mockImplementation((_url, init) => {
+        sharedSignal = init?.signal;
+        fetchStarted.resolve();
+        return backendResponse.promise;
+      });
+
+      const hardResponsePromise = proxy(
+        new NextRequest(`http://localhost:3000${PRIMARY_PROTECTED_PAGE_PATH}`, {
+          headers: {
+            cookie: `accessToken=${expiredAccessToken}; refreshToken=${refreshToken}`,
+          },
+        })
+      );
+      await fetchStarted.promise;
+      const softResponsePromise = proxy(
+        new NextRequest("http://localhost:3000/api/members/me/profile", {
+          headers: {
+            cookie: `accessToken=${expiringAccessToken}; refreshToken=${refreshToken}`,
+          },
+        })
+      );
+
+      await jest.advanceTimersByTimeAsync(1500);
+      const softResponse = await softResponsePromise;
+      expect(softResponse.status).toBe(200);
+      expect(hasSetCookie(softResponse, (cookie) => cookie.startsWith("accessToken=;"))).toBe(
         false
       );
-      expect(hasSetCookie(mismatchResponse, (cookie) => cookie.startsWith("refreshToken=;"))).toBe(
-        false
-      );
+      expect(sharedSignal?.aborted).toBe(false);
+
+      backendResponse.resolve(createRefreshSuccessResponse("hard-access", "hard-refresh"));
+      const hardResponse = await hardResponsePromise;
+      expect(hasSetCookie(hardResponse, (cookie) => cookie.includes("hard-access"))).toBe(true);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 
     it("토큰이 이미 만료되었으면 재발급을 시도해야 함", async () => {
@@ -729,6 +769,116 @@ describe("Proxy Middleware", () => {
       expect(setCookies[1]).toContain(newRefreshToken);
     });
 
+    it("Refresh Token과 새 토큰 쌍을 로그에 남기지 않아야 함", async () => {
+      const refreshToken = `secret-${createMockToken(30 * 24 * 60 * 60)}`;
+      const newAccessToken = "secret-new-access";
+      const newRefreshToken = "secret-new-refresh";
+      const request = new NextRequest(`http://localhost:3000${PRIMARY_PROTECTED_PAGE_PATH}`, {
+        headers: { cookie: `refreshToken=${refreshToken}` },
+      });
+      mockFetch.mockResolvedValueOnce(
+        createRefreshSuccessResponse(newAccessToken, newRefreshToken)
+      );
+
+      await proxy(request);
+
+      const serializedLogs = JSON.stringify([
+        ...consoleErrorSpy.mock.calls,
+        ...consoleWarnSpy.mock.calls,
+      ]);
+      expect(serializedLogs).not.toContain(refreshToken);
+      expect(serializedLogs).not.toContain(newAccessToken);
+      expect(serializedLogs).not.toContain(newRefreshToken);
+      const successCalls = consoleWarnSpy.mock.calls.filter(
+        ([message]) => message === "Proxy: Token refresh succeeded"
+      );
+      expect(successCalls).toEqual([
+        [
+          "Proxy: Token refresh succeeded",
+          {
+            status: 200,
+            routeType: "protected",
+            mode: "hard",
+            disposition: "created",
+          },
+        ],
+      ]);
+    });
+
+    it("지문 계산 실패 경고는 정적 필드만 사용해 warm module당 한 번만 남겨야 함", async () => {
+      const createRequest = () =>
+        new NextRequest(`http://localhost:3000${PRIMARY_PROTECTED_PAGE_PATH}`, {
+          headers: {
+            cookie: `refreshToken=${createMockToken(30 * 24 * 60 * 60)}`,
+          },
+        });
+      jest.spyOn(crypto.subtle, "digest").mockRejectedValue(new Error("digest unavailable"));
+      mockFetch
+        .mockResolvedValueOnce(createRefreshSuccessResponse())
+        .mockResolvedValueOnce(createRefreshSuccessResponse());
+
+      await proxy(createRequest());
+      await proxy(createRequest());
+
+      const bypassCalls = consoleWarnSpy.mock.calls.filter(
+        ([message]) => message === "Proxy: Token refresh fingerprint bypass"
+      );
+      expect(bypassCalls).toEqual([["Proxy: Token refresh fingerprint bypass", { mode: "hard" }]]);
+    });
+
+    it("성공한 hard 갱신 결과는 2초 미만에 재사용하고 2초부터 새로 호출해야 함", async () => {
+      jest.useFakeTimers();
+      const refreshToken = createMockToken(30 * 24 * 60 * 60);
+      const createRequest = () =>
+        new NextRequest(`http://localhost:3000${PRIMARY_PROTECTED_PAGE_PATH}`, {
+          headers: { cookie: `refreshToken=${refreshToken}` },
+        });
+      mockFetch
+        .mockResolvedValueOnce(createRefreshSuccessResponse("access-1", "refresh-1"))
+        .mockResolvedValueOnce(createRefreshSuccessResponse("access-2", "refresh-2"));
+
+      const firstResponse = await proxy(createRequest());
+      await jest.advanceTimersByTimeAsync(1999);
+      const reusedResponse = await proxy(createRequest());
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(firstResponse).not.toBe(reusedResponse);
+      expect(hasSetCookie(reusedResponse, (cookie) => cookie.includes("access-1"))).toBe(true);
+
+      await jest.advanceTimersByTimeAsync(1);
+      const refreshedResponse = await proxy(createRequest());
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(hasSetCookie(refreshedResponse, (cookie) => cookie.includes("access-2"))).toBe(true);
+    });
+
+    it("서로 다른 refreshToken의 hard 요청은 결과를 섞지 않아야 함", async () => {
+      const refreshTokenA = createMockToken(30 * 24 * 60 * 60);
+      const refreshTokenB = createMockToken(30 * 24 * 60 * 60);
+      const createRequest = (refreshToken: string) =>
+        new NextRequest(`http://localhost:3000${PRIMARY_PROTECTED_PAGE_PATH}`, {
+          headers: { cookie: `refreshToken=${refreshToken}` },
+        });
+      mockFetch.mockImplementation((_url, init) => {
+        const cookie = (init?.headers as Record<string, string>).Cookie;
+        return Promise.resolve(
+          cookie.includes(refreshTokenA)
+            ? createRefreshSuccessResponse("access-a", "refresh-a")
+            : createRefreshSuccessResponse("access-b", "refresh-b")
+        );
+      });
+
+      const [responseA, responseB] = await Promise.all([
+        proxy(createRequest(refreshTokenA)),
+        proxy(createRequest(refreshTokenB)),
+      ]);
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(hasSetCookie(responseA, (cookie) => cookie.includes("access-a"))).toBe(true);
+      expect(hasSetCookie(responseA, (cookie) => cookie.includes("access-b"))).toBe(false);
+      expect(hasSetCookie(responseB, (cookie) => cookie.includes("access-b"))).toBe(true);
+      expect(hasSetCookie(responseB, (cookie) => cookie.includes("access-a"))).toBe(false);
+    });
+
     it("보호된 라우트에서 재발급 응답 형식이 비정상이면 로그인 라우트(COMMON500)로 리다이렉트해야 함", async () => {
       // Given
       const refreshToken = createMockToken(30 * 24 * 60 * 60);
@@ -801,6 +951,25 @@ describe("Proxy Middleware", () => {
         status: 401,
         cookieClear: true,
       });
+    });
+
+    it("hard 갱신 실패는 저장하지 않고 같은 토큰의 다음 요청이 재시도해야 함", async () => {
+      const refreshToken = createMockToken(30 * 24 * 60 * 60);
+      const createRequest = () =>
+        new NextRequest(`http://localhost:3000${PRIMARY_PROTECTED_PAGE_PATH}`, {
+          headers: { cookie: `refreshToken=${refreshToken}` },
+        });
+      mockFetch
+        .mockResolvedValueOnce(createRefreshMismatchResponse())
+        .mockResolvedValueOnce(createRefreshSuccessResponse());
+
+      const failedResponse = await proxy(createRequest());
+      const retriedResponse = await proxy(createRequest());
+
+      expectLoginRedirect(failedResponse, "AUTH401_7");
+      expect(retriedResponse.status).toBe(200);
+      expect(hasSetCookie(retriedResponse, (cookie) => cookie.includes("new_access"))).toBe(true);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
     });
 
     it("재발급 API 호출 중 네트워크 에러가 발생하면 로그인 라우트로 리다이렉트해야 함", async () => {
@@ -1058,7 +1227,7 @@ describe("Proxy Middleware", () => {
       expect(mockFetch).not.toHaveBeenCalled();
     });
 
-    it("/api/* 에서 토큰이 만료 임박하면 재발급을 시도해야 함", async () => {
+    it("/api/* 에서 토큰이 만료 임박해도 기존 hard 작업이 없으면 재발급하지 않아야 함", async () => {
       // Given: 3분 후 만료 토큰
       const accessToken = createMockToken(3 * 60);
       const refreshToken = createMockToken(30 * 24 * 60 * 60);
@@ -1067,27 +1236,20 @@ describe("Proxy Middleware", () => {
         headers: { cookie: `accessToken=${accessToken}; refreshToken=${refreshToken}` },
       });
 
-      mockFetch.mockResolvedValueOnce(createRefreshSuccessResponse("new_access", "new_refresh"));
-
       // When
       const response = await proxy(request);
 
-      // Then: 재발급 API 호출
-      expect(mockFetch).toHaveBeenCalledWith(
-        "http://localhost:8080/auth/refresh",
-        expect.objectContaining({ method: "POST" })
-      );
+      // Then: 아직 유효한 Access Token으로 통과
+      expect(mockFetch).not.toHaveBeenCalled();
       expect(response.status).toBe(200);
     });
 
-    it("/api/* 에서 유효한 토큰의 선제 재발급이 AUTH401_7이어도 원래 요청을 통과시켜야 함", async () => {
+    it("/api/* 에서 유효한 토큰의 soft miss는 백엔드 응답과 무관하게 통과해야 함", async () => {
       const accessToken = createMockToken(3 * 60);
       const refreshToken = createMockToken(30 * 24 * 60 * 60);
       const request = new NextRequest("http://localhost:3000/api/members/me/profile", {
         headers: { cookie: `accessToken=${accessToken}; refreshToken=${refreshToken}` },
       });
-
-      mockFetch.mockResolvedValueOnce(createRefreshMismatchResponse());
 
       const response = await proxy(request);
 
@@ -1095,6 +1257,7 @@ describe("Proxy Middleware", () => {
       expect(response.headers.get("location")).toBeNull();
       expect(hasSetCookie(response, (cookie) => cookie.startsWith("accessToken=;"))).toBe(false);
       expect(hasSetCookie(response, (cookie) => cookie.startsWith("refreshToken=;"))).toBe(false);
+      expect(mockFetch).not.toHaveBeenCalled();
     });
 
     it("/api/* 에서 재발급 성공 시 response cookies와 request header 모두에 새 토큰을 설정해야 함", async () => {
@@ -1155,6 +1318,91 @@ describe("Proxy Middleware", () => {
       });
     });
 
+    it("공유된 hard 실패도 페이지와 API에서 각자의 응답 형식을 유지해야 함", async () => {
+      const expiredAccessToken = createMockToken(-60);
+      const refreshToken = createMockToken(30 * 24 * 60 * 60);
+      const cookie = `accessToken=${expiredAccessToken}; refreshToken=${refreshToken}`;
+      const pageRequest = new NextRequest(`http://localhost:3000${PRIMARY_PROTECTED_PAGE_PATH}`, {
+        headers: { cookie },
+      });
+      const apiRequest = new NextRequest("http://localhost:3000/api/members/me/profile", {
+        headers: { cookie },
+      });
+      const backendResponse = deferred<ReturnType<typeof createRefreshMismatchResponse>>();
+      const fetchStarted = deferred<void>();
+      jest.spyOn(crypto.subtle, "digest").mockResolvedValue(new Uint8Array(32).fill(250).buffer);
+      mockFetch.mockImplementation(() => {
+        fetchStarted.resolve();
+        return backendResponse.promise;
+      });
+
+      const pageResponsePromise = proxy(pageRequest);
+      const apiResponsePromise = proxy(apiRequest);
+      await fetchStarted.promise;
+      await Promise.resolve();
+      backendResponse.resolve(createRefreshMismatchResponse());
+      const [pageResponse, apiResponse] = await Promise.all([
+        pageResponsePromise,
+        apiResponsePromise,
+      ]);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expectLoginRedirect(pageResponse, "AUTH401_7");
+      await expectApiAuthError(apiResponse, { code: "AUTH401_7" });
+      expect(hasSetCookie(pageResponse, (value) => value.startsWith("accessToken=;"))).toBe(true);
+      expect(hasSetCookie(apiResponse, (value) => value.startsWith("accessToken=;"))).toBe(true);
+    });
+
+    it("실패한 hard 작업에 합류한 soft 요청은 리다이렉트와 쿠키 삭제 없이 통과해야 함", async () => {
+      const expiredAccessToken = createMockToken(-60);
+      const expiringAccessToken = createMockToken(3 * 60);
+      const refreshToken = createMockToken(30 * 24 * 60 * 60);
+      const backendResponse = deferred<ReturnType<typeof createRefreshMismatchResponse>>();
+      const fetchStarted = deferred<void>();
+      jest.spyOn(crypto.subtle, "digest").mockResolvedValue(new Uint8Array(32).fill(248).buffer);
+      mockFetch.mockImplementation(() => {
+        fetchStarted.resolve();
+        return backendResponse.promise;
+      });
+
+      const hardResponsePromise = proxy(
+        new NextRequest(`http://localhost:3000${PRIMARY_PROTECTED_PAGE_PATH}`, {
+          headers: {
+            cookie: `accessToken=${expiredAccessToken}; refreshToken=${refreshToken}`,
+          },
+        })
+      );
+      await fetchStarted.promise;
+      const softResponsePromise = proxy(
+        new NextRequest("http://localhost:3000/api/members/me/profile", {
+          headers: {
+            cookie: `accessToken=${expiringAccessToken}; refreshToken=${refreshToken}`,
+          },
+        })
+      );
+      await Promise.resolve();
+      backendResponse.resolve(createRefreshMismatchResponse());
+      const [hardResponse, softResponse] = await Promise.all([
+        hardResponsePromise,
+        softResponsePromise,
+      ]);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expectLoginRedirect(hardResponse, "AUTH401_7");
+      expect(softResponse.status).toBe(200);
+      expect(softResponse.headers.get("location")).toBeNull();
+      expect(hasSetCookie(softResponse, (value) => value.startsWith("accessToken=;"))).toBe(false);
+      expect(hasSetCookie(softResponse, (value) => value.startsWith("refreshToken=;"))).toBe(false);
+      expectRefreshFailureLog({
+        reason: "http_error",
+        routeType: "api",
+        status: 401,
+        cookieClear: false,
+        mode: "soft",
+        disposition: "joined",
+      });
+    });
+
     it("/api/* 에서 재발급 네트워크 에러가 나면 500 JSON 에러를 반환해야 함", async () => {
       // Given
       const accessToken = createMockToken(-60);
@@ -1174,6 +1422,50 @@ describe("Proxy Middleware", () => {
         status: 500,
         code: "network_error",
       });
+    });
+
+    it("/api/* hard 갱신 success body는 10초에 timeout되고 다음 요청이 재시도해야 함", async () => {
+      jest.useFakeTimers();
+      const refreshToken = createMockToken(30 * 24 * 60 * 60);
+      const createRequest = () =>
+        new NextRequest("http://localhost:3000/api/members/me/profile", {
+          headers: { cookie: `refreshToken=${refreshToken}` },
+        });
+      mockFetch
+        .mockImplementationOnce((_url, init) => {
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            json: jest.fn().mockImplementation(
+              () =>
+                new Promise((_resolve, reject) => {
+                  init?.signal?.addEventListener("abort", () => {
+                    reject(new DOMException("Aborted", "AbortError"));
+                  });
+                })
+            ),
+          });
+        })
+        .mockResolvedValueOnce(createRefreshSuccessResponse());
+
+      const timedOutResponsePromise = proxy(createRequest());
+      await jest.advanceTimersByTimeAsync(10_000);
+      const timedOutResponse = await timedOutResponsePromise;
+
+      await expectApiAuthError(timedOutResponse, {
+        status: 504,
+        code: "network_error",
+      });
+      expectRefreshFailureLog({
+        reason: "timeout",
+        routeType: "api",
+        status: 504,
+        cookieClear: true,
+      });
+
+      const retriedResponse = await proxy(createRequest());
+      expect(retriedResponse.status).toBe(200);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/src/test/proxy.test.ts
+++ b/src/test/proxy.test.ts
@@ -461,8 +461,8 @@ describe("Proxy Middleware", () => {
     });
   });
 
-  describe("토큰 만료 검증", () => {
-    it("토큰이 5분 이상 남았으면 그대로 통과해야 함", async () => {
+  describe("Access Token 갱신 필요 상태 판단", () => {
+    it("만료까지 5분 이상 남은 usable Token은 그대로 통과해야 함", async () => {
       // Given: 10분 후 만료되는 토큰
       const accessToken = createMockToken(10 * 60); // 10분
       const refreshToken = createMockToken(30 * 24 * 60 * 60); // 30일
@@ -481,7 +481,7 @@ describe("Proxy Middleware", () => {
       expect(mockFetch).not.toHaveBeenCalled(); // 재발급 호출 안함
     });
 
-    it("base64url 형식 토큰도 만료 시간을 정상 판별해야 함", async () => {
+    it("base64url 형식 usable Token도 갱신 없이 통과해야 함", async () => {
       // Given: base64url 형식 + 10분 후 만료
       const accessToken = createBase64UrlMockToken(10 * 60);
       const refreshToken = createMockToken(30 * 24 * 60 * 60);
@@ -500,7 +500,7 @@ describe("Proxy Middleware", () => {
       expect(mockFetch).not.toHaveBeenCalled();
     });
 
-    it("토큰이 5분 이내로 남아도 기존 hard 작업이 없으면 재발급을 시작하지 않아야 함", async () => {
+    it("만료가 임박한 expiring Token도 기존 hard 작업이 없으면 재발급을 시작하지 않아야 함", async () => {
       // Given: 3분 후 만료되는 토큰
       const accessToken = createMockToken(3 * 60); // 3분
       const refreshToken = createMockToken(30 * 24 * 60 * 60);


### PR DESCRIPTION
## 작업 내용

- 동일 warm Vercel module context에서 같은 Refresh Token의 hard 갱신을 SHA-256 지문 기반 single-flight로 병합했습니다.
- soft 요청은 새 갱신을 시작하지 않고 기존 hard 작업 또는 완료 후 2초 미만의 성공 결과에만 API 진입부터 총 1.5초 동안 합류합니다.
- 공유 값은 요청 비종속 `RefreshOutcome`으로 제한하고, 각 caller가 별도 `NextResponse`, forwarded headers, cookies, page redirect/API JSON을 생성하도록 분리했습니다.
- hard 10초 deadline을 response headers뿐 아니라 성공·오류 body 소비와 outcome 확정까지 적용하고, 실패 결과는 즉시 제거했습니다.
- 기존 로그인 만료 문구와 hard/soft 실패 정책을 유지하고 raw token, fingerprint, token pair, request path를 갱신 로그에서 제외했습니다.
- 동시성, 1.5초·2초·10초 경계, stale timer identity, cold module, 실패 재시도, caller 격리와 logging schema 회귀 테스트를 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 토큰 갱신 요청을 효율적으로 조정해 동시에 발생한 요청을 통합합니다.
  - 성공한 갱신 결과를 짧은 시간 재사용해 불필요한 중복 요청을 줄입니다.
  - 공개 경로와 인증 필요 경로에 맞춰 토큰 갱신을 처리합니다.
  - 갱신 성공 시 새 인증 토큰이 요청과 응답에 자동 반영됩니다.

- **버그 수정**
  - 네트워크 오류, 잘못된 응답, 시간 초과 상황을 일관되게 처리합니다.
  - 갱신 실패 시 재시도와 요청 통과 동작을 개선했습니다.
  - 인증 관련 로그에서 민감한 정보가 노출되지 않도록 했습니다.

- **테스트**
  - 동시 요청, 격리, 재사용, 시간 초과 및 실패 시나리오를 폭넓게 검증했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## 참고 사항

- 이 변경은 같은 warm 함수 인스턴스 안의 best-effort 완화책입니다. 다중 Vercel 인스턴스의 완전한 멱등성은 백엔드가 이전 Refresh Token과 최초 갱신 결과를 원자적으로 연결해 보장해야 합니다.
- 만료 5분 전 분류는 유지하지만, 기존 hard 작업이 없는 soft-only 요청은 더 이상 선제 Refresh를 시작하지 않습니다.
- `pnpm test --runInBand`: 70 suites, 665 tests 통과
- focused auth tests: 3 suites, 88 tests 통과
- `pnpm lint`: 오류 0, 기존 경고 7
- `pnpm typecheck`: 통과
- `pnpm build`: 통과
- `git diff --check`: 통과
- local production API QA: 동일-token hard 2개 → refresh 1회, expiring soft miss → 0회, hard+soft join → 1회
- Ultragoal frozen generation 2: cleaner PASS, Architect CLEAR/APPROVE, red-team QA passed

## 연관 이슈

close #332

관련 배경: #302, #321

## CodeRabbit 운영 메모

- 증분 리뷰 재실행: `@coderabbitai review`
- 전체 PR 재검토: `@coderabbitai full review`