### PR TITLE
refactor: 메인 홈 페이지 불필요 리렌더링 제거 및 React Compiler bail-out 분석 (#345)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,7 @@ import nextTs from "eslint-config-next/typescript";
 import prettierConfig from "eslint-config-prettier";
 import importPlugin from "eslint-plugin-import";
 import prettierPlugin from "eslint-plugin-prettier";
+import reactCompiler from "eslint-plugin-react-compiler";
 import storybook from "eslint-plugin-storybook";
 
 const eslintConfig = defineConfig([
@@ -18,8 +19,10 @@ const eslintConfig = defineConfig([
     plugins: {
       import: importPlugin,
       prettier: prettierPlugin,
+      "react-compiler": reactCompiler,
     },
     rules: {
+      "react-compiler/react-compiler": "warn",
       "import/first": "error",
       "import/newline-after-import": ["error", { count: 1 }],
       "import/order": [

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-prettier": "^5.5.5",
+    "eslint-plugin-react-compiler": "19.1.0-rc.2",
     "eslint-plugin-storybook": "^10.1.11",
     "husky": "^9.1.7",
     "jest": "^30.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,6 +147,9 @@ importers:
       eslint-plugin-prettier:
         specifier: ^5.5.5
         version: 5.5.5(eslint-config-prettier@10.1.8(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))(prettier@3.8.1)
+      eslint-plugin-react-compiler:
+        specifier: 19.1.0-rc.2
+        version: 19.1.0-rc.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-storybook:
         specifier: ^10.1.11
         version: 10.2.9(eslint@9.39.2(jiti@2.6.1))(storybook@10.2.9(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
@@ -221,6 +224,10 @@ packages:
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/compat-data@7.29.0':
     resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
     engines: {node: '>=6.9.0'}
@@ -233,12 +240,34 @@ packages:
     resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/generator@7.29.8':
+    resolution: {integrity: sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-annotate-as-pure@7.29.7':
+    resolution: {integrity: sha512-OoK6239jHPuSQOoS0kfTVKn0b/rVTk0seKq4Gd2UMLtmOVLjDC0ki3e+c90Trqv2gMfvJFqkiljrr568+qddiw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-compilation-targets@7.28.6':
     resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-create-class-features-plugin@7.29.7':
+    resolution: {integrity: sha512-IY3ZD9Tmooqr3TUhc3DUWxiuo8xx1DWLhd5M7hQ+ZWJamqM2BbalrBJb2MisSLoYorOj75U03qULCxQTY9r3hg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
   '@babel/helper-globals@7.28.0':
     resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-member-expression-to-functions@7.29.7':
+    resolution: {integrity: sha512-j+7JYmk1JYDtACIGj0QJqqWZjoUpMoEikQGADMaHgCMCSDqd2+P32rfcibUNrGOMWrlzK1WJBdxrB3JJQZwWtg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-module-imports@7.28.6':
@@ -251,16 +280,38 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
+  '@babel/helper-optimise-call-expression@7.29.7':
+    resolution: {integrity: sha512-+kmGVjcT9RGYzoDwdwEqEvGgKe3BYq+O1iGzjFubaNgZHwYHP6lsF2Yghf4kEuv9BV7tYDZ913aBW9am6YKong==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-plugin-utils@7.28.6':
     resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-replace-supers@7.29.7':
+    resolution: {integrity: sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
+    resolution: {integrity: sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.27.1':
@@ -275,6 +326,18 @@ packages:
     resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  '@babel/parser@7.29.8':
+    resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-proposal-private-methods@7.18.6':
+    resolution: {integrity: sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==}
+    engines: {node: '>=6.9.0'}
+    deprecated: This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-methods instead.
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
 
   '@babel/plugin-syntax-async-generators@7.8.4':
     resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
@@ -375,12 +438,24 @@ packages:
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/traverse@7.29.0':
     resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/traverse@7.29.8':
+    resolution: {integrity: sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.8':
+    resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@0.2.3':
@@ -2927,6 +3002,12 @@ packages:
         optional: true
       eslint-config-prettier:
         optional: true
+
+  eslint-plugin-react-compiler@19.1.0-rc.2:
+    resolution: {integrity: sha512-oKalwDGcD+RX9mf3NEO4zOoUMeLvjSvcbbEOpquzmzqEEM2MQdp7/FY/Hx9NzmUwFzH1W9SKTz5fihfMldpEYw==}
+    engines: {node: ^14.17.0 || ^16.0.0 || >= 18.0.0}
+    peerDependencies:
+      eslint: '>=7'
 
   eslint-plugin-react-hooks@7.0.1:
     resolution: {integrity: sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==}
@@ -5535,11 +5616,20 @@ packages:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
 
+  zod-validation-error@3.5.4:
+    resolution: {integrity: sha512-+hEiRIiPobgyuFlEojnqjJnhFvg4r/i3cqgcm67eehZf/WBaK3g6cD02YU9mtdVxZjv8CzCA9n/Rhrs3yAAvAw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      zod: ^3.24.4
+
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -5582,6 +5672,12 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
   '@babel/compat-data@7.29.0': {}
 
   '@babel/core@7.29.0':
@@ -5612,6 +5708,18 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
+  '@babel/generator@7.29.8':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-annotate-as-pure@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.8
+
   '@babel/helper-compilation-targets@7.28.6':
     dependencies:
       '@babel/compat-data': 7.29.0
@@ -5620,7 +5728,29 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
+  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-member-expression-to-functions': 7.29.7
+      '@babel/helper-optimise-call-expression': 7.29.7
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.0)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7
+      '@babel/traverse': 7.29.8
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-member-expression-to-functions@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.8
+      '@babel/types': 7.29.8
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-module-imports@7.28.6':
     dependencies:
@@ -5638,11 +5768,35 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-optimise-call-expression@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.8
+
   '@babel/helper-plugin-utils@7.28.6': {}
+
+  '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-member-expression-to-functions': 7.29.7
+      '@babel/helper-optimise-call-expression': 7.29.7
+      '@babel/traverse': 7.29.8
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-skip-transparent-expression-wrappers@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.8
+      '@babel/types': 7.29.8
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/helper-string-parser@7.27.1': {}
 
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/helper-validator-option@7.27.1': {}
 
@@ -5654,6 +5808,18 @@ snapshots:
   '@babel/parser@7.29.0':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@babel/parser@7.29.8':
+    dependencies:
+      '@babel/types': 7.29.8
+
+  '@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.0)
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.0)':
     dependencies:
@@ -5748,6 +5914,12 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/types': 7.29.0
 
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+
   '@babel/traverse@7.29.0':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -5760,10 +5932,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/traverse@7.29.8':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.8
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.8
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/types@7.29.0':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@babel/types@7.29.8':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@bcoe/v8-coverage@0.2.3': {}
 
@@ -8525,6 +8714,18 @@ snapshots:
       synckit: 0.11.12
     optionalDependencies:
       eslint-config-prettier: 10.1.8(eslint@9.39.2(jiti@2.6.1))
+
+  eslint-plugin-react-compiler@19.1.0-rc.2(eslint@9.39.2(jiti@2.6.1)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/parser': 7.29.0
+      '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.29.0)
+      eslint: 9.39.2(jiti@2.6.1)
+      hermes-parser: 0.25.1
+      zod: 3.25.76
+      zod-validation-error: 3.5.4(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
 
   eslint-plugin-react-hooks@7.0.1(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
@@ -11448,9 +11649,15 @@ snapshots:
 
   yoctocolors@2.1.2: {}
 
+  zod-validation-error@3.5.4(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+
   zod-validation-error@4.0.2(zod@4.3.6):
     dependencies:
       zod: 4.3.6
+
+  zod@3.25.76: {}
 
   zod@4.3.6: {}
 

--- a/src/features/session/components/Banner/Banner.tsx
+++ b/src/features/session/components/Banner/Banner.tsx
@@ -86,24 +86,6 @@ export function Banner() {
           <FeedbackBanner isHovered={!isDefault && isHovered} />
         </motion.div>
       </div>
-
-      {/* 인디케이터 */}
-      {/* <div className="mt-md gap-xs flex justify-center">
-        {[0, 1].map((index) => (
-          <button
-            key={index}
-            type="button"
-            aria-label={`배너 ${index + 1}로 이동`}
-            className={`h-[6px] rounded-full transition-all duration-300 ${
-              index === activeIndex ? "bg-text-secondary w-[24px]" : "bg-surface-subtle w-[6px]"
-            }`}
-            onClick={() => {
-              goTo(index);
-              if (!isHovered) startAutoRoll();
-            }}
-          />
-        ))}
-      </div> */}
     </div>
   );
 }

--- a/src/features/session/components/Banner/Banner.tsx
+++ b/src/features/session/components/Banner/Banner.tsx
@@ -25,15 +25,15 @@ export function Banner() {
 
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  const clearAutoRoll = () => {
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current);
-      intervalRef.current = null;
+  useEffect(() => {
+    if (isHovered) {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+      return;
     }
-  };
 
-  const startAutoRoll = () => {
-    clearAutoRoll();
     intervalRef.current = setInterval(() => {
       setActiveIndex((prev) => {
         const next = (prev + 1) % 2;
@@ -41,21 +41,14 @@ export function Banner() {
         return next;
       });
     }, AUTO_ROLL_INTERVAL);
-  };
 
-  useEffect(() => {
-    if (isHovered) {
-      clearAutoRoll();
-    } else {
-      startAutoRoll();
-    }
-    return clearAutoRoll;
-  }, [isHovered, startAutoRoll, clearAutoRoll]);
-
-  const goTo = (index: number) => {
-    setDirection(index === 1 ? "forward" : "backward");
-    setActiveIndex(index);
-  };
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+  }, [isHovered]);
 
   const isDefault = activeIndex === 0;
 

--- a/src/features/session/components/Banner/Banner.tsx
+++ b/src/features/session/components/Banner/Banner.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { motion } from "motion/react";
 
@@ -23,18 +23,10 @@ export function Banner() {
   const [isHovered, setIsHovered] = useState(false);
   const [direction, setDirection] = useState<"forward" | "backward">("forward");
 
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-
   useEffect(() => {
-    if (isHovered) {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-        intervalRef.current = null;
-      }
-      return;
-    }
+    if (isHovered) return;
 
-    intervalRef.current = setInterval(() => {
+    const id = setInterval(() => {
       setActiveIndex((prev) => {
         const next = (prev + 1) % 2;
         setDirection(next === 1 ? "forward" : "backward");
@@ -42,12 +34,7 @@ export function Banner() {
       });
     }, AUTO_ROLL_INTERVAL);
 
-    return () => {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-        intervalRef.current = null;
-      }
-    };
+    return () => clearInterval(id);
   }, [isHovered]);
 
   const isDefault = activeIndex === 0;

--- a/src/features/session/components/SearchFilterSection/SearchFilterSection.tsx
+++ b/src/features/session/components/SearchFilterSection/SearchFilterSection.tsx
@@ -45,11 +45,6 @@ export function SearchFilterSection() {
     const el = scrollRef.current;
     if (!el) return;
 
-    if (isCategoryExpanded) {
-      el.style.maskImage = "";
-      return;
-    }
-
     const canScrollLeft = el.scrollLeft > 1;
     const canScrollRight = el.scrollLeft < el.scrollWidth - el.clientWidth - 1;
 
@@ -63,7 +58,7 @@ export function SearchFilterSection() {
     } else {
       el.style.maskImage = "";
     }
-  }, [isCategoryExpanded]);
+  }, []);
 
   useEffect(() => {
     updateScrollMask();
@@ -76,18 +71,20 @@ export function SearchFilterSection() {
     };
   }, [updateScrollMask]);
 
-  // 열릴 때: flex-wrap 즉시 적용 / 닫힐 때: 애니메이션 후 flex-nowrap 전환 + 스크롤 초기화
+  // 열릴 때: flex-wrap 즉시 적용 및 마스크 제거 / 닫힐 때: 애니메이션 후 flex-nowrap 전환 + 마스크 갱신
   useEffect(() => {
-    if (!isCategoryExpanded) {
-      if (scrollRef.current) scrollRef.current.scrollLeft = 0;
-      const timer = setTimeout(() => {
-        setDisplayExpanded(false);
-        updateScrollMask();
-      }, 200);
-      return () => clearTimeout(timer);
-    } else {
-      updateScrollMask();
+    const el = scrollRef.current;
+    if (isCategoryExpanded) {
+      if (el) el.style.maskImage = "";
+      return;
     }
+
+    if (el) el.scrollLeft = 0;
+    const timer = setTimeout(() => {
+      setDisplayExpanded(false);
+      updateScrollMask();
+    }, 200);
+    return () => clearTimeout(timer);
   }, [isCategoryExpanded, updateScrollMask]);
 
   const currentCategory = parsedParams.category ?? "ALL";

--- a/src/features/session/components/SearchFilterSection/SearchFilterSection.tsx
+++ b/src/features/session/components/SearchFilterSection/SearchFilterSection.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect } from "react";
 
 import { useRouter, useSearchParams } from "next/navigation";
 
@@ -30,6 +30,24 @@ const CATEGORY_FILTERS: { value: SessionCategoryFilter; label: string }[] = [
   })),
 ];
 
+function updateScrollMask(el: HTMLDivElement | null) {
+  if (!el) return;
+
+  const canScrollLeft = el.scrollLeft > 1;
+  const canScrollRight = el.scrollLeft < el.scrollWidth - el.clientWidth - 1;
+
+  if (canScrollLeft && canScrollRight) {
+    el.style.maskImage =
+      "linear-gradient(to right, transparent, black 40px, black calc(100% - 40px), transparent)";
+  } else if (canScrollLeft) {
+    el.style.maskImage = "linear-gradient(to right, transparent, black 40px)";
+  } else if (canScrollRight) {
+    el.style.maskImage = "linear-gradient(to right, black calc(100% - 40px), transparent)";
+  } else {
+    el.style.maskImage = "";
+  }
+}
+
 export function SearchFilterSection() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -41,35 +59,17 @@ export function SearchFilterSection() {
   // 먼저 1행으로 리플로우되어 max-height 트랜지션이 시각적으로 사라지는 문제 방지
   const [displayExpanded, setDisplayExpanded] = useState(false);
 
-  const updateScrollMask = useCallback(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-
-    const canScrollLeft = el.scrollLeft > 1;
-    const canScrollRight = el.scrollLeft < el.scrollWidth - el.clientWidth - 1;
-
-    if (canScrollLeft && canScrollRight) {
-      el.style.maskImage =
-        "linear-gradient(to right, transparent, black 40px, black calc(100% - 40px), transparent)";
-    } else if (canScrollLeft) {
-      el.style.maskImage = "linear-gradient(to right, transparent, black 40px)";
-    } else if (canScrollRight) {
-      el.style.maskImage = "linear-gradient(to right, black calc(100% - 40px), transparent)";
-    } else {
-      el.style.maskImage = "";
-    }
-  }, []);
-
   useEffect(() => {
-    updateScrollMask();
     const el = scrollRef.current;
-    el?.addEventListener("scroll", updateScrollMask, { passive: true });
-    window.addEventListener("resize", updateScrollMask);
+    updateScrollMask(el);
+    const handleScroll = () => updateScrollMask(el);
+    el?.addEventListener("scroll", handleScroll, { passive: true });
+    window.addEventListener("resize", handleScroll);
     return () => {
-      el?.removeEventListener("scroll", updateScrollMask);
-      window.removeEventListener("resize", updateScrollMask);
+      el?.removeEventListener("scroll", handleScroll);
+      window.removeEventListener("resize", handleScroll);
     };
-  }, [updateScrollMask]);
+  }, []);
 
   // 열릴 때: flex-wrap 즉시 적용 및 마스크 제거 / 닫힐 때: 애니메이션 후 flex-nowrap 전환 + 마스크 갱신
   useEffect(() => {
@@ -82,10 +82,10 @@ export function SearchFilterSection() {
     if (el) el.scrollLeft = 0;
     const timer = setTimeout(() => {
       setDisplayExpanded(false);
-      updateScrollMask();
+      updateScrollMask(el);
     }, 200);
     return () => clearTimeout(timer);
-  }, [isCategoryExpanded, updateScrollMask]);
+  }, [isCategoryExpanded]);
 
   const currentCategory = parsedParams.category ?? "ALL";
   const currentQuery = parsedParams.keyword ?? "";

--- a/src/features/session/components/SearchFilterSection/SearchFilterSection.tsx
+++ b/src/features/session/components/SearchFilterSection/SearchFilterSection.tsx
@@ -40,26 +40,41 @@ export function SearchFilterSection() {
   // 닫기 애니메이션(200ms) 동안 flex-wrap 유지 — 즉시 flex-nowrap 전환 시 콘텐츠가
   // 먼저 1행으로 리플로우되어 max-height 트랜지션이 시각적으로 사라지는 문제 방지
   const [displayExpanded, setDisplayExpanded] = useState(false);
-  const [canScrollLeft, setCanScrollLeft] = useState(false);
-  const [canScrollRight, setCanScrollRight] = useState(true);
 
-  const updateScrollState = useCallback(() => {
+  const updateScrollMask = useCallback(() => {
     const el = scrollRef.current;
     if (!el) return;
-    setCanScrollLeft(el.scrollLeft > 1);
-    setCanScrollRight(el.scrollLeft < el.scrollWidth - el.clientWidth - 1);
-  }, []);
+
+    if (isCategoryExpanded) {
+      el.style.maskImage = "";
+      return;
+    }
+
+    const canScrollLeft = el.scrollLeft > 1;
+    const canScrollRight = el.scrollLeft < el.scrollWidth - el.clientWidth - 1;
+
+    if (canScrollLeft && canScrollRight) {
+      el.style.maskImage =
+        "linear-gradient(to right, transparent, black 40px, black calc(100% - 40px), transparent)";
+    } else if (canScrollLeft) {
+      el.style.maskImage = "linear-gradient(to right, transparent, black 40px)";
+    } else if (canScrollRight) {
+      el.style.maskImage = "linear-gradient(to right, black calc(100% - 40px), transparent)";
+    } else {
+      el.style.maskImage = "";
+    }
+  }, [isCategoryExpanded]);
 
   useEffect(() => {
-    updateScrollState();
+    updateScrollMask();
     const el = scrollRef.current;
-    el?.addEventListener("scroll", updateScrollState, { passive: true });
-    window.addEventListener("resize", updateScrollState);
+    el?.addEventListener("scroll", updateScrollMask, { passive: true });
+    window.addEventListener("resize", updateScrollMask);
     return () => {
-      el?.removeEventListener("scroll", updateScrollState);
-      window.removeEventListener("resize", updateScrollState);
+      el?.removeEventListener("scroll", updateScrollMask);
+      window.removeEventListener("resize", updateScrollMask);
     };
-  }, [updateScrollState]);
+  }, [updateScrollMask]);
 
   // 열릴 때: flex-wrap 즉시 적용 / 닫힐 때: 애니메이션 후 flex-nowrap 전환 + 스크롤 초기화
   useEffect(() => {
@@ -67,20 +82,13 @@ export function SearchFilterSection() {
       if (scrollRef.current) scrollRef.current.scrollLeft = 0;
       const timer = setTimeout(() => {
         setDisplayExpanded(false);
-        updateScrollState();
+        updateScrollMask();
       }, 200);
       return () => clearTimeout(timer);
+    } else {
+      updateScrollMask();
     }
-  }, [isCategoryExpanded, updateScrollState]);
-
-  const scrollMaskImage =
-    !isCategoryExpanded && (canScrollLeft || canScrollRight)
-      ? canScrollLeft && canScrollRight
-        ? "linear-gradient(to right, transparent, black 40px, black calc(100% - 40px), transparent)"
-        : canScrollLeft
-          ? "linear-gradient(to right, transparent, black 40px)"
-          : "linear-gradient(to right, black calc(100% - 40px), transparent)"
-      : undefined;
+  }, [isCategoryExpanded, updateScrollMask]);
 
   const currentCategory = parsedParams.category ?? "ALL";
   const currentQuery = parsedParams.keyword ?? "";
@@ -137,7 +145,6 @@ export function SearchFilterSection() {
         >
           <div
             ref={scrollRef}
-            style={{ maskImage: scrollMaskImage }}
             className={cn(
               "gap-xs md:gap-sm flex w-full flex-wrap items-center md:justify-center",
               "[scrollbar-width:none] [&::-webkit-scrollbar]:hidden",

--- a/src/hooks/useViewportLayout.ts
+++ b/src/hooks/useViewportLayout.ts
@@ -43,6 +43,7 @@ export function useViewportLayout(): ViewportLayoutState {
 
   useEffect(() => {
     const observer = new ResizeObserver(([entry]) => {
+      if (!entry) return;
       const nextLayout = getViewportLayout(entry.contentRect.width);
       if (currentLayoutRef.current === nextLayout) {
         return;

--- a/src/hooks/useViewportLayout.ts
+++ b/src/hooks/useViewportLayout.ts
@@ -39,17 +39,15 @@ export function useViewportLayout(): ViewportLayoutState {
     isResolved: false,
   });
 
-  const currentLayoutRef = useRef<ViewportLayout>("desktop");
-  const isResolvedRef = useRef(false);
+  const currentLayoutRef = useRef<ViewportLayout | null>(null);
 
   useEffect(() => {
     const observer = new ResizeObserver(([entry]) => {
       const nextLayout = getViewportLayout(entry.contentRect.width);
-      if (isResolvedRef.current && currentLayoutRef.current === nextLayout) {
+      if (currentLayoutRef.current === nextLayout) {
         return;
       }
       currentLayoutRef.current = nextLayout;
-      isResolvedRef.current = true;
       setState({
         layout: nextLayout,
         isResolved: true,

--- a/src/hooks/useViewportLayout.ts
+++ b/src/hooks/useViewportLayout.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { BREAKPOINT_MD_PX, BREAKPOINT_XL_PX } from "@/lib/constants/breakpoints";
 
@@ -34,11 +34,26 @@ function getViewportLayout(width: number | null): ViewportLayout {
  * 클라이언트에서 실제 너비를 읽은 뒤 `isResolved`를 true로 전환합니다.
  */
 export function useViewportLayout(): ViewportLayoutState {
-  const [width, setWidth] = useState<number | null>(null);
+  const [state, setState] = useState<ViewportLayoutState>({
+    layout: "desktop",
+    isResolved: false,
+  });
+
+  const currentLayoutRef = useRef<ViewportLayout>("desktop");
+  const isResolvedRef = useRef(false);
 
   useEffect(() => {
     const observer = new ResizeObserver(([entry]) => {
-      setWidth(entry.contentRect.width);
+      const nextLayout = getViewportLayout(entry.contentRect.width);
+      if (isResolvedRef.current && currentLayoutRef.current === nextLayout) {
+        return;
+      }
+      currentLayoutRef.current = nextLayout;
+      isResolvedRef.current = true;
+      setState({
+        layout: nextLayout,
+        isResolved: true,
+      });
     });
 
     observer.observe(document.documentElement);
@@ -48,8 +63,5 @@ export function useViewportLayout(): ViewportLayoutState {
     };
   }, []);
 
-  return {
-    layout: getViewportLayout(width),
-    isResolved: width !== null,
-  };
+  return state;
 }

--- a/src/test/hooks/useViewportLayout.test.tsx
+++ b/src/test/hooks/useViewportLayout.test.tsx
@@ -60,4 +60,40 @@ describe("useViewportLayout", () => {
 
     expect(screen.getByText("mobile:resolved")).toBeInTheDocument();
   });
+
+  it("동일한 레이아웃 범위 내에서는 리렌더링을 유발하지 않는다", () => {
+    const renderSpy = jest.fn();
+    function RenderCountProbe() {
+      const { layout } = useViewportLayout();
+      renderSpy(layout);
+      return <div>{layout}</div>;
+    }
+
+    render(<RenderCountProbe />);
+
+    // 초기 마운트 시 renderSpy 호출 (desktop)
+    expect(renderSpy).toHaveBeenCalledTimes(1);
+
+    // 1024px (tablet)으로 변경 -> 1회 리렌더
+    act(() => {
+      observerCallback(
+        [{ contentRect: { width: 1024 } } as ResizeObserverEntry],
+        {} as ResizeObserver
+      );
+    });
+    expect(renderSpy).toHaveBeenCalledTimes(2);
+
+    // 동일 tablet 구간(1100px)으로 10회 변경
+    act(() => {
+      for (let w = 1025; w <= 1034; w++) {
+        observerCallback(
+          [{ contentRect: { width: w } } as ResizeObserverEntry],
+          {} as ResizeObserver
+        );
+      }
+    });
+
+    // 레이아웃이 변하지 않았으므로 리렌더링 횟수는 2회 유지
+    expect(renderSpy).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/test/session/SearchFilterSection.test.tsx
+++ b/src/test/session/SearchFilterSection.test.tsx
@@ -25,23 +25,73 @@ describe("SearchFilterSection", () => {
     expect(screen.getByRole("button", { name: "개발" })).toBeInTheDocument();
   });
 
+  it("카테고리 버튼 클릭 시 URL searchParams를 업데이트한다", () => {
+    render(<SearchFilterSection />);
+
+    const devButton = screen.getByRole("button", { name: "개발" });
+    fireEvent.click(devButton);
+
+    expect(mockPush).toHaveBeenCalledWith("?category=DEVELOPMENT", { scroll: false });
+  });
+
+  it("검색어 입력 후 제출 시 URL searchParams를 업데이트한다", () => {
+    render(<SearchFilterSection />);
+
+    const searchInput = screen.getByPlaceholderText("관심 분야의 세션을 검색해 보세요");
+    fireEvent.change(searchInput, { target: { value: "알고리즘" } });
+    fireEvent.submit(searchInput.closest("form")!);
+
+    expect(mockPush).toHaveBeenCalledWith("?q=%EC%95%8C%EA%B3%A0%EB%A6%AC%EC%A6%98", {
+      scroll: false,
+    });
+  });
+
+  it("카테고리 펼치기/접기 토글 시 aria-expanded가 변경되고 마스크가 제거된다", () => {
+    render(<SearchFilterSection />);
+
+    const toggleButton = screen.getByRole("button", { name: "카테고리 펼치기" });
+    expect(toggleButton).toHaveAttribute("aria-expanded", "false");
+
+    fireEvent.click(toggleButton);
+
+    expect(screen.getByRole("button", { name: "카테고리 접기" })).toHaveAttribute(
+      "aria-expanded",
+      "true"
+    );
+
+    const allButton = screen.getByRole("button", { name: "전체" });
+    const scrollContainer = allButton.parentElement as HTMLDivElement;
+    expect(scrollContainer.style.maskImage).toBe("");
+  });
+
   it("가로 스크롤 이벤트 발생 시 컴포넌트 리렌더링 없이 DOM style.maskImage를 직접 갱신한다", () => {
     render(<SearchFilterSection />);
 
-    // 전체 버튼의 부모 요소(scrollRef)를 가져옴
     const allButton = screen.getByRole("button", { name: "전체" });
     const scrollContainer = allButton.parentElement as HTMLDivElement;
     expect(scrollContainer).toBeInTheDocument();
 
-    // scrollWidth, clientWidth, scrollLeft 모킹
+    // 1) 중간 위치로 스크롤 (좌우 모두 그라데이션)
     Object.defineProperty(scrollContainer, "scrollWidth", { value: 1000, configurable: true });
     Object.defineProperty(scrollContainer, "clientWidth", { value: 300, configurable: true });
     Object.defineProperty(scrollContainer, "scrollLeft", { value: 50, configurable: true });
-
-    // 스크롤 이벤트 발생
     fireEvent.scroll(scrollContainer);
+    expect(scrollContainer.style.maskImage).toBe(
+      "linear-gradient(to right, transparent, black 40px, black calc(100% - 40px), transparent)"
+    );
 
-    // style.maskImage가 DOM에 직접 반영되었는지 검증
-    expect(scrollContainer.style.maskImage).toContain("linear-gradient");
+    // 2) 오른쪽 끝으로 스크롤 (왼쪽만 그라데이션)
+    Object.defineProperty(scrollContainer, "scrollLeft", { value: 700, configurable: true });
+    fireEvent.scroll(scrollContainer);
+    expect(scrollContainer.style.maskImage).toBe(
+      "linear-gradient(to right, transparent, black 40px)"
+    );
+
+    // 3) 왼쪽 시작점으로 스크롤 (오른쪽만 그라데이션)
+    Object.defineProperty(scrollContainer, "scrollLeft", { value: 0, configurable: true });
+    fireEvent.scroll(scrollContainer);
+    expect(scrollContainer.style.maskImage).toBe(
+      "linear-gradient(to right, black calc(100% - 40px), transparent)"
+    );
   });
 });

--- a/src/test/session/SearchFilterSection.test.tsx
+++ b/src/test/session/SearchFilterSection.test.tsx
@@ -1,0 +1,47 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { SearchFilterSection } from "@/features/session/components/SearchFilterSection/SearchFilterSection";
+
+const mockPush = jest.fn();
+let mockSearchParams = new URLSearchParams();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+  }),
+  useSearchParams: () => mockSearchParams,
+}));
+
+describe("SearchFilterSection", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSearchParams = new URLSearchParams();
+  });
+
+  it("카테고리 버튼들을 정상적으로 렌더링한다", () => {
+    render(<SearchFilterSection />);
+
+    expect(screen.getByRole("button", { name: "전체" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "개발" })).toBeInTheDocument();
+  });
+
+  it("가로 스크롤 이벤트 발생 시 컴포넌트 리렌더링 없이 DOM style.maskImage를 직접 갱신한다", () => {
+    render(<SearchFilterSection />);
+
+    // 전체 버튼의 부모 요소(scrollRef)를 가져옴
+    const allButton = screen.getByRole("button", { name: "전체" });
+    const scrollContainer = allButton.parentElement as HTMLDivElement;
+    expect(scrollContainer).toBeInTheDocument();
+
+    // scrollWidth, clientWidth, scrollLeft 모킹
+    Object.defineProperty(scrollContainer, "scrollWidth", { value: 1000, configurable: true });
+    Object.defineProperty(scrollContainer, "clientWidth", { value: 300, configurable: true });
+    Object.defineProperty(scrollContainer, "scrollLeft", { value: 50, configurable: true });
+
+    // 스크롤 이벤트 발생
+    fireEvent.scroll(scrollContainer);
+
+    // style.maskImage가 DOM에 직접 반영되었는지 검증
+    expect(scrollContainer.style.maskImage).toContain("linear-gradient");
+  });
+});


### PR DESCRIPTION
## 작업 내용

- **`eslint-plugin-react-compiler` 설정 추가**: React 19 + Next.js 16 환경에서 React Compiler의 bail-out 패턴을 정적 분석하고 감지하도록 ESLint 플러그인 연동
- **`useViewportLayout` 렌더링 최적화**: ResizeObserver에서 매 1px 너비 변경마다 `setState`가 발생하던 문제를 개선하여, Tailwind breakpoint(768px, 1280px) 경계를 넘을 때만 상태를 갱신하도록 ref 가드 적용
- **`SearchFilterSection` 스크롤 마스크 최적화**: 좌우 스크롤 가능 여부(`canScrollLeft`, `canScrollRight`)의 `useState`를 제거하고 `el.style.maskImage`를 직접 조작하는 방식으로 전환하여 가로 스크롤 시 발생하는 불필요 리렌더링을 0회로 제거
- **`Banner` 컴포넌트 interval 정리**: 자동 롤링 인터벌 로직을 `useEffect` 내부로 캡슐화하고 미사용 함수를 제거하여 린트 경고 및 불필요한 effect 재등록 방지
- **단위 테스트 추가**: 동일 레이아웃 구간 내 너비 변경 시 컴포넌트 리렌더링이 발생하지 않음을 검증하는 테스트(`useViewportLayout.test.tsx`) 추가

@coderabbitai summary

## 참고 사항

- `useViewportLayout`을 구독하는 `DefaultBanner`, `SessionListFilterBar`, `SessionList` 전반의 resize 리렌더링 횟수가 획기적으로 감소했습니다.
- `pnpm lint`, `pnpm typecheck`, `pnpm test` (75 suites, 692 tests), `pnpm build` 검증을 모두 통과했습니다.

## 연관 이슈

close #345

## CodeRabbit 운영 메모

- 증분 리뷰 재실행: `@coderabbitai review`
- 전체 PR 재검토: `@coderabbitai full review`