### PR TITLE
chore: CI 트리거를 main push에서 PR 검증 방식으로 전환 (#343)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 on:
-  push:
+  pull_request:
     branches: [main]
 
 concurrency:

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ pnpm dev
 ## 품질 보증 현황 (2026-03-06 기준)
 
 - **CI 파이프라인** (`.github/workflows/ci.yml`)
-  - `main` push 시 `lint` -> `test --ci --coverage` -> `build` -> `docker build` 실행
+  - `main` 대상 PR 생성 및 업데이트 시 `lint` -> `test --ci --coverage` -> `build` -> `docker build` 실행
 - **UI 변경 검증** (`.github/workflows/chromatic.yml`)
   - 스토리/디자인 토큰/스토리북 설정 변경 시 Chromatic 자동 실행
 - **테스트 및 스토리 자산 규모**


### PR DESCRIPTION
## 작업 내용

- GitHub Actions CI 워크플로우(`.github/workflows/ci.yml`)의 실행 트리거를 `push: branches: [main]`에서 `pull_request: branches: [main]`으로 전환
- `README.md`의 CI 파이프라인 설명 문구를 PR 단계 검증 기준으로 갱신
- 기존 CI 내부 실행 단계(Lint, Test, Build, Docker Build) 유지

@coderabbitai summary

## 참고 사항

- merge 이후에 CI가 동작하여 발생하던 문제를 방지하고, PR 단계에서 검증이 통과된 코드만 merge될 수 있도록 개선했습니다.

## 연관 이슈

close #343

## CodeRabbit 운영 메모

- 증분 리뷰 재실행: `@coderabbitai review`
- 전체 PR 재검토: `@coderabbitai full review`
