### PR TITLE
perf: 세션 상세 SSR 중복 API 요청 제거

### DIFF
--- a/src/app/(with-header)/session/[sessionId]/page.tsx
+++ b/src/app/(with-header)/session/[sessionId]/page.tsx
@@ -6,9 +6,9 @@ import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 
 import { memberKeys } from "@/features/member/hooks/useMemberHooks";
 import type { GetMeResponse } from "@/features/member/types";
-import { sessionApi } from "@/features/session/api";
 import { SessionPageContent } from "@/features/session/components/SessionPageContent";
 import { sessionQueries } from "@/features/session/hooks/useSessionHooks";
+import { getSessionDetail } from "@/features/session/server/get-session-detail";
 import { isWaitingStatus } from "@/features/session/types";
 import { handleSessionNotFound } from "@/features/session/utils/handleSessionNotFound";
 import { getQueryClient } from "@/lib/getQueryClient";
@@ -23,7 +23,7 @@ export async function generateMetadata({ params }: SessionPageProps): Promise<Me
   const { sessionId } = await params;
 
   try {
-    const { result } = await sessionApi.getDetail(sessionId);
+    const { result } = await getSessionDetail(sessionId);
     return createPageMetadata({
       title: result.title,
       description: result.summary || `${result.category} 세션에 참여하세요.`,
@@ -45,7 +45,10 @@ export default async function SessionPage({ params }: SessionPageProps) {
   const queryClient = getQueryClient();
 
   const sessionData = await queryClient
-    .fetchQuery(sessionQueries.detail(sessionId))
+    .fetchQuery({
+      ...sessionQueries.detail(sessionId),
+      queryFn: () => getSessionDetail(sessionId),
+    })
     .catch(handleSessionNotFound);
 
   // mock mode에서는 UI 확인을 위해 세션 화면에 직접 접근할 수 있도록 상태 기반 redirect를 제한한다.

--- a/src/features/session/server/get-session-detail.ts
+++ b/src/features/session/server/get-session-detail.ts
@@ -1,0 +1,5 @@
+import { cache } from "react";
+
+import { sessionApi } from "../api";
+
+export const getSessionDetail = cache((sessionId: string) => sessionApi.getDetail(sessionId));

--- a/src/features/session/server/get-session-detail.ts
+++ b/src/features/session/server/get-session-detail.ts
@@ -2,4 +2,4 @@ import { cache } from "react";
 
 import { sessionApi } from "../api";
 
-export const getSessionDetail = cache((sessionId: string) => sessionApi.getDetail(sessionId));
+export const getSessionDetail = cache(sessionApi.getDetail);

--- a/src/test/session/get-session-detail.test.ts
+++ b/src/test/session/get-session-detail.test.ts
@@ -1,0 +1,55 @@
+import { sessionApi } from "@/features/session/api";
+import { getSessionDetail } from "@/features/session/server/get-session-detail";
+import type { SessionDetailResponse } from "@/features/session/types";
+import type { ApiSuccessResponse } from "@/types/shared/types";
+
+jest.mock("@/features/session/api", () => ({
+  sessionApi: {
+    getDetail: jest.fn(),
+  },
+}));
+
+const mockedGetDetail = sessionApi.getDetail as jest.MockedFunction<typeof sessionApi.getDetail>;
+
+function createSessionDetailResponse(sessionId: number): ApiSuccessResponse<SessionDetailResponse> {
+  return {
+    isSuccess: true,
+    code: "COMMON200",
+    message: "성공적으로 요청을 처리했습니다.",
+    result: {
+      sessionId,
+      category: "개발",
+      title: "테스트 세션",
+      hostNickname: "host",
+      status: "진행중",
+      currentParticipants: 1,
+      maxParticipants: 6,
+      sessionDurationMinutes: 60,
+      startTime: "2026-08-22T10:00:00",
+      imageUrl: "https://example.com/image.png",
+      summary: "세션 요약",
+      notice: "공지",
+    },
+  };
+}
+
+describe("getSessionDetail", () => {
+  beforeEach(() => {
+    mockedGetDetail.mockReset();
+  });
+
+  it("sessionApi.getDetail에 sessionId를 그대로 전달한다", async () => {
+    const response = createSessionDetailResponse(101);
+    mockedGetDetail.mockResolvedValue(response);
+
+    await expect(getSessionDetail("101")).resolves.toEqual(response);
+    expect(mockedGetDetail).toHaveBeenCalledWith("101");
+  });
+
+  it("sessionApi.getDetail 실패를 그대로 전파한다", async () => {
+    const error = new Error("session not found");
+    mockedGetDetail.mockRejectedValue(error);
+
+    await expect(getSessionDetail("404")).rejects.toBe(error);
+  });
+});

--- a/src/test/session/session-detail-ssr.test.ts
+++ b/src/test/session/session-detail-ssr.test.ts
@@ -1,0 +1,119 @@
+import { dehydrate, QueryClient } from "@tanstack/react-query";
+
+import { sessionKeys, sessionQueries } from "@/features/session/hooks/useSessionHooks";
+import { getSessionDetail } from "@/features/session/server/get-session-detail";
+import type { SessionDetailResponse } from "@/features/session/types";
+import type { ApiSuccessResponse } from "@/types/shared/types";
+
+const mockGetSessionDetail = jest.fn();
+const mockGetQueryClient = jest.fn();
+
+jest.mock("@/features/session/server/get-session-detail", () => ({
+  getSessionDetail: (...args: unknown[]) => mockGetSessionDetail(...args),
+}));
+
+jest.mock("@/lib/getQueryClient", () => ({
+  getQueryClient: () => mockGetQueryClient(),
+}));
+
+jest.mock("@/features/session/components/SessionPageContent", () => ({
+  SessionPageContent: () => null,
+}));
+
+jest.mock("next/navigation", () => ({
+  redirect: jest.fn(),
+  notFound: jest.fn(),
+}));
+
+jest.mock("@/mocks/is-mock-mode-enabled", () => ({
+  isMockModeEnabled: () => true,
+}));
+
+function createSessionDetailResponse(sessionId: number): ApiSuccessResponse<SessionDetailResponse> {
+  return {
+    isSuccess: true,
+    code: "COMMON200",
+    message: "성공적으로 요청을 처리했습니다.",
+    result: {
+      sessionId,
+      category: "개발",
+      title: "테스트 세션",
+      hostNickname: "host",
+      status: "진행중",
+      currentParticipants: 1,
+      maxParticipants: 6,
+      sessionDurationMinutes: 60,
+      startTime: "2026-08-22T10:00:00",
+      imageUrl: "https://example.com/image.png",
+      summary: "세션 요약",
+      notice: "공지",
+    },
+  };
+}
+
+describe("session detail SSR hydration", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("fetchQuery가 sessionQueries.detail queryKey에 데이터를 저장하고 dehydrate한다", async () => {
+    const sessionId = "669";
+    const response = createSessionDetailResponse(669);
+    mockGetSessionDetail.mockResolvedValue(response);
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+
+    await queryClient.fetchQuery({
+      ...sessionQueries.detail(sessionId),
+      queryFn: () => getSessionDetail(sessionId),
+    });
+
+    expect(queryClient.getQueryData(sessionKeys.detail(sessionId))).toEqual(response);
+    expect(mockGetSessionDetail).toHaveBeenCalledWith(sessionId);
+
+    const dehydrated = dehydrate(queryClient);
+    const hydratedQuery = dehydrated.queries.find(
+      (query) =>
+        Array.isArray(query.queryKey) &&
+        query.queryKey[0] === "session" &&
+        query.queryKey[1] === "detail" &&
+        query.queryKey[2] === sessionId
+    );
+
+    expect(hydratedQuery?.state.data).toEqual(response);
+  });
+
+  it("generateMetadata와 SessionPage가 같은 loader를 사용하고 QueryClient에 detail을 넣는다", async () => {
+    const sessionId = "669";
+    const response = createSessionDetailResponse(669);
+    mockGetSessionDetail.mockResolvedValue(response);
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    mockGetQueryClient.mockReturnValue(queryClient);
+
+    const { generateMetadata, default: SessionPage } =
+      await import("@/app/(with-header)/session/[sessionId]/page");
+
+    const params = Promise.resolve({ sessionId });
+    await generateMetadata({ params });
+    await SessionPage({ params });
+
+    expect(mockGetSessionDetail).toHaveBeenCalledWith(sessionId);
+    expect(queryClient.getQueryData(sessionKeys.detail(sessionId))).toEqual(response);
+
+    const dehydrated = dehydrate(queryClient);
+    expect(
+      dehydrated.queries.some(
+        (query) =>
+          Array.isArray(query.queryKey) &&
+          query.queryKey[0] === "session" &&
+          query.queryKey[1] === "detail" &&
+          query.queryKey[2] === sessionId
+      )
+    ).toBe(true);
+  });
+});

--- a/src/test/session/session-detail-ssr.test.ts
+++ b/src/test/session/session-detail-ssr.test.ts
@@ -1,8 +1,12 @@
+import { notFound, redirect } from "next/navigation";
+
 import { dehydrate, QueryClient } from "@tanstack/react-query";
 
 import { sessionKeys, sessionQueries } from "@/features/session/hooks/useSessionHooks";
 import { getSessionDetail } from "@/features/session/server/get-session-detail";
 import type { SessionDetailResponse } from "@/features/session/types";
+import { ApiError } from "@/lib/api/api-client";
+import { createPageMetadata } from "@/lib/seo/metadata";
 import type { ApiSuccessResponse } from "@/types/shared/types";
 
 const mockGetSessionDetail = jest.fn();
@@ -21,15 +25,31 @@ jest.mock("@/features/session/components/SessionPageContent", () => ({
 }));
 
 jest.mock("next/navigation", () => ({
-  redirect: jest.fn(),
-  notFound: jest.fn(),
+  redirect: jest.fn(() => {
+    throw new Error("NEXT_REDIRECT");
+  }),
+  notFound: jest.fn(() => {
+    throw new Error("NEXT_NOT_FOUND");
+  }),
 }));
 
 jest.mock("@/mocks/is-mock-mode-enabled", () => ({
   isMockModeEnabled: () => true,
 }));
 
-function createSessionDetailResponse(sessionId: number): ApiSuccessResponse<SessionDetailResponse> {
+const mockedNotFound = jest.mocked(notFound);
+const mockedRedirect = jest.mocked(redirect);
+
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+}
+
+function createSessionDetailResponse(
+  sessionId: number,
+  title = "테스트 세션"
+): ApiSuccessResponse<SessionDetailResponse> {
   return {
     isSuccess: true,
     code: "COMMON200",
@@ -37,7 +57,7 @@ function createSessionDetailResponse(sessionId: number): ApiSuccessResponse<Sess
     result: {
       sessionId,
       category: "개발",
-      title: "테스트 세션",
+      title,
       hostNickname: "host",
       status: "진행중",
       currentParticipants: 1,
@@ -51,9 +71,15 @@ function createSessionDetailResponse(sessionId: number): ApiSuccessResponse<Sess
   };
 }
 
+async function loadSessionPageModule() {
+  return import("@/app/(with-header)/session/[sessionId]/page");
+}
+
 describe("session detail SSR hydration", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetSessionDetail.mockReset();
+    mockGetQueryClient.mockReset();
   });
 
   it("fetchQuery가 sessionQueries.detail queryKey에 데이터를 저장하고 dehydrate한다", async () => {
@@ -61,9 +87,7 @@ describe("session detail SSR hydration", () => {
     const response = createSessionDetailResponse(669);
     mockGetSessionDetail.mockResolvedValue(response);
 
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
+    const queryClient = createTestQueryClient();
 
     await queryClient.fetchQuery({
       ...sessionQueries.detail(sessionId),
@@ -90,13 +114,10 @@ describe("session detail SSR hydration", () => {
     const response = createSessionDetailResponse(669);
     mockGetSessionDetail.mockResolvedValue(response);
 
-    const queryClient = new QueryClient({
-      defaultOptions: { queries: { retry: false } },
-    });
+    const queryClient = createTestQueryClient();
     mockGetQueryClient.mockReturnValue(queryClient);
 
-    const { generateMetadata, default: SessionPage } =
-      await import("@/app/(with-header)/session/[sessionId]/page");
+    const { generateMetadata, default: SessionPage } = await loadSessionPageModule();
 
     const params = Promise.resolve({ sessionId });
     await generateMetadata({ params });
@@ -115,5 +136,107 @@ describe("session detail SSR hydration", () => {
           query.queryKey[2] === sessionId
       )
     ).toBe(true);
+  });
+
+  it("generateMetadata returns fallback metadata when session detail fetch fails", async () => {
+    mockGetSessionDetail.mockRejectedValue(new Error("session not found"));
+
+    const { generateMetadata } = await loadSessionPageModule();
+    const metadataPromise = generateMetadata({
+      params: Promise.resolve({ sessionId: "669" }),
+    });
+
+    await expect(metadataPromise).resolves.toEqual(
+      createPageMetadata({
+        title: "세션 상세",
+        description: "모각작 세션 정보를 확인하세요.",
+      })
+    );
+
+    const metadata = await metadataPromise;
+    expect(metadata.title).toBe("세션 상세");
+    expect(metadata.description).toBe("모각작 세션 정보를 확인하세요.");
+    expect(mockGetSessionDetail).toHaveBeenCalledWith("669");
+    expect(mockedNotFound).not.toHaveBeenCalled();
+    expect(mockedRedirect).not.toHaveBeenCalled();
+  });
+
+  it("SessionPage handles session detail fetch failure correctly", async () => {
+    const error = new Error("session not found");
+    mockGetSessionDetail.mockRejectedValue(error);
+
+    const queryClient = createTestQueryClient();
+    mockGetQueryClient.mockReturnValue(queryClient);
+
+    const { default: SessionPage } = await loadSessionPageModule();
+
+    await expect(SessionPage({ params: Promise.resolve({ sessionId: "669" }) })).rejects.toBe(
+      error
+    );
+    expect(mockedNotFound).not.toHaveBeenCalled();
+    expect(mockedRedirect).not.toHaveBeenCalled();
+    expect(queryClient.getQueryData(sessionKeys.detail("669"))).toBeUndefined();
+  });
+
+  it("SessionPage calls notFound when session detail fetch returns 404", async () => {
+    mockGetSessionDetail.mockRejectedValue(new ApiError("session not found", 404));
+
+    const queryClient = createTestQueryClient();
+    mockGetQueryClient.mockReturnValue(queryClient);
+
+    const { default: SessionPage } = await loadSessionPageModule();
+
+    await expect(SessionPage({ params: Promise.resolve({ sessionId: "669" }) })).rejects.toThrow(
+      "NEXT_NOT_FOUND"
+    );
+    expect(mockedNotFound).toHaveBeenCalledTimes(1);
+    expect(mockedRedirect).not.toHaveBeenCalled();
+  });
+
+  it("different session ids should keep separate query cache", async () => {
+    const responseA = createSessionDetailResponse(669, "session A");
+    const responseB = createSessionDetailResponse(670, "session B");
+
+    mockGetSessionDetail.mockImplementation((sessionId: unknown) => {
+      if (sessionId === "669") return Promise.resolve(responseA);
+      if (sessionId === "670") return Promise.resolve(responseB);
+      return Promise.reject(new Error(`unexpected sessionId: ${String(sessionId)}`));
+    });
+
+    const queryClient = createTestQueryClient();
+    mockGetQueryClient.mockReturnValue(queryClient);
+
+    const { default: SessionPage } = await loadSessionPageModule();
+    await SessionPage({ params: Promise.resolve({ sessionId: "669" }) });
+    await SessionPage({ params: Promise.resolve({ sessionId: "670" }) });
+
+    expect(sessionKeys.detail("669")).toEqual(["session", "detail", "669"]);
+    expect(sessionKeys.detail("670")).toEqual(["session", "detail", "670"]);
+    expect(queryClient.getQueryData(sessionKeys.detail("669"))).toEqual(responseA);
+    expect(queryClient.getQueryData(sessionKeys.detail("670"))).toEqual(responseB);
+    expect(queryClient.getQueryData(sessionKeys.detail("669"))).not.toEqual(
+      queryClient.getQueryData(sessionKeys.detail("670"))
+    );
+
+    const dehydrated = dehydrate(queryClient);
+    const queryA = dehydrated.queries.find(
+      (query) =>
+        Array.isArray(query.queryKey) &&
+        query.queryKey[0] === "session" &&
+        query.queryKey[1] === "detail" &&
+        query.queryKey[2] === "669"
+    );
+    const queryB = dehydrated.queries.find(
+      (query) =>
+        Array.isArray(query.queryKey) &&
+        query.queryKey[0] === "session" &&
+        query.queryKey[1] === "detail" &&
+        query.queryKey[2] === "670"
+    );
+
+    expect(queryA?.state.data).toEqual(responseA);
+    expect(queryB?.state.data).toEqual(responseB);
+    expect(mockGetSessionDetail).toHaveBeenCalledWith("669");
+    expect(mockGetSessionDetail).toHaveBeenCalledWith("670");
   });
 });


### PR DESCRIPTION
## 관련 Issue

- #347 `perf: 세션 상세 SSR 중복 API 요청 분석 및 제거`

---

## 변경 배경

세션 상세 페이지의 SSR 데이터 패칭 구조를 분석하는 과정에서 `generateMetadata`와 `SessionPage`가 동일한 세션 상세 데이터를 각각 요청하고 있는 것을 확인했습니다.

Production standalone runtime 기준으로 최초 SSR 요청 1회당:

| 구간 | 요청 횟수 |
| --- | ---: |
| BFF `/api/sessions/{id}` | 2회 |
| Backend `/api/v1/sessions/{id}` | 2회 |

가 발생했습니다.

---

## 문제 원인

동일한 세션 상세 데이터를 요청하는 두 경로가 존재했습니다.

```text
generateMetadata
└─ sessionApi.getDetail(sessionId)
   └─ BFF
      └─ Backend


SessionPage
└─ queryClient.fetchQuery(sessionQueries.detail(sessionId))
   └─ sessionApi.getDetail(sessionId)
      └─ BFF
         └─ Backend
```

분석 결과 Custom API Client의 `executeFetch`가 모든 fetch 요청에 `AbortSignal`을 전달하고 있었고, 이로 인해 Next.js/React request memoization이 적용되지 않는 것을 확인했습니다.

실험 결과:

| 조건 | BFF 요청 | Backend 요청 |
| --- | ---: | ---: |
| 기존 `AbortSignal` 유지 | 2회 | 2회 |
| signal 제거 | 1회 | 1회 |

따라서 동일 SSR request 내에서도 동일 데이터 요청이 deduplication되지 않고 각각 Backend까지 전달되고 있었습니다.

---

## 해결 방법

전역 API Client의 timeout/signal 정책은 변경하지 않고, 세션 상세 SSR 데이터 조회에 request-scoped loader를 적용했습니다.

### 추가

`src/features/session/server/get-session-detail.ts`

```ts
import { cache } from "react";

import { sessionApi } from "../api";

export const getSessionDetail = cache((sessionId: string) =>
  sessionApi.getDetail(sessionId)
);
```

`React.cache()`를 활용해 동일 SSR request 내부에서 동일한 세션 상세 조회 결과를 공유하도록 했습니다.

---

## 변경 내용

### generateMetadata

기존:

```ts
sessionApi.getDetail(sessionId)
```

변경:

```ts
getSessionDetail(sessionId)
```

---

### SessionPage

기존 TanStack Query 구조는 유지했습니다.

변경 전:

```ts
queryClient.fetchQuery(
  sessionQueries.detail(sessionId)
)
```

변경 후:

```ts
queryClient.fetchQuery({
  ...sessionQueries.detail(sessionId),
  queryFn: () => getSessionDetail(sessionId),
})
```

이를 통해:

- React.cache → SSR request 내부 중복 제거
- TanStack Query → 기존 query cache / hydration 유지

역할을 분리했습니다.

---

## 검증

### 정적 검증

| 항목 | 결과 |
| --- | --- |
| TypeScript | ✅ 통과 |
| ESLint | ✅ 통과 |
| Jest | ✅ 77 suites / 699 tests 통과 |
| Production Build | ✅ 통과 |

---

## Production Before / After

측정 환경:

- Next.js standalone runtime
- MSW OFF
- 실제 Backend 사용
- 익명 사용자
- clean boot 후 최초 SSR 요청

### Before

| 구간 | 요청 횟수 |
| --- | ---: |
| Page | 1 |
| BFF | 2 |
| Backend | 2 |

### After

| 구간 | 요청 횟수 |
| --- | ---: |
| Page | 1 |
| BFF | 1 |
| Backend | 1 |

동일 SSR request 기준 Backend 요청을 2회 → 1회로 감소했습니다.

---

## 추가 검증

React.cache가 persistent cache로 동작하지 않는지 확인했습니다.

Request #1:

```text
BFF: 1회
Backend: 1회
```

Request #2:

```text
BFF: 1회
Backend: 1회
```

즉:

- 동일 SSR request 내부 → deduplication
- 새로운 HTTP request → 최신 데이터 재조회

동작을 확인했습니다.

---

## 유지한 부분

이번 변경에서는 다음 영역을 수정하지 않았습니다.

- `executeFetch`
- AbortSignal / timeout 정책
- retry 정책
- BFF Route Handler
- TanStack Query query key
- QueryClient 구조
- HydrationBoundary 구조
- Client Hook 구조

기존 데이터 최신성과 네트워크 timeout 정책을 유지하면서 SSR 중복 요청만 제거했습니다.

---

## 변경 파일

### 추가

- `src/features/session/server/get-session-detail.ts`
- `src/test/session/get-session-detail.test.ts`
- `src/test/session/session-detail-ssr.test.ts`

### 수정

- `src/app/(with-header)/session/[sessionId]/page.tsx`

---

## 결과

Next.js App Router SSR 과정에서 동일 데이터를 요청하는 Server Component 경로를 분석하고, Custom API Client의 AbortSignal 정책과 request memoization 충돌을 확인했습니다.

전역 API Client 정책 변경 대신 request-scoped `React.cache()` loader를 적용하여:

- timeout / retry 정책 유지
- TanStack Query hydration 유지
- Backend 중복 요청 제거

를 달성했습니다.

---

## 테스트 보강

SSR loader 변경 이후 기존 동작 계약이 유지되는지 검증하기 위해 다음 edge case 테스트를 추가했습니다.

- metadata 생성 실패 시 fallback metadata 유지
- session detail 조회 실패 시 기존 error handling 유지
- 404 응답 시 notFound 처리 유지
- 서로 다른 sessionId 간 query cache 격리 확인

검증 결과:

- 기존 테스트: 695
- 추가 테스트: 4
- 전체 테스트: 699 passed