### PR TITLE
fix: 시작 시간 필터에 새벽 추가

### DIFF
--- a/src/features/session/components/SessionList/sessionListFilter.types.ts
+++ b/src/features/session/components/SessionList/sessionListFilter.types.ts
@@ -24,6 +24,7 @@ export const DURATION_OPTIONS: FilterOption<DurationRange>[] = [
 ];
 
 export const TIME_SLOT_OPTIONS: TimeSlotFilterOption[] = [
+  { value: "DAWN", triggerLabel: "새벽(0-6시)", panelLabel: "새벽 (0 ~ 6시)" },
   { value: "MORNING", triggerLabel: "오전(6-12시)", panelLabel: "오전 (6 ~ 12시)" },
   { value: "AFTERNOON", triggerLabel: "오후(12-18시)", panelLabel: "오후 (12 ~ 18시)" },
   { value: "EVENING", triggerLabel: "저녁(18-24시)", panelLabel: "저녁 (18 ~ 24시)" },

--- a/src/features/session/types.ts
+++ b/src/features/session/types.ts
@@ -55,7 +55,7 @@ export type SessionCategoryFilter = CategoryFilter;
 
 export type SessionSort = "POPULAR" | "LATEST" | "DEADLINE_APPROACHING";
 
-export type TimeSlot = "MORNING" | "AFTERNOON" | "EVENING";
+export type TimeSlot = "DAWN" | "MORNING" | "AFTERNOON" | "EVENING";
 
 export type DurationRange = "ONE_HOUR_OR_LESS" | "ONE_TO_TWO_HOURS" | "TWO_TO_THREE_HOURS";
 

--- a/src/features/session/utils/timeSlots.ts
+++ b/src/features/session/utils/timeSlots.ts
@@ -1,6 +1,6 @@
 import type { TimeSlot } from "../types";
 
-export const TIME_SLOT_ORDER: TimeSlot[] = ["MORNING", "AFTERNOON", "EVENING"];
+export const TIME_SLOT_ORDER: TimeSlot[] = ["DAWN", "MORNING", "AFTERNOON", "EVENING"];
 
 const TIME_SLOT_SET = new Set<TimeSlot>(TIME_SLOT_ORDER);
 

--- a/src/test/timeSlots.test.ts
+++ b/src/test/timeSlots.test.ts
@@ -2,7 +2,8 @@ import { formatTimeSlotsParam, parseTimeSlotsParam } from "@/features/session/ut
 
 describe("timeSlots utils", () => {
   it("콤마 문자열을 TimeSlot 배열로 파싱해야 합니다", () => {
-    expect(parseTimeSlotsParam("MORNING,AFTERNOON,EVENING")).toEqual([
+    expect(parseTimeSlotsParam("DAWN,MORNING,AFTERNOON,EVENING")).toEqual([
+      "DAWN",
       "MORNING",
       "AFTERNOON",
       "EVENING",
@@ -10,10 +11,7 @@ describe("timeSlots utils", () => {
   });
 
   it("중복/공백/잘못된 값을 제거하고 정의된 순서로 정렬해야 합니다", () => {
-    expect(parseTimeSlotsParam("EVENING, MORNING, MORNING,INVALID")).toEqual([
-      "MORNING",
-      "EVENING",
-    ]);
+    expect(parseTimeSlotsParam("EVENING, DAWN, DAWN,INVALID")).toEqual(["DAWN", "EVENING"]);
   });
 
   it("TimeSlot 배열을 콤마 문자열로 변환해야 합니다", () => {


### PR DESCRIPTION
## 작업 내용

> 해당 PR에서 작업한 내용을 정리해주세요.

서버의 시작 시간 필터 스펙 변경(새벽 시간대 추가)을 프론트에 반영했습니다.

- 기존에는 0시 ~ 5시 59분 구간이 시작 시간 필터에 존재하지 않았음
- 서버에서 `DAWN`(새벽, 0시 ~ 5시 59분) 옵션이 추가되고, `MORNING`(오전)은 6시 ~ 11시 59분으로 조정됨

**변경 사항**

- `TimeSlot` 타입에 `DAWN` 추가 (`src/features/session/types.ts`)
- 시작 시간대 필터 옵션에 `새벽(0-6시)` 추가 (`sessionListFilter.types.ts`)
- `TIME_SLOT_ORDER`에 `DAWN`을 맨 앞에 추가하여 URL 파라미터 파싱/정렬 순서 반영 (`utils/timeSlots.ts`)
- 관련 유닛 테스트에 `DAWN` 케이스 반영 (`src/test/timeSlots.test.ts`)

@coderabbitai summary

## 참고 사항

> 코드 리뷰 시 참고할 만한 사항이나 주의할 점을 작성해주세요.

- 필터 트리거 라벨(`getTimeSlotFilterLabel`)과 패널 UI(`StartTimeFilter`)는 모두 `TIME_SLOT_OPTIONS`에서 파생되므로 옵션 배열 추가만으로 UI에 자동 반영됩니다.
- 기존 `MORNING` 라벨은 이미 "오전(6-12시)"로 표기되어 있어 조정된 서버 범위(6시 ~ 11시 59분)와 일치하므로 수정하지 않았습니다.

## 연관 이슈

> 이 PR과 연관된 이슈 번호를 작성하세요. 예) close #10

close #305

## CodeRabbit 운영 메모

- 증분 리뷰 재실행: `@coderabbitai review`
- 전체 PR 재검토: `@coderabbitai full review`